### PR TITLE
docs: add deployment and troubleshooting guides

### DIFF
--- a/CD/moog-agent/docker-compose.yaml
+++ b/CD/moog-agent/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       - DOCKER_CONFIG=/run/secrets/docker
     restart: always
     privileged: true
-    command: "--poll-interval 60 --days 1 --trust-all-requesters"
+    command: "--poll-interval 60 --minutes 1440 --trust-all-requesters"
     volumes:
       - tmp:/tmp
         # Mount CA certificates, curl seems not to find them when the pkgs.cacert is included in the image

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -1,0 +1,299 @@
+# Deployment Guide
+
+This guide covers deploying the oracle and agent services as Docker containers.
+
+## Infrastructure Overview
+
+```mermaid
+graph TB
+    subgraph Oracle Machine
+        oracle[moog-oracle container]
+        oracle-secrets[secrets.yaml<br/>oracle-wallet.json]
+    end
+    subgraph Agent Machine
+        agent[moog-agent container]
+        agent-secrets[secrets.yaml<br/>agent-wallet.json<br/>docker/config.json]
+        docker[Docker socket]
+    end
+    subgraph External Services
+        mpfs[MPFS Service]
+        cardano[Cardano Blockchain<br/>preprod]
+        github[GitHub API]
+        antithesis[Antithesis Platform]
+    end
+
+    oracle --> mpfs
+    oracle --> github
+    agent --> mpfs
+    agent --> antithesis
+    agent --> docker
+    mpfs --> cardano
+    oracle-secrets -.-> oracle
+    agent-secrets -.-> agent
+```
+
+## Prerequisites
+
+- **Docker** and **Docker Compose** on each machine
+- **Cardano wallets** for both oracle and agent roles (created with `moog wallet create`)
+- **GitHub PAT** with `repo` scope for the oracle (used to validate requests against GitHub)
+- **GitHub PAT** with `repo` scope for the agent (used to download test assets)
+- **Antithesis credentials** for the agent (registry password, platform user)
+- **MPFS service** accessible from both machines (default: `https://mpfs.plutimus.com`)
+- **Moog token** already created by the oracle (`moog oracle token boot`)
+
+## Oracle Deployment
+
+### Secrets setup
+
+Create the secrets directory:
+
+```bash
+mkdir -p /secrets/moog-oracle
+```
+
+**`/secrets/moog-oracle/oracle.json`** — the oracle wallet file (from `moog wallet create`).
+
+**`/secrets/moog-oracle/secrets.yaml`**:
+
+```yaml
+githubPAT: ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+walletPassphrase: your_wallet_passphrase  # if wallet is encrypted
+```
+
+### Docker Compose
+
+Use the compose file from `CD/moog-oracle/docker-compose.yaml`:
+
+```yaml
+services:
+  moog-oracle:
+    image: ghcr.io/cardano-foundation/moog/moog-oracle:${MOOG_VERSION:-latest}
+    secrets:
+      - oracle-wallet
+      - secrets
+    environment:
+      - MOOG_MPFS_HOST=https://mpfs.plutimus.com
+      - MOOG_WALLET_FILE=/run/secrets/oracle-wallet
+      - MOOG_TOKEN_ID=<your-token-id>
+      - MOOG_SECRETS_FILE=/run/secrets/secrets
+      - MOOG_WAIT=240
+    restart: always
+    volumes:
+      - tmp:/tmp
+secrets:
+  oracle-wallet:
+    file: /secrets/moog-oracle/oracle.json
+  secrets:
+    file: /secrets/moog-oracle/secrets.yaml
+volumes:
+  tmp:
+```
+
+### Start and verify
+
+```bash
+export MOOG_VERSION=<desired-version>
+docker compose up -d
+docker compose logs -f moog-oracle
+```
+
+Look for log lines showing successful polling and validation cycles. The oracle polls every `MOOG_WAIT` seconds (default 240).
+
+## Agent Deployment
+
+### Secrets setup
+
+Create the secrets directory:
+
+```bash
+mkdir -p /secrets/moog-agent/docker
+```
+
+**`/secrets/moog-agent/agent.json`** — the agent wallet file.
+
+**`/secrets/moog-agent/docker/config.json`** — Docker registry credentials for pulling/pushing Antithesis images.
+
+**`/secrets/moog-agent/secrets.yaml`**:
+
+```yaml
+agentEmail: agent@example.com
+agentEmailPassword: xxxx-xxxx-xxxx-xxxx  # Google app password
+githubPAT: ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+antithesisPassword: your_antithesis_password
+slackWebhook: https://hooks.slack.com/services/...  # optional
+trustedRequesters:  # optional, ignored when --trust-all-requesters is used
+  - requester_pkh_1
+  - requester_pkh_2
+```
+
+### Docker Compose
+
+Use the compose file from `CD/moog-agent/docker-compose.yaml`:
+
+```yaml
+services:
+  moog-agent:
+    image: ghcr.io/cardano-foundation/moog/moog-agent:${MOOG_VERSION:-latest}
+    secrets:
+      - agent-wallet
+      - secrets
+      - source: docker
+        target: /run/secrets/docker/config.json
+    environment:
+      - MOOG_MPFS_HOST=https://mpfs.plutimus.com
+      - MOOG_WALLET_FILE=/run/secrets/agent-wallet
+      - MOOG_TOKEN_ID=<your-token-id>
+      - MOOG_SECRETS_FILE=/run/secrets/secrets
+      - MOOG_WAIT=240
+      - MOOG_ANTITHESIS_USER=cardano
+      - DOCKER_CONFIG=/run/secrets/docker
+    restart: always
+    privileged: true
+    command: "--poll-interval 60 --minutes 1440 --trust-all-requesters"
+    volumes:
+      - tmp:/tmp
+      - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
+      - /var/run/docker.sock:/var/run/docker.sock:rw
+secrets:
+  agent-wallet:
+    file: /secrets/moog-agent/agent.json
+  secrets:
+    file: /secrets/moog-agent/secrets.yaml
+  docker:
+    file: /secrets/moog-agent/docker/config.json
+volumes:
+  tmp:
+```
+
+!!! warning "Privileged mode and Docker socket"
+    The agent container requires privileged mode and access to the Docker socket because it runs `docker compose` to validate test assets locally before pushing them to Antithesis. See [Security](security.md#docker-security) for implications.
+
+### Start and verify
+
+```bash
+export MOOG_VERSION=<desired-version>
+docker compose up -d
+docker compose logs -f moog-agent
+```
+
+The agent polls for pending test runs every `--poll-interval` seconds (default 60) and checks for email results within the `--minutes` window.
+
+## Environment Variables Reference
+
+| Variable | Used by | Description |
+|---|---|---|
+| `MOOG_MPFS_HOST` | oracle, agent | URL of the MPFS service |
+| `MOOG_WALLET_FILE` | oracle, agent | Path to the wallet JSON file |
+| `MOOG_TOKEN_ID` | oracle, agent | The moog token asset ID on Cardano |
+| `MOOG_SECRETS_FILE` | oracle, agent | Path to `secrets.yaml` |
+| `MOOG_WAIT` | oracle, agent | Seconds between polling cycles |
+| `MOOG_ANTITHESIS_USER` | agent | Antithesis platform username |
+| `DOCKER_CONFIG` | agent | Path to Docker config directory (for private registries) |
+
+## Service Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant O as Oracle
+    participant M as MPFS
+    participant GH as GitHub
+    participant A as Agent
+    participant AT as Antithesis
+
+    loop Every MOOG_WAIT seconds
+        O->>M: Query pending requests
+        O->>GH: Validate requests (users, roles, repos)
+        O->>M: Submit state update transaction
+    end
+
+    loop Every poll-interval seconds
+        A->>M: Query pending test runs
+        A->>GH: Download test assets
+        A->>A: Local docker compose validation
+        A->>AT: Push test to Antithesis
+        A->>M: Report test acceptance
+    end
+
+    loop Every poll-interval seconds
+        A->>A: Check email for results
+        A->>M: Report test completion
+    end
+```
+
+## PAT Management
+
+GitHub Personal Access Tokens are required by both oracle and agent for GitHub API access.
+
+### Scope requirements
+
+- **`repo`** — needed to access repository contents, CODEOWNERS files, and user profile repos
+
+### Rotation
+
+PATs have an expiration date. When a PAT expires:
+
+1. The oracle/agent will receive 401 errors from GitHub API
+2. All validation requests will fail
+3. The service will continue polling but accomplish nothing, burning rate limit on failed auth
+
+**To rotate a PAT:**
+
+1. Create a new PAT at [github.com/settings/tokens](https://github.com/settings/tokens)
+2. Update `secrets.yaml` with the new token
+3. Restart the service: `docker compose restart`
+
+!!! tip "Set a calendar reminder"
+    Create a reminder 1 week before PAT expiry to avoid service disruption.
+
+### Rate limits
+
+GitHub API has a per-user rate limit of **5,000 requests/hour**. This limit is shared across all PATs belonging to the same GitHub user. If both oracle and agent use PATs from the same user, they share the 5,000 request budget.
+
+See [Troubleshooting](troubleshooting.md#pat-expired-or-rate-limited) for diagnosing PAT issues.
+
+## Monitoring
+
+### Log checking
+
+```bash
+# Oracle logs
+docker compose logs --tail 50
+
+# Agent logs
+docker compose logs --tail 50
+```
+
+### Health verification
+
+```bash
+# Check pending requests
+moog token | jq '.requests | length'
+
+# Check system facts
+moog facts test-runs pending --pretty
+
+# Check GitHub rate limit
+curl -s -H "Authorization: token <PAT>" \
+  https://api.github.com/rate_limit | jq '.rate'
+```
+
+## Updating
+
+### Image version bump
+
+```bash
+export MOOG_VERSION=<new-version>
+docker compose pull
+docker compose up -d
+```
+
+### Configuration changes
+
+For changes to `secrets.yaml` or environment variables, restart the service:
+
+```bash
+docker compose restart
+```
+
+No state is lost on restart — the service resumes polling from the current on-chain state.

--- a/docs/ops/oracle-role.md
+++ b/docs/ops/oracle-role.md
@@ -2,6 +2,21 @@
 
 This is the role of the user that wants to run a service to control access to the Antithesis platform. There will be only one token and so there will be only one oracle service running at a time, but we document it here for completeness.
 
+## Oracle Processing Loop
+
+```mermaid
+flowchart TB
+    sleep[Sleep MOOG_WAIT seconds] --> poll[Query MPFS for pending requests]
+    poll --> validate[Validate each request against GitHub]
+    validate --> submit[Submit batch state update transaction]
+    submit --> sleep
+
+    validate -->|user profile check| GH[GitHub API]
+    validate -->|CODEOWNERS check| GH
+    validate -->|repo contents check| GH
+    submit --> MPFS[(MPFS Service)]
+```
+
 ## Running the oracle service
 
 You can build an executable that will continuously check for pending requests and include them in the Antithesis token.
@@ -28,6 +43,10 @@ version=$(nix eval .#version --raw)
 docker run ghcr.io/cardano-foundation/moog/moog-oracle:$version
 ```
 
+### Running as Docker Service
+
+For production deployment, use Docker Compose. See the [Deployment Guide](deployment.md#oracle-deployment) for full setup instructions including secrets, docker-compose configuration, and startup verification.
+
 ## Running oracle commands manually
 
 Alternatively, oracle commands can be run manually, using the `moog` CLI. See the [Installation instructions](../user/installation.md) for how to install it.
@@ -42,15 +61,17 @@ You can create a wallet with the `moog wallet create` command.
 moog wallet create
 ```
 
-The current oracle wallet reports
+You can check the wallet info with:
 
 ```bash
 moog wallet info
 ```
 
+Example output:
+
 ```json
 {
-  "address": "addr_test1vq04e6lvknx3ettppz5xq9x7nk8j87w5gaammke7z2ymyfqtkl4vv",
+  "address": "addr_test1...",
   "filePath": "tmp/oracle.json",
   "owner": "1f5cebecb4cd1cad6108a86014de9d8f23f9d4477bbddb3e1289b224"
 }

--- a/docs/ops/security.md
+++ b/docs/ops/security.md
@@ -1,7 +1,92 @@
 # Security Considerations
 
+## Threat Model
+
+```mermaid
+flowchart TB
+    subgraph Attack Surfaces
+        pat[GitHub PAT compromise]
+        mpfs_trust[Malicious MPFS operator]
+        docker_priv[Docker privileged escalation]
+        wallet_theft[Wallet file theft]
+        rate_abuse[Rate limit exhaustion]
+    end
+
+    pat --> impersonate[Impersonate user on GitHub]
+    pat --> rate_abuse
+    mpfs_trust --> alter_tx[Alter unsigned transactions]
+    docker_priv --> host_escape[Container-to-host escape]
+    wallet_theft --> drain[Drain wallet funds]
+    rate_abuse --> dos[Denial of service for all tokens]
+```
+
 ## Remote MPFS Service
 
 The MPFS service is not able to sign transactions for the user. Nevertheless the current implementation doesn't perform any intent-check on the unsigned transactions it receives. Therefore, when using a remote MPFS service, users should ensure that they trust the operator of the service, as a malicious operator could potentially alter the unsigned transactions before sending them back to the user.
 
 To improve the situation [an issue is open in GitHub](https://github.com/cardano-foundation/moog/issues).
+
+## PAT Management
+
+GitHub Personal Access Tokens are used by the oracle and agent to validate requests against GitHub (checking user profiles, CODEOWNERS, downloading assets).
+
+### Scope requirements
+
+PATs should be created with the minimum required scope:
+
+- **`repo`** — access to repository contents, CODEOWNERS files, and user profile repos
+
+### Rotation
+
+PATs expire. An expired PAT causes silent failures — the service continues polling but all GitHub validation fails, burning rate limit requests on 401 responses.
+
+- Set PAT expiry to **90 days** and create a calendar reminder 1 week before
+- To rotate: update `githubPAT` in `secrets.yaml` and restart the service
+- See [Troubleshooting](troubleshooting.md#pat-expired-or-rate-limited) for diagnosis
+
+### Shared rate limits
+
+GitHub API rate limits (5,000 requests/hour) are **per-user**, not per-token. All PATs belonging to the same GitHub user share one budget. If oracle and agent both use PATs from the same GitHub user, they compete for the same 5,000 requests.
+
+**Recommendation:** Use PATs from different GitHub users for oracle and agent services.
+
+## Docker Security
+
+The agent container runs with **privileged mode** and mounts the **Docker socket** from the host. This is required because the agent validates test assets by running `docker compose up --build` locally before pushing to Antithesis.
+
+### Implications
+
+- **Container-to-host escape:** A compromised agent container with privileged mode and Docker socket access has effective root access to the host machine.
+- **Image pull/push:** The agent has Docker registry credentials (via `DOCKER_CONFIG`) that could be used to access private registries.
+
+### Mitigations
+
+- Run the agent on a dedicated machine or VM, not on shared infrastructure
+- Use read-only mounts where possible (CA certs are already mounted `:ro`)
+- Monitor Docker socket usage through host-level auditing
+- Restrict network access from the agent machine to only required endpoints
+
+## Wallet Security
+
+Oracle and agent wallets hold ADA needed for submitting Cardano transactions. They should contain only the minimum balance needed for operations.
+
+### Passphrase protection
+
+Wallets can be encrypted with a passphrase. When encrypted, provide the passphrase via `secrets.yaml`:
+
+```yaml
+walletPassphrase: your_passphrase
+```
+
+### File permissions
+
+Wallet files and `secrets.yaml` should have restricted permissions:
+
+```bash
+chmod 600 /secrets/moog-oracle/oracle.json
+chmod 600 /secrets/moog-oracle/secrets.yaml
+chmod 600 /secrets/moog-agent/agent.json
+chmod 600 /secrets/moog-agent/secrets.yaml
+```
+
+In Docker Compose, these are mounted as Docker secrets (under `/run/secrets/`), which provides isolation from the container filesystem.

--- a/docs/ops/troubleshooting.md
+++ b/docs/ops/troubleshooting.md
@@ -1,0 +1,192 @@
+# Troubleshooting
+
+Common issues and how to resolve them.
+
+## Diagnostic Flowchart
+
+```mermaid
+flowchart TD
+    start[Service not working] --> logs[Check docker compose logs]
+    logs --> auth_err{401/403 errors?}
+    auth_err -->|Yes| pat[PAT expired or rate-limited]
+    auth_err -->|No| pending{Requests accumulating?}
+    pending -->|Yes| stale[Stale pending requests]
+    pending -->|No| poll{Polling but no action?}
+    poll -->|Yes| config[Check env vars and secrets]
+    poll -->|No| stuck{Agent changing state errors?}
+    stuck -->|Yes| agent_stuck[Agent stuck in state transition]
+    stuck -->|No| other[Check MPFS service availability]
+```
+
+## PAT Expired or Rate-Limited
+
+### Symptoms
+
+- **401 Unauthorized** or **403 Forbidden** errors in logs
+- Oracle validates no requests despite pending ones existing
+- Agent fails to download test assets
+- Rate limit header shows `remaining: 0`
+
+### Diagnosis
+
+Check the PAT validity and rate limit status:
+
+```bash
+# Check rate limit (replace <PAT> with your token)
+curl -s -H "Authorization: token <PAT>" \
+  https://api.github.com/rate_limit | jq '.rate'
+```
+
+Expected output:
+```json
+{
+  "limit": 5000,
+  "remaining": 4832,
+  "reset": 1708300000,
+  "used": 168
+}
+```
+
+If `remaining` is 0 or the request returns 401, the PAT is expired or rate-limited.
+
+### Fix
+
+1. **If expired:** Create a new PAT at [github.com/settings/tokens](https://github.com/settings/tokens) with `repo` scope
+2. Update `secrets.yaml`:
+   ```yaml
+   githubPAT: ghp_new_token_here
+   ```
+3. Restart the service:
+   ```bash
+   docker compose restart
+   ```
+
+!!! warning "Rate limit is per-user, not per-token"
+    If oracle and agent use PATs from the same GitHub user, they share the 5,000 requests/hour budget. Consider using PATs from different GitHub users for oracle and agent.
+
+## Stale Pending Requests
+
+### Symptoms
+
+- Multiple pending requests visible in `moog facts test-runs pending`
+- Requests have been pending for longer than expected (hours/days)
+- Oracle logs show it is polling but not processing requests
+
+### Diagnosis
+
+Check how many requests are pending:
+
+```bash
+moog facts test-runs pending --pretty
+```
+
+Check oracle logs for validation errors:
+
+```bash
+docker compose logs --tail 100 | grep -i "error\|fail\|reject"
+```
+
+### Fix
+
+If the oracle is down or the PAT was expired for an extended period, requests may have accumulated. There are two approaches:
+
+**Option 1: Fix the oracle and let it catch up**
+
+Once the oracle is running with a valid PAT, it will process all pending requests in subsequent polling cycles.
+
+**Option 2: Retract stale requests**
+
+If requests are no longer relevant, the requester can retract them:
+
+```bash
+moog retract -o <output-ref-id>
+```
+
+The `output-ref-id` can be found in the pending requests output.
+
+## Oracle Polling Failures
+
+### Symptoms
+
+- Oracle container is running but logs show repeated errors
+- No state updates happening on-chain
+- Pending requests keep accumulating
+
+### Diagnosis
+
+```bash
+# Check oracle is running
+docker compose ps
+
+# Check recent logs
+docker compose logs --tail 50 moog-oracle
+
+# Verify MPFS is reachable
+curl -s https://mpfs.plutimus.com/health
+```
+
+### Common causes
+
+| Cause | Log indicator | Fix |
+|---|---|---|
+| MPFS unreachable | Connection refused / timeout | Check MPFS service, check `MOOG_MPFS_HOST` |
+| Invalid wallet | Wallet decode error | Verify `MOOG_WALLET_FILE` path and file contents |
+| Wrong token ID | Token not found | Verify `MOOG_TOKEN_ID` matches the deployed token |
+| Expired PAT | 401/403 from GitHub | Rotate PAT in `secrets.yaml`, restart |
+| Insufficient funds | Balance too low | Send ADA to the oracle wallet address |
+
+## Agent Stuck in State Transition
+
+### Symptoms
+
+- Agent logs show errors when trying to accept or report a test
+- Test stuck in `pending` or `running` state
+- Transaction submission failures
+
+### Diagnosis
+
+```bash
+# Check agent logs
+docker compose logs --tail 100 moog-agent
+
+# Check current test run states
+moog facts test-runs pending --pretty
+moog facts test-runs running --pretty
+```
+
+### Common causes
+
+- **Insufficient funds** in agent wallet — send ADA to the agent wallet address
+- **MPFS transaction conflicts** — another transaction was submitted concurrently; the agent will retry on next poll
+- **Antithesis API errors** — check if Antithesis platform is reachable and credentials are valid
+
+## Rate Limit Monitoring
+
+### Check current rate limit
+
+```bash
+curl -s -H "Authorization: token <PAT>" \
+  https://api.github.com/rate_limit | jq '{
+    limit: .rate.limit,
+    remaining: .rate.remaining,
+    used: .rate.used,
+    resets_at: (.rate.reset | todate)
+  }'
+```
+
+### Estimate consumption
+
+Each oracle polling cycle makes approximately:
+
+- 1 request to check pending requests
+- N requests for GitHub validation (per pending request: user profile, CODEOWNERS, repo contents)
+
+Each agent polling cycle makes approximately:
+
+- 1 request to check pending test runs
+- 2-3 requests per test run to download assets
+
+With a 60-second poll interval and 10 pending requests, the agent alone could use ~1,800 requests/hour.
+
+!!! tip "Reduce rate limit usage"
+    Increase `--poll-interval` or `MOOG_WAIT` to reduce API call frequency when rate limits are a concern.

--- a/docs/user/secrets-management.md
+++ b/docs/user/secrets-management.md
@@ -9,7 +9,7 @@ sshPassword: your_ssh_password
 githubPAT: your_github_pat
 ```
 
-and then pass it to the container with someething like:
+and then pass it to the container with something like:
 
 ```yaml
 services:
@@ -25,11 +25,75 @@ secrets:
     file: ./secrets.yaml
 ```
 
-These are the supported secrets for different commands:
-```yaml
-sshPassword: requester_ssh_password
-githubPAT: requester_or_oracle_github_pat
-walletPassphrase: anyone_wallet_passphrase_if_any
-antithesisPassword: agent_antithesis_platform_password
-slackWebhook: agent_slack_webhook_url
+## Secrets by Role
+
+```mermaid
+graph LR
+    subgraph secrets.yaml
+        pat[githubPAT]
+        wallet[walletPassphrase]
+        ssh[sshPassword]
+        anti[antithesisPassword]
+        email[agentEmail]
+        emailpw[agentEmailPassword]
+        slack[slackWebhook]
+        trusted[trustedRequesters]
+    end
+
+    Oracle --> pat
+    Oracle --> wallet
+    Agent --> pat
+    Agent --> wallet
+    Agent --> anti
+    Agent --> email
+    Agent --> emailpw
+    Agent --> slack
+    Agent --> trusted
+    Requester --> ssh
+    Requester --> pat
+    Requester --> wallet
 ```
+
+Each role uses a different subset of the secrets. Below is the complete `secrets.yaml` structure for each role.
+
+### Oracle secrets.yaml
+
+```yaml
+githubPAT: ghp_xxxxxxxxxxxx        # GitHub PAT with repo scope
+walletPassphrase: your_passphrase   # wallet encryption passphrase (if any)
+```
+
+### Agent secrets.yaml
+
+```yaml
+agentEmail: agent@example.com             # email for receiving Antithesis results
+agentEmailPassword: xxxx-xxxx-xxxx-xxxx   # app password for the email account
+githubPAT: ghp_xxxxxxxxxxxx              # GitHub PAT with repo scope
+antithesisPassword: your_password         # Antithesis registry/platform password
+walletPassphrase: your_passphrase         # wallet encryption passphrase (if any)
+slackWebhook: https://hooks.slack.com/... # Slack notifications (optional)
+trustedRequesters:                        # allowed requester PKHs (optional)
+  - pkh_1
+  - pkh_2
+```
+
+### Requester secrets.yaml
+
+```yaml
+sshPassword: your_ssh_password      # SSH password for Git operations
+githubPAT: ghp_xxxxxxxxxxxx        # GitHub PAT with repo scope
+walletPassphrase: your_passphrase   # wallet encryption passphrase (if any)
+```
+
+### All supported keys
+
+| Key | Used by | Description |
+|---|---|---|
+| `sshPassword` | requester | SSH password for Git operations |
+| `githubPAT` | oracle, agent, requester | GitHub Personal Access Token |
+| `walletPassphrase` | oracle, agent, requester | Wallet encryption passphrase |
+| `antithesisPassword` | agent | Antithesis platform/registry password |
+| `agentEmail` | agent | Email address for receiving test results |
+| `agentEmailPassword` | agent | App password for the email account |
+| `slackWebhook` | agent | Slack webhook URL for notifications |
+| `trustedRequesters` | agent | List of trusted requester public key hashes |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,10 +84,12 @@ nav:
     - Introduction: ops/intro.md
     - Architecture: ops/architecture.md
     - Protocol: ops/protocol.md
+    - Deployment: ops/deployment.md
     - Oracle Role: ops/oracle-role.md
     - Agent Role: ops/agent-role.md
     - Real World: ops/real-world.md
     - Security: ops/security.md
+    - Troubleshooting: ops/troubleshooting.md
   - Developers:
     - Code Design: dev/code-design.md
   - Blog:


### PR DESCRIPTION
## Summary

- New deployment guide with infrastructure diagrams, secrets setup, env vars reference, PAT management, monitoring
- New troubleshooting guide with diagnostic flowchart, PAT/rate-limit issues, stale requests
- Expanded agent-role, oracle-role, security, and secrets-management docs
- Fixed `--days 1` → `--minutes 1440` in agent docker-compose (v0.4.1.1)