### PR TITLE
ci: add --quiet flag to nix commands

### DIFF
--- a/.github/workflows/E2E-test.yaml
+++ b/.github/workflows/E2E-test.yaml
@@ -51,8 +51,8 @@ jobs:
 
       - name: Fund the wallet
         run: |
-          nix shell -c moog wallet create -w "$MOOG_WALLET_FILE"
-          address=$(nix shell -c moog wallet info | jq -r '.address')
+          nix --quiet shell -c moog wallet create -w "$MOOG_WALLET_FILE"
+          address=$(nix --quiet shell -c moog wallet info | jq -r '.address')
           topup(){
               curl -s -X 'POST' \
                   "$MOOG_TEST_YACI_ADMIN/local-cluster/api/addresses/topup" \
@@ -73,11 +73,11 @@ jobs:
 
       - name: Export agent PKH
         run: |
-          owner=$(nix shell -c moog wallet info | jq -r '.owner')
+          owner=$(nix --quiet shell -c moog wallet info | jq -r '.owner')
           echo "MOOG_AGENT_PUBLIC_KEY_HASH=$owner" >> $GITHUB_ENV
 
       - name: Run E2E tests
-        run: nix shell -c nix run .#e2e-tests
+        run: nix --quiet shell -c nix --quiet run .#e2e-tests
 
       - name: Tear down
         if: always()

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Build oracle docker image
-        run: nix build .#moog-oracle-docker-image -o moog-oracle-image
+        run: nix --quiet build .#moog-oracle-docker-image -o moog-oracle-image
       - name: Smoke test oracle docker image
         run: |
           IMAGE=$(docker load < moog-oracle-image | grep "Loaded image:" | awk '{print $3}')
@@ -28,7 +28,7 @@ jobs:
           name: moog-oracle-image
           path: ./moog-oracle-image
       - name: Build agent docker image
-        run: nix build .#moog-agent-docker-image -o moog-agent-image
+        run: nix --quiet build .#moog-agent-docker-image -o moog-agent-image
       - name: Smoke test agent docker image
         run: |
           IMAGE=$(docker load < moog-agent-image | grep "Loaded image:" | awk '{print $3}')
@@ -48,7 +48,7 @@ jobs:
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Build oracle docker image
-        run: nix build .#moog-oracle-docker-image -o moog-oracle-image-aarch64
+        run: nix --quiet build .#moog-oracle-docker-image -o moog-oracle-image-aarch64
       - name: Smoke test oracle docker image
         run: |
           IMAGE=$(docker load < moog-oracle-image-aarch64 | grep "Loaded image:" | awk '{print $3}')
@@ -59,7 +59,7 @@ jobs:
           name: moog-oracle-image-aarch64
           path: ./moog-oracle-image-aarch64
       - name: Build agent docker image
-        run: nix build .#moog-agent-docker-image -o moog-agent-image-aarch64
+        run: nix --quiet build .#moog-agent-docker-image -o moog-agent-image-aarch64
       - name: Smoke test agent docker image
         run: |
           IMAGE=$(docker load < moog-agent-image-aarch64 | grep "Loaded image:" | awk '{print $3}')

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Fund the wallet
         run: |
-          nix shell -c moog wallet create -w "$MOOG_WALLET_FILE"
-          address=$(nix shell -c moog wallet info | jq -r '.address')
+          nix --quiet shell -c moog wallet create -w "$MOOG_WALLET_FILE"
+          address=$(nix --quiet shell -c moog wallet info | jq -r '.address')
           topup(){
               curl -s -X 'POST' \
                   "$MOOG_TEST_YACI_ADMIN/local-cluster/api/addresses/topup" \
@@ -67,11 +67,11 @@ jobs:
 
       - name: Export agent PKH
         run: |
-          owner=$(nix shell -c moog wallet info | jq -r '.owner')
+          owner=$(nix --quiet shell -c moog wallet info | jq -r '.owner')
           echo "MOOG_AGENT_PUBLIC_KEY_HASH=$owner" >> $GITHUB_ENV
 
       - name: Run integration tests
-        run: nix run .#integration-tests
+        run: nix --quiet run .#integration-tests
 
       - name: Tear down
         if: always()

--- a/.github/workflows/publish-site.yaml
+++ b/.github/workflows/publish-site.yaml
@@ -17,4 +17,4 @@ jobs:
       - uses: paolino/dev-assets/setup-nix@v0.0.1
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-      - run: nix develop github:paolino/dev-assets?dir=mkdocs -c mkdocs gh-deploy --force
+      - run: nix --quiet develop github:paolino/dev-assets?dir=mkdocs -c mkdocs gh-deploy --force

--- a/.github/workflows/tarballs.yaml
+++ b/.github/workflows/tarballs.yaml
@@ -24,7 +24,7 @@ jobs:
           name: paolino
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Build linux tarball
-        run: nix build -L .#linux64.tarball -o linux-tarball
+        run: nix --quiet build -L .#linux64.tarball -o linux-tarball
       - name: Smoke test tarball binaries
         run: |
           mkdir -p /tmp/tarball-test
@@ -54,7 +54,7 @@ jobs:
           name: paolino
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Build ARM64 linux tarball
-        run: nix build -L .#linux-aarch64.tarball -o linux-aarch64-tarball
+        run: nix --quiet build -L .#linux-aarch64.tarball -o linux-aarch64-tarball
       - name: Smoke test tarball binaries
         run: |
           mkdir -p /tmp/tarball-test
@@ -84,7 +84,7 @@ jobs:
           name: paolino
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Build macOS tarball
-        run: nix build .#darwin64.tarball -o darwin-tarball
+        run: nix --quiet build .#darwin64.tarball -o darwin-tarball
       - name: Smoke test tarball binaries
         run: |
           mkdir -p /tmp/tarball-test

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -20,4 +20,4 @@ jobs:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Run moog unit tests
-        run: nix run .#unit-tests
+        run: nix --quiet run .#unit-tests


### PR DESCRIPTION
## Summary
- Adds `--quiet` flag to all nix commands in CI workflows
- Reduces verbose nix output in CI logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)