### PR TITLE
fix: increase the convergence check out

### DIFF
--- a/compose/sidecar/composer/convergence/eventually_converged.sh
+++ b/compose/sidecar/composer/convergence/eventually_converged.sh
@@ -79,12 +79,16 @@ main() {
     while true; do
         status=1
 
+        # Try up to ~16 minutes for status to converge, in slices of 10 seconds
+        # The reason we wait for 15 minutes is because that's the default timeout for
+        # failed DNS resolutions and connections errors baked in the node network
+        # layer.
         for i in {1..100}; do
             validate_block_hash
             if [ "${status}" -eq 0 ]; then
                 break
             else
-                sleep 2
+                sleep 10
             fi
         done
 
@@ -95,8 +99,6 @@ main() {
             echo "[{\"status\":\"diverged\"}]"
             exit 1
         fi
-
-        sleep 300
     done
 }
 


### PR DESCRIPTION
we increase convergence check to make sure it goes over the 15 minutes timeout baked into network layer when DNS or connection errors to peer happen. This should increase the likelihood a transient network partition heals and leads to successful convergence of the network.