### PR TITLE
Remove docker-compose image extraction from test-run POST

### DIFF
--- a/src/Docker.hs
+++ b/src/Docker.hs
@@ -1,14 +1,10 @@
 module Docker
     ( build
     , dockerCompose
-    , collectImagesFromAssets
     )
 where
 
 import Core.Types.Basic
-import Data.Functor ((<&>))
-import Data.List (sort)
-import Data.List.NonEmpty qualified as NE
 import Lib.System (runSystemCommand)
 
 type CLI = (String, [String])
@@ -39,13 +35,3 @@ dockerCompose (Directory dirname) args = do
         [("INTERNAL_NETWORK", "true")]
         "docker"
         $ ["compose", "--project-directory", dirname] ++ args
-
-collectImagesFromAssets :: Directory -> IO (Either String [String])
-collectImagesFromAssets dirname = do
-    output <- dockerCompose dirname ["config", "--images"]
-    let images = uniqueAfterSort . filter (not . null) . lines
-    return $ output <&> images
-
--- Function to get unique elements after sorting a list
-uniqueAfterSort :: Ord a => [a] -> [a]
-uniqueAfterSort xs = map NE.head (NE.group (sort xs))

--- a/src/User/Agent/PushTest.hs
+++ b/src/User/Agent/PushTest.hs
@@ -40,7 +40,6 @@ import Data.Functor (($>), (<&>))
 import Data.Functor.Identity (Identity (..))
 import Data.List (intercalate)
 import Data.String.QQ (s)
-import Docker (collectImagesFromAssets)
 import Lib.JSON.Canonical.Extra (object, withObject, (.:), (.=))
 import Lib.System (runSystemCommand)
 import Oracle.Validate.Types
@@ -87,7 +86,6 @@ data PostTestRunRequest = PostTestRunRequest
     { description :: String
     , duration :: Float
     , config_image :: String
-    , images :: [String]
     , recipients :: [String]
     , source :: String
     , slack :: Maybe String
@@ -102,7 +100,6 @@ instance Aeson.ToJSON PostTestRunRequest where
             { description
             , duration
             , config_image
-            , images
             , recipients
             , source
             , slack
@@ -117,7 +114,6 @@ instance Aeson.ToJSON PostTestRunRequest where
                 [ "antithesis.description" Aeson..= description
                 , "antithesis.duration" Aeson..= duration
                 , "antithesis.config_image" Aeson..= config_image
-                , "antithesis.images" Aeson..= intercalate ";" images
                 , "antithesis.report.recipients"
                     Aeson..= intercalate ";" recipients
                 , "antithesis.source" Aeson..= source
@@ -156,8 +152,6 @@ pushTestToAntithesisIO
         tag <- throwLeft DockerBuildFailure etag
         epush <- liftIO $ pushConfigImage tag
         void $ throwLeft DockerPushFailure epush
-        eimages <- liftIO $ collectImagesFromAssets dir
-        images <- throwLeft DockerComposeFailure eimages
         (tr, duration, faultsEnabled) <- getTestRun tk testRunId
         let body =
                 PostTestRunRequest
@@ -166,7 +160,6 @@ pushTestToAntithesisIO
                         Hours h -> realToFrac h * 60
                         Minutes m -> realToFrac m
                     , config_image = tagString tag
-                    , images
                     , recipients = ["antithesis@cardanofoundation.org"]
                     , source = renderSource tr
                     , slack = fmap unSlackWebhook slack
@@ -298,7 +291,6 @@ buildConfigImage (Registry registry) (Directory context) (TestRunId trId) =
 data PushFailure
     = DockerBuildFailure String
     | DockerPushFailure String
-    | DockerComposeFailure String
     | Couldn'tResolveTestRunId TestRunId
     | PostToAntithesisFailure String
     deriving (Show, Eq)
@@ -311,10 +303,6 @@ instance Monad m => ToJSON m PushFailure where
     toJSON (DockerPushFailure msg) =
         object
             [ "dockerPushFailure" .= msg
-            ]
-    toJSON (DockerComposeFailure msg) =
-        object
-            [ "dockerComposeFailure" .= msg
             ]
     toJSON (Couldn'tResolveTestRunId (TestRunId trId)) =
         object

--- a/test/User/Agent/PushTestSpec.hs
+++ b/test/User/Agent/PushTestSpec.hs
@@ -11,7 +11,6 @@ import Core.Types.Basic
     , Platform (..)
     , Try (..)
     )
-import Docker (collectImagesFromAssets)
 import Test.Hspec (Spec, describe, it, shouldBe, shouldReturn)
 import User.Agent.PushTest
     ( AntithesisAuth (..)
@@ -27,17 +26,6 @@ import User.Types (TestRun (..))
 
 spec :: Spec
 spec = do
-    describe "collectImagesFromAssets" $ do
-        it "should collect images from a docker-compose file" $ do
-            -- Here you would write tests for the collectImagesFromAssets function
-            collectImagesFromAssets (Directory "test/data")
-                `shouldReturn` Right
-                    [ "ghcr.io/cardano-foundation/moog/configurator:latest"
-                    , "ghcr.io/cardano-foundation/moog/sidecar:latest"
-                    , "ghcr.io/cardano-foundation/moog/tracer-sidecar:latest"
-                    , "ghcr.io/cardano-foundation/moog/tracer:latest"
-                    , "ghcr.io/intersectmbo/cardano-node:latest"
-                    ]
     describe "buildConfigImage" $ do
         it "should build the Dockerfile for the cardano_node_master" $ do
             buildConfigImage
@@ -48,8 +36,6 @@ spec = do
                     (Tag "registry/cardano-moog-config:dummy")
     describe "renderPostToAntithesis" $ do
         it "should render the curl command for pushing to Antithesis" $ do
-            Right images <-
-                collectImagesFromAssets (Directory "test/data")
             Right configTag <-
                 buildConfigImage
                     (Registry "registry")
@@ -72,7 +58,6 @@ spec = do
                         { description = renderTestRun testRunId testRun
                         , duration = 3600
                         , config_image = tagString configTag
-                        , images = images
                         , recipients = ["hal@cardanofoundation.org"]
                         , source = "dummy"
                         , slack = Nothing
@@ -90,5 +75,5 @@ spec = do
                            , "-H"
                            , "Content-Type: application/json"
                            , "-d"
-                           , "{\"params\":{\"antithesis.config_image\":\"registry/cardano-moog-config:dummy\",\"antithesis.description\":\"{\\\"testRun\\\":{\\\"commitId\\\":\\\"abcdef1234567890\\\",\\\"directory\\\":\\\"tests\\\",\\\"platform\\\":\\\"github\\\",\\\"repository\\\":{\\\"organization\\\":\\\"cardano-foundation\\\",\\\"repo\\\":\\\"moog\\\"},\\\"requester\\\":\\\"alice\\\",\\\"try\\\":1,\\\"type\\\":\\\"test-run\\\"},\\\"testRunId\\\":\\\"test-run-001\\\"}\",\"antithesis.duration\":3600,\"antithesis.images\":\"ghcr.io/cardano-foundation/moog/configurator:latest;ghcr.io/cardano-foundation/moog/sidecar:latest;ghcr.io/cardano-foundation/moog/tracer-sidecar:latest;ghcr.io/cardano-foundation/moog/tracer:latest;ghcr.io/intersectmbo/cardano-node:latest\",\"antithesis.report.recipients\":\"hal@cardanofoundation.org\",\"antithesis.source\":\"dummy\",\"custom.faults_enabled\":true}}"
+                           , "{\"params\":{\"antithesis.config_image\":\"registry/cardano-moog-config:dummy\",\"antithesis.description\":\"{\\\"testRun\\\":{\\\"commitId\\\":\\\"abcdef1234567890\\\",\\\"directory\\\":\\\"tests\\\",\\\"platform\\\":\\\"github\\\",\\\"repository\\\":{\\\"organization\\\":\\\"cardano-foundation\\\",\\\"repo\\\":\\\"moog\\\"},\\\"requester\\\":\\\"alice\\\",\\\"try\\\":1,\\\"type\\\":\\\"test-run\\\"},\\\"testRunId\\\":\\\"test-run-001\\\"}\",\"antithesis.duration\":3600,\"antithesis.report.recipients\":\"hal@cardanofoundation.org\",\"antithesis.source\":\"dummy\",\"custom.faults_enabled\":true}}"
                            ]


### PR DESCRIPTION
Closes #74

Antithesis now handles docker-compose image extraction on their backend. Moog no longer needs to parse the compose file and include image references in the create-test POST payload.

## Changes

- Remove `collectImagesFromAssets` from `Docker` module
- Remove `images` field from `PostTestRunRequest` and its JSON encoding (`antithesis.images`)
- Remove `DockerComposeFailure` error constructor
- Update tests accordingly

Based on `v0.4.1.2`.