### PR TITLE
feat: add HasInstrumentation flag to test run protocol

### DIFF
--- a/src/Core/Options.hs
+++ b/src/Core/Options.hs
@@ -16,6 +16,7 @@ module Core.Options
     , walletOption
     , outcomeOption
     , faultsEnabledOption
+    , hasInstrumentationOption
     )
 where
 
@@ -26,6 +27,7 @@ import Core.Types.Basic
     , FaultsEnabled (FaultsEnabled)
     , GithubRepository (..)
     , GithubUsername (..)
+    , HasInstrumentation (HasInstrumentation)
     , Platform (..)
     , RequestRefId (..)
     , TokenId (..)
@@ -219,6 +221,17 @@ faultsEnabledOption =
             [ switch False
             , long "no-faults"
             , help "Disable faults injection for the test-run"
+            , reader auto
+            , value True
+            ]
+
+hasInstrumentationOption :: Parser HasInstrumentation
+hasInstrumentationOption =
+    HasInstrumentation
+        <$> setting
+            [ switch False
+            , long "no-instrumentation"
+            , help "Declare that the project has no instrumentation"
             , reader auto
             , value True
             ]

--- a/src/Core/Types/Basic.hs
+++ b/src/Core/Types/Basic.hs
@@ -18,6 +18,7 @@ module Core.Types.Basic
     , GithubUsername (..)
     , Success (..)
     , FaultsEnabled (..)
+    , HasInstrumentation (..)
     , organizationL
     , projectL
     )
@@ -207,6 +208,20 @@ instance ReportSchemaErrors m => FromJSON m FaultsEnabled where
 
 instance Monad m => ToJSON m FaultsEnabled where
     toJSON (FaultsEnabled b) = pure $ JSBool b
+
+newtype HasInstrumentation = HasInstrumentation
+    { getHasInstrumentation :: Bool
+    }
+    deriving (Eq, Show)
+    deriving newtype (Aeson.FromJSON)
+    deriving newtype (Aeson.ToJSON)
+
+instance ReportSchemaErrors m => FromJSON m HasInstrumentation where
+    fromJSON (JSBool b) = pure $ HasInstrumentation b
+    fromJSON v = expectedButGotValue "Bool" v
+
+instance Monad m => ToJSON m HasInstrumentation where
+    toJSON (HasInstrumentation b) = pure $ JSBool b
 
 newtype Try = Try Int
     deriving (Eq, Show, Ord, Enum, Num, Generic)

--- a/src/Oracle/Validate/Requests/TestRun/Create.hs
+++ b/src/Oracle/Validate/Requests/TestRun/Create.hs
@@ -304,7 +304,7 @@ validateCreateTestRunCore
     config
     validation
     testRun
-    (Pending duration _faultsEnabled signature) = do
+    (Pending duration _faultsEnabled _hasInstrumentation signature) = do
         (withSystemTempDirectory $ hoistValidation validation)
             "moog-test-run"
             $ \tmpDir -> do

--- a/src/User/Agent/Lib.hs
+++ b/src/User/Agent/Lib.hs
@@ -3,11 +3,12 @@ module User.Agent.Lib
     , withState
     , testRunDuration
     , testRunFaultsEnabled
+    , testRunHasInstrumentation
     ) where
 
 import Control.Applicative (Alternative (..))
 import Core.Context (WithContext, withMPFS)
-import Core.Types.Basic (FaultsEnabled, TokenId)
+import Core.Types.Basic (FaultsEnabled, HasInstrumentation, TokenId)
 import Core.Types.Duration (Duration)
 import Core.Types.Fact (Fact (..), keyHash, parseFacts)
 import Data.Foldable (find)
@@ -58,7 +59,10 @@ fromPending f = \case
     (Finished accepted _ _ _) -> fromPending f accepted
 
 testRunDuration :: TestRunState v -> Duration
-testRunDuration = fromPending $ \(Pending d _ _) -> d
+testRunDuration = fromPending $ \(Pending d _ _ _) -> d
 
 testRunFaultsEnabled :: TestRunState v -> FaultsEnabled
-testRunFaultsEnabled = fromPending $ \(Pending _ faultsEnabled _) -> faultsEnabled
+testRunFaultsEnabled = fromPending $ \(Pending _ faultsEnabled _ _) -> faultsEnabled
+
+testRunHasInstrumentation :: TestRunState v -> HasInstrumentation
+testRunHasInstrumentation = fromPending $ \(Pending _ _ hi _) -> hi

--- a/src/User/Agent/PushTest.hs
+++ b/src/User/Agent/PushTest.hs
@@ -28,6 +28,7 @@ import Core.Types.Basic
     ( Directory (..)
     , FaultsEnabled (..)
     , GithubRepository (..)
+    , HasInstrumentation (..)
     , TokenId
     )
 import Core.Types.Duration (Duration (..))
@@ -60,6 +61,7 @@ import User.Agent.Lib
     ( resolveTestRunId
     , testRunDuration
     , testRunFaultsEnabled
+    , testRunHasInstrumentation
     , withState
     )
 import User.Agent.Types
@@ -90,6 +92,7 @@ data PostTestRunRequest = PostTestRunRequest
     , source :: String
     , slack :: Maybe String
     , faults_enabled :: Bool
+    , is_haskell :: Bool
     }
     deriving (Show, Eq)
 
@@ -104,6 +107,7 @@ instance Aeson.ToJSON PostTestRunRequest where
             , source
             , slack
             , faults_enabled
+            , is_haskell
             } =
             Aeson.object
                 [ "params"
@@ -118,6 +122,7 @@ instance Aeson.ToJSON PostTestRunRequest where
                     Aeson..= intercalate ";" recipients
                 , "antithesis.source" Aeson..= source
                 , "custom.faults_enabled" Aeson..= faults_enabled
+                , "custom.is_haskell" Aeson..= is_haskell
                 ]
                     <> maybe
                         []
@@ -152,7 +157,8 @@ pushTestToAntithesisIO
         tag <- throwLeft DockerBuildFailure etag
         epush <- liftIO $ pushConfigImage tag
         void $ throwLeft DockerPushFailure epush
-        (tr, duration, faultsEnabled) <- getTestRun tk testRunId
+        (tr, duration, faultsEnabled, hasInstrumentation) <-
+            getTestRun tk testRunId
         let body =
                 PostTestRunRequest
                     { description = renderTestRun testRunId tr
@@ -164,6 +170,7 @@ pushTestToAntithesisIO
                     , source = renderSource tr
                     , slack = fmap unSlackWebhook slack
                     , faults_enabled = getFaultsEnabled faultsEnabled
+                    , is_haskell = not (getHasInstrumentation hasInstrumentation)
                     }
             post = renderPostToAntithesis auth body
         epost <- liftIO $ curl post
@@ -204,13 +211,19 @@ getTestRun
     -> Validate
         PushFailure
         (WithContext m)
-        (TestRun, Duration, FaultsEnabled)
+        (TestRun, Duration, FaultsEnabled, HasInstrumentation)
 getTestRun tk testRunId = do
     mts <- lift $ resolveTestRunId tk testRunId
     Fact tr v _ <- liftMaybe (Couldn'tResolveTestRunId testRunId) mts
     liftMaybe (Couldn'tResolveTestRunId testRunId)
         $ withState
-            (\state -> (tr, testRunDuration state, testRunFaultsEnabled state))
+            ( \state ->
+                ( tr
+                , testRunDuration state
+                , testRunFaultsEnabled state
+                , testRunHasInstrumentation state
+                )
+            )
             v
 
 data AntithesisAuth = AntithesisAuth

--- a/src/User/Requester/Cli.hs
+++ b/src/User/Requester/Cli.hs
@@ -21,6 +21,7 @@ import Core.Types.Basic
     ( Directory (..)
     , FaultsEnabled
     , GithubRepository (..)
+    , HasInstrumentation
     , Success (..)
     , TokenId
     )
@@ -118,6 +119,7 @@ data RequesterCommand a where
         -> TestRun
         -> Duration
         -> FaultsEnabled
+        -> HasInstrumentation
         -> RequesterCommand
             ( AValidationResult
                 CreateTestRunFailure
@@ -148,14 +150,22 @@ requesterCmd command = do
             registerRole tokenId wallet request
         UnregisterRole tokenId wallet request ->
             unregisterRole tokenId wallet request
-        RequestTest tokenId wallet mSshClient testRun duration faultsEnabled ->
-            createCommand
-                tokenId
-                wallet
-                mSshClient
-                testRun
-                duration
-                faultsEnabled
+        RequestTest
+            tokenId
+            wallet
+            mSshClient
+            testRun
+            duration
+            faultsEnabled
+            hasInstrumentation ->
+                createCommand
+                    tokenId
+                    wallet
+                    mSshClient
+                    testRun
+                    duration
+                    faultsEnabled
+                    hasInstrumentation
         GenerateAssets directory -> generateAssets directory
 
 generateAssets
@@ -206,6 +216,7 @@ createCommand
     -> TestRun
     -> Duration
     -> FaultsEnabled
+    -> HasInstrumentation
     -> WithContext
         m
         ( AValidationResult
@@ -218,7 +229,8 @@ createCommand
     mSshClient
     testRun
     duration
-    faultsEnabled = do
+    faultsEnabled
+    hasInstrumentation = do
         mconfig <- askConfig tokenId
         validation <- askValidation $ Just tokenId
         Submission submit <- askSubmit wallet
@@ -238,7 +250,7 @@ createCommand
                         liftMaybe CreateTestRunInvalidSSHKey
                             =<< decodePrivateSSHFile (hoistValidation validation) sshClient
                     lift $ signKey sshKeyPair testRun
-            let newState = Pending duration faultsEnabled signature
+            let newState = Pending duration faultsEnabled hasInstrumentation signature
             Config{configTestRun} <-
                 liftMaybe CreateTestConfigNotAvailable mconfig
             void

--- a/src/User/Requester/Options.hs
+++ b/src/User/Requester/Options.hs
@@ -13,6 +13,7 @@ import Core.Options
     , downloadAssetsDirectoryOption
     , durationOption
     , faultsEnabledOption
+    , hasInstrumentationOption
     , platformOption
     , repositoryOption
     , sshPublicKeyHashParser
@@ -208,3 +209,4 @@ requestTestOptions =
             )
         <*> durationOption
         <*> faultsEnabledOption
+        <*> hasInstrumentationOption

--- a/src/User/Types.hs
+++ b/src/User/Types.hs
@@ -37,6 +37,7 @@ import Core.Types.Basic
     , FaultsEnabled (..)
     , GithubRepository (..)
     , GithubUsername (..)
+    , HasInstrumentation (..)
     , Platform (..)
     , Try (..)
     )
@@ -206,6 +207,7 @@ data TestRunState a where
     Pending
         :: Duration
         -> FaultsEnabled
+        -> HasInstrumentation
         -> Ed25519.Signature
         -> TestRunState PendingT
     Rejected
@@ -223,12 +225,13 @@ deriving instance Eq (TestRunState a)
 deriving instance Show (TestRunState a)
 
 instance Monad m => ToJSON m (TestRunState a) where
-    toJSON (Pending d faultsEnabled signature) =
+    toJSON (Pending d faultsEnabled hasInstrumentation signature) =
         object
             [ ("phase", stringJSON "pending")
             , ("duration", toJSON d)
             , ("signature", byteStringToJSON $ BA.convert signature)
             , "faults_enabled" .= faultsEnabled
+            , "has_instrumentation" .= hasInstrumentation
             ]
     toJSON (Rejected pending reasons) =
         object
@@ -264,9 +267,19 @@ instance
                 signatureByteString <- byteStringFromJSON signatureJSValue
                 faultsEnabled <-
                     getFieldWithDefault "faults_enabled" (FaultsEnabled True) mapping
+                hasInstrumentation <-
+                    getFieldWithDefault
+                        "has_instrumentation"
+                        (HasInstrumentation True)
+                        mapping
                 case Ed25519.signature signatureByteString of
                     CryptoPassed signature ->
-                        pure $ Pending duration faultsEnabled signature
+                        pure
+                            $ Pending
+                                duration
+                                faultsEnabled
+                                hasInstrumentation
+                                signature
                     CryptoFailed e ->
                         expectedButGotValue
                             ("a valid Ed25519 signature " ++ show e)

--- a/test/Oracle/Validate/Requests/TestRun/AcceptSpec.hs
+++ b/test/Oracle/Validate/Requests/TestRun/AcceptSpec.hs
@@ -6,6 +6,7 @@ where
 import Control.Monad (when)
 import Core.Types.Basic
     ( FaultsEnabled (..)
+    , HasInstrumentation (HasInstrumentation)
     , Owner (..)
     , RequestRefId (..)
     )
@@ -60,7 +61,7 @@ spec = do
             testRun <- testRunEGen
             signature <- gen signatureGen
             faultsEnabled <- FaultsEnabled <$> gen arbitrary
-            let pendingState = Pending (Hours 5) faultsEnabled signature
+            let pendingState = Pending (Hours 5) faultsEnabled (HasInstrumentation True) signature
             testRunFact <- toJSFact testRun pendingState 0
             let validation =
                     mkEffects (withFacts [testRunFact] mockMPFS) noValidation
@@ -77,7 +78,7 @@ spec = do
                 anOwner <- gen $ Owner <$> genAscii
                 faultsEnabled <- FaultsEnabled <$> gen arbitrary
                 configFact <- testConfigFactGen anOwner
-                let pendingState = Pending (Hours 5) faultsEnabled signature
+                let pendingState = Pending (Hours 5) faultsEnabled (HasInstrumentation True) signature
                     change = Change (Key testRun) (Update pendingState (Accepted pendingState))
                     pendingRequest =
                         AcceptRequest
@@ -100,7 +101,12 @@ spec = do
                 signature <- gen signatureGen
                 duration <- genA
                 faultsEnabled <- FaultsEnabled <$> gen arbitrary
-                let pendingState = Pending (Hours duration) faultsEnabled signature
+                let pendingState =
+                        Pending
+                            (Hours duration)
+                            faultsEnabled
+                            (HasInstrumentation True)
+                            signature
                     newTestRunState = Accepted pendingState
                     test =
                         validateToRunningCore
@@ -119,9 +125,18 @@ spec = do
                 signature <- gen signatureGen
                 differentSignature <- gen $ oneof [signatureGen, pure signature]
                 faultsEnabled <- FaultsEnabled <$> gen arbitrary
-                let fact = Pending (Hours duration) faultsEnabled signature
+                let fact =
+                        Pending
+                            (Hours duration)
+                            faultsEnabled
+                            (HasInstrumentation True)
+                            signature
                     request =
-                        Pending (Hours differentDuration) faultsEnabled differentSignature
+                        Pending
+                            (Hours differentDuration)
+                            faultsEnabled
+                            (HasInstrumentation True)
+                            differentSignature
                 testRunFact <- toJSFact testRun fact 0
                 let validation =
                         mkEffects (withFacts [testRunFact] mockMPFS) noValidation

--- a/test/Oracle/Validate/Requests/TestRun/CreateSpec.hs
+++ b/test/Oracle/Validate/Requests/TestRun/CreateSpec.hs
@@ -12,6 +12,7 @@ import Control.Monad (when)
 import Core.Types.Basic
     ( FaultsEnabled (..)
     , FileName (..)
+    , HasInstrumentation (HasInstrumentation)
     , Owner (..)
     , RequestRefId (RequestRefId)
     , organization
@@ -170,7 +171,7 @@ spec = do
                     n -> do
                         let previousTestRun = testRun{tryIndex = n - 1}
                         previousState <-
-                            Pending duration faultsEnabled
+                            Pending duration faultsEnabled (HasInstrumentation True)
                                 <$> signTestRun
                                     sign
                                     previousTestRun
@@ -197,7 +198,7 @@ spec = do
                             , mockAssets = files
                             }
             testRunState <-
-                Pending duration faultsEnabled
+                Pending duration faultsEnabled (HasInstrumentation True)
                     <$> signTestRun sign testRun
             pure $ do
                 mresult <-
@@ -224,7 +225,7 @@ spec = do
                 (sign, _pk) <- genBlind ed25519Gen
                 forRole <- genForRole
                 testRunState <-
-                    Pending duration faultsEnabled
+                    Pending duration faultsEnabled (HasInstrumentation True)
                         <$> signTestRun sign testRun
                 let validation =
                         mkEffects
@@ -274,7 +275,7 @@ spec = do
                         )
                         0
                 testRunState <-
-                    Pending duration faultsEnabled
+                    Pending duration faultsEnabled (HasInstrumentation True)
                         <$> signTestRun sign testRun
                 let validation =
                         mkEffects
@@ -327,10 +328,10 @@ spec = do
                 (sign, _pk) <- genBlind ed25519Gen
                 forRole <- genForRole
                 testRunState <-
-                    Pending duration faultsEnabled
+                    Pending duration faultsEnabled (HasInstrumentation True)
                         <$> signTestRun sign testRun
                 otherTestRunState <-
-                    Pending otherDuration faultsEnabled
+                    Pending otherDuration faultsEnabled (HasInstrumentation True)
                         <$> signTestRun sign testRun
                 let pendingRequest =
                         CreateTestRequest
@@ -371,7 +372,7 @@ spec = do
             testConfig <- testConfigEGen
             signature <- gen signatureGen
             faultsEnabled <- FaultsEnabled <$> gen arbitrary
-            let testRunState = Pending duration faultsEnabled signature
+            let testRunState = Pending duration faultsEnabled (HasInstrumentation True) signature
             pure $ do
                 mresult <-
                     runValidate
@@ -408,7 +409,12 @@ spec = do
                     mkEffects
                         (withFacts [roleFact] mockMPFS)
                         noValidation
-                testRunState = Pending (Hours duration) faultsEnabled signature
+                testRunState =
+                    Pending
+                        (Hours duration)
+                        faultsEnabled
+                        (HasInstrumentation True)
+                        signature
             pure $ do
                 mresult <-
                     runValidate
@@ -450,7 +456,12 @@ spec = do
                         ]
             let mkTestRunFact :: Monad m => TestRunState x -> m JSFact
                 mkTestRunFact s = toJSFact testRunDB s 0
-                pending = Pending (Hours duration) faultsEnabled signature
+                pending =
+                    Pending
+                        (Hours duration)
+                        faultsEnabled
+                        (HasInstrumentation True)
+                        signature
                 accepted = Accepted pending
             rejections <-
                 gen $ listOf $ elements [BrokenInstructions, UnclearIntent]
@@ -476,7 +487,12 @@ spec = do
                     mkEffects
                         (withFacts [testRunFact | testRunDB.tryIndex > 0] mockMPFS)
                         noValidation
-            let testRunState = Pending (Hours duration) faultsEnabled signature
+            let testRunState =
+                    Pending
+                        (Hours duration)
+                        faultsEnabled
+                        (HasInstrumentation True)
+                        signature
             pure
                 $ counterexample (show testRunDB)
                 $ cover
@@ -507,7 +523,12 @@ spec = do
             signature <- gen signatureGen
             testRun <- testRunEGen
             testRun' <- gen $ oneof [changeDirectory testRun, pure testRun]
-            let testRunState = Pending (Hours duration) faultsEnabled signature
+            let testRunState =
+                    Pending
+                        (Hours duration)
+                        faultsEnabled
+                        (HasInstrumentation True)
+                        signature
             testRunFact <- toJSFact testRun' testRunState 0
             let validation =
                     mkEffects (withFacts [testRunFact] mockMPFS)
@@ -534,7 +555,12 @@ spec = do
             faultsEnabled <- FaultsEnabled <$> gen arbitrary
             signature <- gen signatureGen
             testRun <- testRunEGen
-            let testRunState = Pending (Hours duration) faultsEnabled signature
+            let testRunState =
+                    Pending
+                        (Hours duration)
+                        faultsEnabled
+                        (HasInstrumentation True)
+                        signature
                 key =
                     WhiteListKey
                         { platform = testRun.platform

--- a/test/Oracle/Validate/Requests/TestRun/FinishSpec.hs
+++ b/test/Oracle/Validate/Requests/TestRun/FinishSpec.hs
@@ -6,6 +6,7 @@ where
 import Control.Monad (when)
 import Core.Types.Basic
     ( FaultsEnabled (..)
+    , HasInstrumentation (HasInstrumentation)
     , Owner (..)
     , RequestRefId (..)
     )
@@ -65,7 +66,13 @@ spec = do
             actualDuration <- genA
             url <- gen genAscii
             faultsEnabled <- FaultsEnabled <$> gen arbitrary
-            let acceptedState = Accepted $ Pending (Hours 5) faultsEnabled signature
+            let acceptedState =
+                    Accepted
+                        $ Pending
+                            (Hours 5)
+                            faultsEnabled
+                            (HasInstrumentation True)
+                            signature
             testRunFact <- toJSFact testRun acceptedState 0
             let validation =
                     mkEffects
@@ -92,6 +99,7 @@ spec = do
                             ( Pending
                                 (Hours 5)
                                 (FaultsEnabled True)
+                                (HasInstrumentation True)
                                 signature
                             )
                     change =
@@ -127,6 +135,7 @@ spec = do
                         Pending
                             (Hours duration)
                             (FaultsEnabled True)
+                            (HasInstrumentation True)
                             signature
                     newTestRunState = Accepted pendingState
                     test =
@@ -150,12 +159,18 @@ spec = do
                 faultsEnabled <- FaultsEnabled <$> gen arbitrary
                 url <- genA
                 let fact =
-                        Accepted $ Pending (Hours pendingDuration) faultsEnabled signature
+                        Accepted
+                            $ Pending
+                                (Hours pendingDuration)
+                                faultsEnabled
+                                (HasInstrumentation True)
+                                signature
                     request =
                         Accepted
                             $ Pending
                                 (Hours differentPendingDuration)
                                 faultsEnabled
+                                (HasInstrumentation True)
                                 differentSignature
                 testRunFact <- toJSFact testRun fact 0
                 let validation =

--- a/test/Oracle/Validate/Requests/TestRun/RejectSpec.hs
+++ b/test/Oracle/Validate/Requests/TestRun/RejectSpec.hs
@@ -6,6 +6,7 @@ where
 import Control.Monad (when)
 import Core.Types.Basic
     ( FaultsEnabled (..)
+    , HasInstrumentation (HasInstrumentation)
     , Owner (..)
     , RequestRefId (..)
     )
@@ -61,7 +62,7 @@ spec = do
             testRun <- testRunEGen
             signature <- gen signatureGen
             faultsEnabled <- FaultsEnabled <$> gen arbitrary
-            let pendingState = Pending (Hours 5) faultsEnabled signature
+            let pendingState = Pending (Hours 5) faultsEnabled (HasInstrumentation True) signature
             testRunFact <- toJSFact testRun pendingState 0
             agent <- Owner <$> gen genAscii
             configFact <- testConfigFactGen agent
@@ -82,7 +83,7 @@ spec = do
                 anOwner <- gen $ Owner <$> genAscii
                 faultsEnabled <- FaultsEnabled <$> gen arbitrary
                 configFact <- testConfigFactGen anOwner
-                let pendingState = Pending (Hours 5) faultsEnabled signature
+                let pendingState = Pending (Hours 5) faultsEnabled (HasInstrumentation True) signature
                     change =
                         Change
                             { key = Key testRun
@@ -116,7 +117,12 @@ spec = do
                 configFact <- testConfigFactGen anOwner
                 let validation =
                         mkEffects (withFacts [configFact] mockMPFS) noValidation
-                let pendingState = Pending (Hours duration) faultsEnabled signature
+                let pendingState =
+                        Pending
+                            (Hours duration)
+                            faultsEnabled
+                            (HasInstrumentation True)
+                            signature
                     newTestRunState = Rejected pendingState [BrokenInstructions]
                     test =
                         validateToDoneCore
@@ -137,9 +143,18 @@ spec = do
                 anOwner <- gen $ Owner <$> genAscii
                 configFact <- testConfigFactGen anOwner
                 differentSignature <- gen $ oneof [signatureGen, pure signature]
-                let fact = Pending (Hours duration) faultsEnabled signature
+                let fact =
+                        Pending
+                            (Hours duration)
+                            faultsEnabled
+                            (HasInstrumentation True)
+                            signature
                     request =
-                        Pending (Hours differentDuration) faultsEnabled differentSignature
+                        Pending
+                            (Hours differentDuration)
+                            faultsEnabled
+                            (HasInstrumentation True)
+                            differentSignature
                 testRunFact <- toJSFact testRun fact 0
                 let validation =
                         mkEffects

--- a/test/User/Agent/PushTestSpec.hs
+++ b/test/User/Agent/PushTestSpec.hs
@@ -62,6 +62,7 @@ spec = do
                         , source = "dummy"
                         , slack = Nothing
                         , faults_enabled = True
+                        , is_haskell = False
                         }
                 (cmd, args) = renderPostToAntithesis auth body
             cmd `shouldBe` "curl"
@@ -75,5 +76,5 @@ spec = do
                            , "-H"
                            , "Content-Type: application/json"
                            , "-d"
-                           , "{\"params\":{\"antithesis.config_image\":\"registry/cardano-moog-config:dummy\",\"antithesis.description\":\"{\\\"testRun\\\":{\\\"commitId\\\":\\\"abcdef1234567890\\\",\\\"directory\\\":\\\"tests\\\",\\\"platform\\\":\\\"github\\\",\\\"repository\\\":{\\\"organization\\\":\\\"cardano-foundation\\\",\\\"repo\\\":\\\"moog\\\"},\\\"requester\\\":\\\"alice\\\",\\\"try\\\":1,\\\"type\\\":\\\"test-run\\\"},\\\"testRunId\\\":\\\"test-run-001\\\"}\",\"antithesis.duration\":3600,\"antithesis.report.recipients\":\"hal@cardanofoundation.org\",\"antithesis.source\":\"dummy\",\"custom.faults_enabled\":true}}"
+                           , "{\"params\":{\"antithesis.config_image\":\"registry/cardano-moog-config:dummy\",\"antithesis.description\":\"{\\\"testRun\\\":{\\\"commitId\\\":\\\"abcdef1234567890\\\",\\\"directory\\\":\\\"tests\\\",\\\"platform\\\":\\\"github\\\",\\\"repository\\\":{\\\"organization\\\":\\\"cardano-foundation\\\",\\\"repo\\\":\\\"moog\\\"},\\\"requester\\\":\\\"alice\\\",\\\"try\\\":1,\\\"type\\\":\\\"test-run\\\"},\\\"testRunId\\\":\\\"test-run-001\\\"}\",\"antithesis.duration\":3600,\"antithesis.report.recipients\":\"hal@cardanofoundation.org\",\"antithesis.source\":\"dummy\",\"custom.faults_enabled\":true,\"custom.is_haskell\":false}}"
                            ]

--- a/test/User/Requester/CliSpec.hs
+++ b/test/User/Requester/CliSpec.hs
@@ -14,6 +14,7 @@ import Core.Types.Basic
     , FileName (..)
     , GithubRepository (..)
     , GithubUsername (..)
+    , HasInstrumentation (HasInstrumentation)
     , Owner (..)
     , Platform (..)
     , TokenId (..)
@@ -200,10 +201,14 @@ testDuration = Hours 3
 faultsEnabled :: FaultsEnabled
 faultsEnabled = FaultsEnabled True
 
+hasInstrumentation :: HasInstrumentation
+hasInstrumentation = HasInstrumentation True
+
 pendingState :: TestRunState 'PendingT
 pendingState = case signKey keyPair testRun of
     Nothing -> error "Failed to sign testRun"
-    Just (_, signature) -> Pending testDuration faultsEnabled signature
+    Just (_, signature) ->
+        Pending testDuration faultsEnabled hasInstrumentation signature
 
 spec :: Spec
 spec = describe "User.Requester.Cli" $ do
@@ -217,6 +222,7 @@ spec = describe "User.Requester.Cli" $ do
                     testRun
                     testDuration
                     faultsEnabled
+                    hasInstrumentation
 
         withContext
             mockMPFS{mpfsGetTokenFacts = const . pure $ renderFacts facts}

--- a/test/User/TypesSpec.hs
+++ b/test/User/TypesSpec.hs
@@ -13,6 +13,7 @@ import Core.Types.Basic
     , FaultsEnabled (..)
     , GithubRepository (GithubRepository, organization, project)
     , GithubUsername (GithubUsername)
+    , HasInstrumentation (..)
     , Platform (Platform)
     , Try (..)
     )
@@ -75,12 +76,14 @@ spec = do
             $ \message
                duration
                faultsEnabled
+               hasInstrumentation
                (ASCIIString url) -> forAll (listOf testRunRejectionGen) $ \rejections -> do
                     forAllBlind ed25519Gen $ \(sign, _verify) -> do
                         let pending =
                                 Pending
                                     (Hours duration)
                                     (FaultsEnabled faultsEnabled)
+                                    (HasInstrumentation hasInstrumentation)
                                     $ sign message
                         roundTrip pending
                         let rejected =
@@ -128,42 +131,40 @@ spec = do
                     (_, Nothing) -> Left "failed to parse TestRunState value"
 
         it "parses finished/unknown test-run (duration:1)" $ do
-            case
-                parseFact
-                    "{\"commitId\":\"031bff3ab7dd23158b94eb377cdbd6be575566e1\",\"directory\":\"testnets/cardano_node_master\",\"platform\":\"github\",\"repository\":{\"organization\":\"cardano-foundation\",\"repo\":\"cardano-node-antithesis\"},\"requester\":\"cfhal\",\"try\":1,\"type\":\"test-run\"}"
-                    "{\"duration\":1,\"from\":{\"from\":{\"duration\":1,\"faults_enabled\":true,\"phase\":\"pending\",\"signature\":\"bb5dcd3b9fe400e6afcbaefc25eda815fa23186b01e376a712867aa89aad0b0eec49b15115155751e6c1faa35d97cf31d2d70b1932c73c04c237090f0b24d00f\"},\"phase\":\"accepted\"},\"outcome\":\"unknown\",\"phase\":\"finished\",\"url\":\"encrypted-url-data\"}"
-                of
-                    Left err -> expectationFailure err
-                    Right (testRun, done) -> do
-                        commitId testRun `shouldBe` Commit "031bff3ab7dd23158b94eb377cdbd6be575566e1"
-                        tryIndex testRun `shouldBe` Try 1
-                        case done of
-                            Finished _ dur outcome _ -> do
-                                dur `shouldBe` Hours 1
-                                outcome `shouldBe` OutcomeUnknown
-                            _ -> expectationFailure "expected Finished state"
+            case parseFact
+                "{\"commitId\":\"031bff3ab7dd23158b94eb377cdbd6be575566e1\",\"directory\":\"testnets/cardano_node_master\",\"platform\":\"github\",\"repository\":{\"organization\":\"cardano-foundation\",\"repo\":\"cardano-node-antithesis\"},\"requester\":\"cfhal\",\"try\":1,\"type\":\"test-run\"}"
+                "{\"duration\":1,\"from\":{\"from\":{\"duration\":1,\"faults_enabled\":true,\"phase\":\"pending\",\"signature\":\"bb5dcd3b9fe400e6afcbaefc25eda815fa23186b01e376a712867aa89aad0b0eec49b15115155751e6c1faa35d97cf31d2d70b1932c73c04c237090f0b24d00f\"},\"phase\":\"accepted\"},\"outcome\":\"unknown\",\"phase\":\"finished\",\"url\":\"encrypted-url-data\"}" of
+                Left err -> expectationFailure err
+                Right (testRun, done) -> do
+                    commitId testRun
+                        `shouldBe` Commit "031bff3ab7dd23158b94eb377cdbd6be575566e1"
+                    tryIndex testRun `shouldBe` Try 1
+                    case done of
+                        Finished _ dur outcome _ -> do
+                            dur `shouldBe` Hours 1
+                            outcome `shouldBe` OutcomeUnknown
+                        _ -> expectationFailure "expected Finished state"
 
         it "parses finished/failure test-run (duration:1)" $ do
-            case
-                parseFact
-                    "{\"commitId\":\"03e14eab93d2bc008e1be4deb75430c1a8d98948\",\"directory\":\"compose/testnets/cardano_node_master\",\"platform\":\"github\",\"repository\":{\"organization\":\"cardano-foundation\",\"repo\":\"moog\"},\"requester\":\"cfhal\",\"try\":1,\"type\":\"test-run\"}"
-                    "{\"duration\":1,\"from\":{\"from\":{\"duration\":1,\"faults_enabled\":true,\"phase\":\"pending\",\"signature\":\"416ed1bf5c531674ed22511aeefeadb935d79691e03e16a9c3771a44fc64b6e558ee61d8266023fcee10d8042583c7fef919b64d7e295405d64f55f6bb855104\"},\"phase\":\"accepted\"},\"outcome\":\"failure\",\"phase\":\"finished\",\"url\":\"encrypted-url-data\"}"
-                of
-                    Left err -> expectationFailure err
-                    Right (testRun, done) -> do
-                        commitId testRun `shouldBe` Commit "03e14eab93d2bc008e1be4deb75430c1a8d98948"
-                        case done of
-                            Finished _ dur outcome _ -> do
-                                dur `shouldBe` Hours 1
-                                outcome `shouldBe` OutcomeFailure
-                            _ -> expectationFailure "expected Finished state"
+            case parseFact
+                "{\"commitId\":\"03e14eab93d2bc008e1be4deb75430c1a8d98948\",\"directory\":\"compose/testnets/cardano_node_master\",\"platform\":\"github\",\"repository\":{\"organization\":\"cardano-foundation\",\"repo\":\"moog\"},\"requester\":\"cfhal\",\"try\":1,\"type\":\"test-run\"}"
+                "{\"duration\":1,\"from\":{\"from\":{\"duration\":1,\"faults_enabled\":true,\"phase\":\"pending\",\"signature\":\"416ed1bf5c531674ed22511aeefeadb935d79691e03e16a9c3771a44fc64b6e558ee61d8266023fcee10d8042583c7fef919b64d7e295405d64f55f6bb855104\"},\"phase\":\"accepted\"},\"outcome\":\"failure\",\"phase\":\"finished\",\"url\":\"encrypted-url-data\"}" of
+                Left err -> expectationFailure err
+                Right (testRun, done) -> do
+                    commitId testRun
+                        `shouldBe` Commit "03e14eab93d2bc008e1be4deb75430c1a8d98948"
+                    case done of
+                        Finished _ dur outcome _ -> do
+                            dur `shouldBe` Hours 1
+                            outcome `shouldBe` OutcomeFailure
+                        _ -> expectationFailure "expected Finished state"
 
-        it "parses finished/success test-run (duration:1, faults_enabled:false)" $ do
-            case
-                parseFact
+        it
+            "parses finished/success test-run (duration:1, faults_enabled:false)"
+            $ do
+                case parseFact
                     "{\"commitId\":\"10b3f601e82560c182f08ba4070f20aab934a0e9\",\"directory\":\"compose/testnets/cardano_node_master\",\"platform\":\"github\",\"repository\":{\"organization\":\"cardano-foundation\",\"repo\":\"moog\"},\"requester\":\"cfhal\",\"try\":2,\"type\":\"test-run\"}"
-                    "{\"duration\":1,\"from\":{\"from\":{\"duration\":1,\"faults_enabled\":false,\"phase\":\"pending\",\"signature\":\"483d4933bba2eea6496cf5dbb28288f5a0076f685714a908c2ac24b625141c642caa504ea9721119875c56caef08f00c0af119b39fbb0fb2bb71a99cb2b42e06\"},\"phase\":\"accepted\"},\"outcome\":\"success\",\"phase\":\"finished\",\"url\":\"encrypted-url-data\"}"
-                of
+                    "{\"duration\":1,\"from\":{\"from\":{\"duration\":1,\"faults_enabled\":false,\"phase\":\"pending\",\"signature\":\"483d4933bba2eea6496cf5dbb28288f5a0076f685714a908c2ac24b625141c642caa504ea9721119875c56caef08f00c0af119b39fbb0fb2bb71a99cb2b42e06\"},\"phase\":\"accepted\"},\"outcome\":\"success\",\"phase\":\"finished\",\"url\":\"encrypted-url-data\"}" of
                     Left err -> expectationFailure err
                     Right (testRun, done) -> do
                         tryIndex testRun `shouldBe` Try 2
@@ -174,13 +175,11 @@ spec = do
                             _ -> expectationFailure "expected Finished state"
 
         it "parses finished test-run with duration:3" $ do
-            case
-                parseFact
-                    "{\"commitId\":\"071b965acee2b8b7529df4eb5a1e87d525d29ba0\",\"directory\":\"testnets/cardano_node_master\",\"platform\":\"github\",\"repository\":{\"organization\":\"cardano-foundation\",\"repo\":\"cardano-node-antithesis\"},\"requester\":\"cfhal\",\"try\":1,\"type\":\"test-run\"}"
-                    "{\"duration\":3,\"from\":{\"from\":{\"duration\":3,\"faults_enabled\":true,\"phase\":\"pending\",\"signature\":\"3c5ecd80f97792efed818c3c066df4522af3f6e2514943b91863c31badccaa18d01de81e381417f40c7dc27592341e74222c5abe151bd7a369204d13025a1005\"},\"phase\":\"accepted\"},\"outcome\":\"unknown\",\"phase\":\"finished\",\"url\":\"encrypted-url-data\"}"
-                of
-                    Left err -> expectationFailure err
-                    Right (_testRun, done) -> do
-                        case done of
-                            Finished _ dur _ _ -> dur `shouldBe` Hours 3
-                            _ -> expectationFailure "expected Finished state"
+            case parseFact
+                "{\"commitId\":\"071b965acee2b8b7529df4eb5a1e87d525d29ba0\",\"directory\":\"testnets/cardano_node_master\",\"platform\":\"github\",\"repository\":{\"organization\":\"cardano-foundation\",\"repo\":\"cardano-node-antithesis\"},\"requester\":\"cfhal\",\"try\":1,\"type\":\"test-run\"}"
+                "{\"duration\":3,\"from\":{\"from\":{\"duration\":3,\"faults_enabled\":true,\"phase\":\"pending\",\"signature\":\"3c5ecd80f97792efed818c3c066df4522af3f6e2514943b91863c31badccaa18d01de81e381417f40c7dc27592341e74222c5abe151bd7a369204d13025a1005\"},\"phase\":\"accepted\"},\"outcome\":\"unknown\",\"phase\":\"finished\",\"url\":\"encrypted-url-data\"}" of
+                Left err -> expectationFailure err
+                Right (_testRun, done) -> do
+                    case done of
+                        Finished _ dur _ _ -> dur `shouldBe` Hours 3
+                        _ -> expectationFailure "expected Finished state"


### PR DESCRIPTION
Closes #76

Add `--no-instrumentation` CLI flag (default: instrumented) following the `FaultsEnabled` pattern.

- `HasInstrumentation` newtype wrapping `Bool` in `Core.Types.Basic`
- CLI option: `--no-instrumentation` negative switch (same pattern as `--no-faults`)
- On-chain field `"has_instrumentation"` with backward-compat default `True`
- Antithesis POST sets `custom.is_haskell` to the **negation** of `hasInstrumentation`
- `Pending` constructor gains 4th field: `Duration -> FaultsEnabled -> HasInstrumentation -> Signature`
- All test sites updated (126 unit tests pass)