### PR TITLE
fix: update publish-site workflow for MkDocs

### DIFF
--- a/.github/workflows/publish-site.yaml
+++ b/.github/workflows/publish-site.yaml
@@ -1,43 +1,20 @@
-name: "Publish Docs"
+name: Build and deploy documentation
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
-  publishing:
-    name: Publish Site
+  deploy:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-
-    - name: 📥 Checkout repository
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 1
-
-    - name: Build documentation
-      working-directory: docs
-      run: |
-        # Only warn on broken links here as the individual documentation builds
-        # should have failed with broken links originally.
-        sed -i 's|onBrokenLinks: "throw"|onBrokenLinks: "warn"|' docusaurus.config.ts
-
-        yarn
-        yarn build
-
-        mkdir -p /tmp/public
-        mv build/* /tmp/public
-        # Clean the working copy
-        git clean -dxf
-
-    - name: 🚢 Publish Documentation
-      uses: peaceiris/actions-gh-pages@v4
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN || github.token }}
-        publish_dir: /tmp/public
-        enable_jekyll: true
-        force_orphan: true
+      - uses: actions/checkout@v4
+      - uses: paolino/dev-assets/setup-nix@v0.0.1
+        with:
+          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - run: nix develop github:paolino/dev-assets?dir=mkdocs -c mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary
- Update publish-site workflow to use MkDocs instead of Docusaurus
- Use `mkdocs gh-deploy` following the haskell-csmt pattern

## Test plan
- [ ] Verify workflow runs successfully on merge
- [ ] Check that https://cardano-foundation.github.io/moog/ shows MkDocs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)