### PR TITLE
Add AntithesisId to Accepted test run state

### DIFF
--- a/src/Core/Types/Basic.hs
+++ b/src/Core/Types/Basic.hs
@@ -19,6 +19,7 @@ module Core.Types.Basic
     , Success (..)
     , FaultsEnabled (..)
     , HasInstrumentation (..)
+    , AntithesisId (..)
     , organizationL
     , projectL
     )
@@ -233,3 +234,21 @@ data Success = Success
 
 instance Monad m => ToJSON m Success where
     toJSON Success = pure $ JSString "OK"
+
+-- | External test run identifier, assigned by the
+-- testing service (Antithesis). Stored on-chain in
+-- the 'Running' state so results can be queried by
+-- ID.
+newtype AntithesisId = AntithesisId
+    { getAntithesisId :: String
+    }
+    deriving (Eq, Show)
+
+instance Monad m => ToJSON m AntithesisId where
+    toJSON (AntithesisId aid) = stringJSON aid
+
+instance ReportSchemaErrors m => FromJSON m AntithesisId where
+    fromJSON (JSString s) =
+        pure $ AntithesisId (fromJSString s)
+    fromJSON v =
+        expectedButGotValue "AntithesisId string" v

--- a/src/Oracle/Validate/Requests/TestRun/Update.hs
+++ b/src/Oracle/Validate/Requests/TestRun/Update.hs
@@ -186,4 +186,4 @@ validateToRunningCore
 validateToRunningCore
     validation
     testRun = \case
-        Accepted pending -> checkPastState validation testRun pending
+        Accepted pending _ -> checkPastState validation testRun pending

--- a/src/User/Agent/Cli.hs
+++ b/src/User/Agent/Cli.hs
@@ -27,7 +27,8 @@ import Core.Context
     , withMPFS
     )
 import Core.Types.Basic
-    ( Directory
+    ( AntithesisId (..)
+    , Directory
     , GithubRepository
     , GithubUsername (..)
     , Owner
@@ -206,10 +207,10 @@ agentCmd = \case
         blackList tokenId wallet platform repo
     DownloadAssets tokenId key dir ->
         ($> Success) <$> downloadAssets tokenId key dir
-    Accept tokenId wallet key () -> runValidate
+    Accept tokenId wallet key () antithesisId -> runValidate
         $ updateTestRunState tokenId key
         $ \fact ->
-            acceptCommand tokenId wallet fact
+            acceptCommand tokenId wallet fact antithesisId
     Reject tokenId wallet key () reason -> runValidate
         $ updateTestRunState tokenId key
         $ \fact ->
@@ -306,6 +307,7 @@ data AgentCommand (phase :: IsReady) result where
         -> Wallet
         -> ResolveId phase
         -> IfReady phase (TestRunState PendingT)
+        -> AntithesisId
         -> AgentCommand
             phase
             ( AValidationResult
@@ -554,16 +556,17 @@ acceptCommand
     => TokenId
     -> Wallet
     -> Fact TestRun (TestRunState PendingT)
+    -> AntithesisId
     -> ValidateWithContext
         m
         (WithTxHash (TestRunState RunningT))
-acceptCommand tokenId wallet fact =
+acceptCommand tokenId wallet fact antithesisId =
     signAndSubmitAnUpdate
         (`validateToRunningUpdate` ForUser)
         tokenId
         wallet
         fact
-        $ Accepted (factValue fact)
+        $ Accepted (factValue fact) antithesisId
 
 reportCommand
     :: Monad m

--- a/src/User/Agent/Lib.hs
+++ b/src/User/Agent/Lib.hs
@@ -55,7 +55,7 @@ fromPending :: (TestRunState 'PendingT -> a) -> TestRunState v -> a
 fromPending f = \case
     p@(Pending{}) -> f p
     (Rejected pending _) -> f pending
-    (Accepted pending) -> f pending
+    (Accepted pending _) -> f pending
     (Finished accepted _ _ _) -> fromPending f accepted
 
 testRunDuration :: TestRunState v -> Duration

--- a/src/User/Agent/Options.hs
+++ b/src/User/Agent/Options.hs
@@ -19,7 +19,7 @@ import Core.Options
     , tokenIdOption
     , walletOption
     )
-import Core.Types.Basic (Success)
+import Core.Types.Basic (AntithesisId (..), Success)
 import Core.Types.Duration (Duration (..))
 import Core.Types.Tx (WithTxHash)
 import Lib.Box (Box (..))
@@ -300,6 +300,21 @@ acceptTestOptions =
         <*> walletOption
         <*> testRunIdOption "accept"
         <*> pure ()
+        <*> antithesisIdOption
+
+antithesisIdOption :: Parser AntithesisId
+antithesisIdOption =
+    AntithesisId
+        <$> setting
+            [ long "antithesis-id"
+            , metavar "ANTITHESIS_ID"
+            , help
+                "External test run ID assigned by \
+                \Antithesis. Stored on-chain in the \
+                \Running state."
+            , option
+            , reader str
+            ]
 
 testRejectionParser :: Parser TestRunRejection
 testRejectionParser =

--- a/src/User/Agent/Process.hs
+++ b/src/User/Agent/Process.hs
@@ -26,7 +26,8 @@ import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Trans.Except (runExceptT, throwE)
 import Core.Options (tokenIdOption, walletOption)
 import Core.Types.Basic
-    ( Directory (..)
+    ( AntithesisId (..)
+    , Directory (..)
     , GithubUsername (..)
     , Success (..)
     , TokenId
@@ -313,7 +314,11 @@ agentProcess
                                         $ "Pushed test-run "
                                             ++ trId
                                             ++ " to Antithesis."
-                        eres <- liftIO $ submitRunning opts testId
+                        let antithesisId =
+                                AntithesisId $ testRunId testId
+                        eres <-
+                            liftIO
+                                $ submitRunning opts testId antithesisId
                         case eres of
                             ValidationFailure err -> do
                                 loggin
@@ -453,6 +458,7 @@ submitDone
 submitRunning
     :: ProcessOptions
     -> TestRunId
+    -> AntithesisId
     -> IO
         ( AValidationResult
             UpdateTestRunFailure
@@ -460,7 +466,8 @@ submitRunning
         )
 submitRunning
     ProcessOptions{poAuth, poMPFSClient, poWallet, poTokenId}
-    testId =
+    testId
+    antithesisId =
         cmd
             $ AgentCommand poAuth poMPFSClient
             $ Accept
@@ -468,6 +475,7 @@ submitRunning
                 poWallet
                 testId
                 ()
+                antithesisId
 
 downloadAssets
     :: ProcessOptions

--- a/src/User/Types.hs
+++ b/src/User/Types.hs
@@ -32,7 +32,8 @@ import Control.Applicative (Alternative, (<|>))
 import Control.Lens (makeLensesFor)
 import Control.Monad (guard)
 import Core.Types.Basic
-    ( Commit (..)
+    ( AntithesisId (..)
+    , Commit (..)
     , Directory (..)
     , FaultsEnabled (..)
     , GithubRepository (..)
@@ -212,7 +213,10 @@ data TestRunState a where
         -> TestRunState PendingT
     Rejected
         :: TestRunState PendingT -> [TestRunRejection] -> TestRunState DoneT
-    Accepted :: TestRunState PendingT -> TestRunState RunningT
+    Accepted
+        :: TestRunState PendingT
+        -> AntithesisId
+        -> TestRunState RunningT
     Finished
         :: TestRunState RunningT
         -> Duration
@@ -239,10 +243,11 @@ instance Monad m => ToJSON m (TestRunState a) where
             , ("from", toJSON pending)
             , ("reasons", traverse toJSON reasons >>= toJSON)
             ]
-    toJSON (Accepted pending) =
+    toJSON (Accepted pending antithesisId) =
         object
             [ ("phase", stringJSON "accepted")
             , ("from", toJSON pending)
+            , "antithesis_id" .= antithesisId
             ]
     toJSON (Finished running duration outcome url) =
         object
@@ -332,7 +337,12 @@ instance
         case phase of
             "accepted" -> do
                 pending <- getField "from" mapping >>= fromJSON
-                pure $ Accepted pending
+                antithesisId <-
+                    getFieldWithDefault
+                        "antithesis_id"
+                        (AntithesisId "")
+                        mapping
+                pure $ Accepted pending antithesisId
             _ ->
                 expectedButGotValue
                     "an accepted phase"

--- a/test/Oracle/Validate/Requests/TestRun/AcceptSpec.hs
+++ b/test/Oracle/Validate/Requests/TestRun/AcceptSpec.hs
@@ -18,7 +18,8 @@ import MockMPFS (mockMPFS, withFacts, withRequests)
 import Oracle.Types (Request (..), RequestZoo (AcceptRequest))
 import Oracle.Validate.Requests.RegisterUserSpec (genForRole)
 import Oracle.Validate.Requests.TestRun.Lib
-    ( mkEffects
+    ( dummyAntithesisId
+    , mkEffects
     , noValidation
     , signatureGen
     , testConfigFactGen
@@ -65,7 +66,7 @@ spec = do
             testRunFact <- toJSFact testRun pendingState 0
             let validation =
                     mkEffects (withFacts [testRunFact] mockMPFS) noValidation
-                newTestRunState = Accepted pendingState
+                newTestRunState = Accepted pendingState dummyAntithesisId
                 test = validateToRunningCore validation testRun newTestRunState
             pure $ test `shouldReturn` Nothing
         it
@@ -79,7 +80,10 @@ spec = do
                 faultsEnabled <- FaultsEnabled <$> gen arbitrary
                 configFact <- testConfigFactGen anOwner
                 let pendingState = Pending (Hours 5) faultsEnabled (HasInstrumentation True) signature
-                    change = Change (Key testRun) (Update pendingState (Accepted pendingState))
+                    change =
+                        Change
+                            (Key testRun)
+                            (Update pendingState (Accepted pendingState dummyAntithesisId))
                     pendingRequest =
                         AcceptRequest
                             (Request{outputRefId = RequestRefId "", owner = anOwner, change})
@@ -107,7 +111,7 @@ spec = do
                             faultsEnabled
                             (HasInstrumentation True)
                             signature
-                    newTestRunState = Accepted pendingState
+                    newTestRunState = Accepted pendingState dummyAntithesisId
                     test =
                         validateToRunningCore
                             (mkEffects mockMPFS noValidation)
@@ -140,7 +144,7 @@ spec = do
                 testRunFact <- toJSFact testRun fact 0
                 let validation =
                         mkEffects (withFacts [testRunFact] mockMPFS) noValidation
-                    newTestRunState = Accepted request
+                    newTestRunState = Accepted request dummyAntithesisId
                     test = validateToRunningCore validation testRun newTestRunState
                 pure
                     $ counterexample (show (fact, request))

--- a/test/Oracle/Validate/Requests/TestRun/CreateSpec.hs
+++ b/test/Oracle/Validate/Requests/TestRun/CreateSpec.hs
@@ -58,6 +58,7 @@ import Oracle.Validate.Requests.TestRun.Lib
     , changeProject
     , changeRequester
     , changeTry
+    , dummyAntithesisId
     , genDuration
     , gitAsset
     , gitCommit
@@ -462,7 +463,7 @@ spec = do
                         faultsEnabled
                         (HasInstrumentation True)
                         signature
-                accepted = Accepted pending
+                accepted = Accepted pending dummyAntithesisId
             rejections <-
                 gen $ listOf $ elements [BrokenInstructions, UnclearIntent]
             let rejected = Rejected pending rejections

--- a/test/Oracle/Validate/Requests/TestRun/FinishSpec.hs
+++ b/test/Oracle/Validate/Requests/TestRun/FinishSpec.hs
@@ -18,7 +18,8 @@ import MockMPFS (mockMPFS, withFacts, withRequests)
 import Oracle.Types (Request (..), RequestZoo (FinishedRequest))
 import Oracle.Validate.Requests.RegisterUserSpec (genForRole)
 import Oracle.Validate.Requests.TestRun.Lib
-    ( mkEffects
+    ( dummyAntithesisId
+    , mkEffects
     , noValidation
     , signatureGen
     , testConfigFactGen
@@ -68,11 +69,13 @@ spec = do
             faultsEnabled <- FaultsEnabled <$> gen arbitrary
             let acceptedState =
                     Accepted
-                        $ Pending
+                        ( Pending
                             (Hours 5)
                             faultsEnabled
                             (HasInstrumentation True)
                             signature
+                        )
+                        dummyAntithesisId
             testRunFact <- toJSFact testRun acceptedState 0
             let validation =
                     mkEffects
@@ -102,6 +105,7 @@ spec = do
                                 (HasInstrumentation True)
                                 signature
                             )
+                            dummyAntithesisId
                     change =
                         Change
                             { key = Key testRun
@@ -137,7 +141,7 @@ spec = do
                             (FaultsEnabled True)
                             (HasInstrumentation True)
                             signature
-                    newTestRunState = Accepted pendingState
+                    newTestRunState = Accepted pendingState dummyAntithesisId
                     test =
                         validateToRunningCore
                             (mkEffects mockMPFS noValidation)
@@ -160,18 +164,22 @@ spec = do
                 url <- genA
                 let fact =
                         Accepted
-                            $ Pending
+                            ( Pending
                                 (Hours pendingDuration)
                                 faultsEnabled
                                 (HasInstrumentation True)
                                 signature
+                            )
+                            dummyAntithesisId
                     request =
                         Accepted
-                            $ Pending
+                            ( Pending
                                 (Hours differentPendingDuration)
                                 faultsEnabled
                                 (HasInstrumentation True)
                                 differentSignature
+                            )
+                            dummyAntithesisId
                 testRunFact <- toJSFact testRun fact 0
                 let validation =
                         mkEffects

--- a/test/Oracle/Validate/Requests/TestRun/Lib.hs
+++ b/test/Oracle/Validate/Requests/TestRun/Lib.hs
@@ -29,6 +29,7 @@ module Oracle.Validate.Requests.TestRun.Lib
     , gitAsset
     , genDuration
     , testConfigFactGen
+    , dummyAntithesisId
     )
 where
 
@@ -40,7 +41,8 @@ import Control.Lens
     , (^.)
     )
 import Core.Types.Basic
-    ( Commit (..)
+    ( AntithesisId (..)
+    , Commit (..)
     , Directory (..)
     , FileName (..)
     , GithubRepository (..)
@@ -416,3 +418,8 @@ testConfigFactGen :: Owner -> EGen JSFact
 testConfigFactGen owner = do
     testConfig <- testConfigEGen
     toJSFact ConfigKey (mkCurrentConfig owner testConfig) 0
+
+-- | Placeholder 'AntithesisId' for tests. Will be
+-- replaced by the real Antithesis API ID in Phase 2.
+dummyAntithesisId :: AntithesisId
+dummyAntithesisId = AntithesisId ""

--- a/test/User/TypesSpec.hs
+++ b/test/User/TypesSpec.hs
@@ -8,7 +8,8 @@ module User.TypesSpec
 where
 
 import Core.Types.Basic
-    ( Commit (Commit)
+    ( AntithesisId (..)
+    , Commit (Commit)
     , Directory (Directory)
     , FaultsEnabled (..)
     , GithubRepository (GithubRepository, organization, project)
@@ -91,7 +92,7 @@ spec = do
                                     pending
                                     rejections
                         roundTrip rejected
-                        let accepted = Accepted pending
+                        let accepted = Accepted pending (AntithesisId "test-id")
                         roundTrip accepted
                         let finished =
                                 Finished


### PR DESCRIPTION
Closes #78

Phase 1 — prepare the on-chain data model for the Antithesis API.

- Add `AntithesisId` newtype to `Core.Types.Basic`
- Extend `Accepted` constructor with an `AntithesisId` field
- Populate with content-hash ID for now (`mkTestRunId`)
- Add `--antithesis-id` CLI option to `moog-agent accept`
- Backward compatible: `FromJSON` uses `getFieldWithDefault` for existing on-chain facts
- All 126 unit tests pass

When the Antithesis API is available, the only change needed is swapping the ID source from our hash to their POST response.