### PR TITLE
feat: versioned wire format for on-chain facts

### DIFF
--- a/docs/design/versioned-wire-format.md
+++ b/docs/design/versioned-wire-format.md
@@ -43,28 +43,36 @@ Types that are unaffected (no format changes):
 - `()` — trivial value for registrations/whitelist
 - `TestRun` — key type, no Duration fields
 
-### Implementation approach
+### Implementation
 
-A `Versioned` wrapper type that handles the dispatch:
+Three helpers in `Core.Types.WireVersion`:
 
 ```haskell
--- The version tag
-newtype WireVersion = WireVersion Int
-
--- Typeclass for versioned on-chain types
-class VersionedJSON a where
-    currentWireVersion :: WireVersion
-    encodeVersioned :: a -> JSValue  -- always current version
-    decodeVersioned :: WireVersion -> JSValue -> Maybe a
-
--- ToJSON writes current version + payload
--- FromJSON reads "v" field, dispatches to decodeVersioned
+currentWireVersion :: Int54        -- 1
+readWireVersion    :: Map String JSValue -> m Int54
+wireVersionField   :: (String, m JSValue)
 ```
 
-The `FromJSON Duration` becomes symmetric (object format only).
-The v0 migration logic moves into `decodeVersioned` for `TestRunState`
-and `Config`, where it converts `JSNum` durations to `Duration` values
-before constructing the Haskell type.
+- `wireVersionField` is added to every `ToJSON` object.
+- `readWireVersion` is called in `FromJSON` to get the version
+  (defaults to `0` when absent).
+
+Version dispatch is inline in each `FromJSON` instance — no
+typeclass needed. The only version-dependent logic is which
+duration decoder to use:
+
+```haskell
+durationForVersion :: Int54 -> JSValue -> m Duration
+durationForVersion 0 = durationFromV0  -- plain JSNum
+durationForVersion _ = fromJSON        -- {"hours":n}
+```
+
+`Duration`'s `FromJSON` is now symmetric (object format only).
+`durationFromV0` handles the legacy `JSNum` format and is called
+by the v0 branches of `TestRunState` and `Config` decoders.
+
+`Config` v0 also uses `testRunValidationConfigFromV0` to parse
+nested `TestRunValidationConfig` with plain-number durations.
 
 ### What does NOT change
 
@@ -74,10 +82,17 @@ before constructing the Haskell type.
 - The `ProtocolVersion` in `Config` — separate concern (client/oracle
   handshake), orthogonal to wire format versioning
 
-### Migration path
+### Modules changed
 
-1. Add `"v"` field support to `TestRunState` and `Config` codecs
-2. Make `Duration` codecs symmetric (object format only)
-3. Move the `directHours` fallback into versioned decoders for v0
-4. Existing golden tests continue passing (old data parses as v0)
-5. New round-trip tests verify symmetry at each version
+| Module | Change |
+|--------|--------|
+| `Core.Types.WireVersion` | New — version helpers |
+| `Core.Types.Duration` | Symmetric `FromJSON`, new `durationFromV0` |
+| `User.Types` | `ToJSON`/`FromJSON` for `TestRunState` write/read `"v"` |
+| `Oracle.Config.Types` | `ToJSON`/`FromJSON` for `Config` write/read `"v"` |
+| `Oracle.Validate.Requests.TestRun.Config` | New `testRunValidationConfigFromV0` |
+
+### Test coverage
+
+- Existing golden tests (v0 on-chain data) continue passing
+- Existing round-trip tests verify v1 symmetry

--- a/docs/design/versioned-wire-format.md
+++ b/docs/design/versioned-wire-format.md
@@ -1,0 +1,83 @@
+# Versioned Wire Format for On-Chain Fact Types
+
+## Problem
+
+On-chain facts are immutable. When a type's serialization changes, the
+system must read old facts forever. Currently this is handled by
+asymmetric `FromJSON` instances that accept multiple formats but only
+write the latest. This hides migration logic inside typeclass instances
+and causes silent format rewriting during round-trips (e.g. when the
+agent transitions a test-run state).
+
+## Design
+
+### Version tag on fact values
+
+Every on-chain fact value carries a `"v"` field:
+
+```json
+{"v": 0, "phase": "pending", "duration": 3, ...}
+{"v": 1, "phase": "pending", "duration": {"hours": 3}, ...}
+```
+
+- `ToJSON` always writes the **current** version.
+- `FromJSON` reads the `"v"` field (defaulting to `0` if absent, for
+  backwards compatibility with existing facts) and dispatches to the
+  appropriate versioned decoder.
+- Each version's decoder is **symmetric** — it knows exactly one format.
+
+### Affected types
+
+Fact values that go on-chain and have had (or may have) format changes:
+
+| Type | Current version | v0 format |
+|------|----------------|-----------|
+| `TestRunState PendingT` | 1 | duration as `Int54` |
+| `TestRunState RunningT` | 1 | wraps v0 PendingT |
+| `TestRunState DoneT` | 1 | wraps v0 PendingT, duration as `Int54` |
+| `Config` (via `TestRunValidationConfig`) | 1 | durations as `Int54`, no `protocolVersion` |
+
+Types that are unaffected (no format changes):
+
+- `RegisterUserKey` / `RegisterRoleKey` / `WhiteListKey` — key types
+- `()` — trivial value for registrations/whitelist
+- `TestRun` — key type, no Duration fields
+
+### Implementation approach
+
+A `Versioned` wrapper type that handles the dispatch:
+
+```haskell
+-- The version tag
+newtype WireVersion = WireVersion Int
+
+-- Typeclass for versioned on-chain types
+class VersionedJSON a where
+    currentWireVersion :: WireVersion
+    encodeVersioned :: a -> JSValue  -- always current version
+    decodeVersioned :: WireVersion -> JSValue -> Maybe a
+
+-- ToJSON writes current version + payload
+-- FromJSON reads "v" field, dispatches to decodeVersioned
+```
+
+The `FromJSON Duration` becomes symmetric (object format only).
+The v0 migration logic moves into `decodeVersioned` for `TestRunState`
+and `Config`, where it converts `JSNum` durations to `Duration` values
+before constructing the Haskell type.
+
+### What does NOT change
+
+- Key types (`TestRun`, `ConfigKey`, etc.) — no versioning needed
+- The fact envelope (`Fact k v`) — unchanged
+- `parseFacts` — still uses `FromJSON`, which now dispatches via version
+- The `ProtocolVersion` in `Config` — separate concern (client/oracle
+  handshake), orthogonal to wire format versioning
+
+### Migration path
+
+1. Add `"v"` field support to `TestRunState` and `Config` codecs
+2. Make `Duration` codecs symmetric (object format only)
+3. Move the `directHours` fallback into versioned decoders for v0
+4. Existing golden tests continue passing (old data parses as v0)
+5. New round-trip tests verify symmetry at each version

--- a/moog.cabal
+++ b/moog.cabal
@@ -99,6 +99,7 @@ library
     Core.Types.Change
     Core.Types.Duration
     Core.Types.Fact
+    Core.Types.WireVersion
     Core.Types.Mnemonics
     Core.Types.Mnemonics.Options
     Core.Types.MPFS

--- a/src/Core/Types/Duration.hs
+++ b/src/Core/Types/Duration.hs
@@ -3,6 +3,7 @@ module Core.Types.Duration
     , durationToTimeDiff
     , negateDuration
     , durationToNominalDiffTime
+    , durationFromV0
     )
 where
 
@@ -52,16 +53,33 @@ instance Monad m => ToJSON m Duration where
     toJSON (Hours h) = object [("hours", intJSON h)]
     toJSON (Minutes m) = object [("minutes", intJSON m)]
 
-instance (Alternative m, ReportSchemaErrors m) => FromJSON m Duration where
-    fromJSON v = directHours v <|> specific v
+-- | Symmetric decoder: only accepts the object format
+-- @{"hours": n}@ or @{"minutes": n}@.
+instance
+    (Alternative m, ReportSchemaErrors m)
+    => FromJSON m Duration
+    where
+    fromJSON obj = do
+        mapping <- fromJSON obj
+        hours mapping <|> minutes mapping
       where
-        directHours (JSNum n) = pure $ Hours (fromIntegral n)
-        directHours w = expectedButGotValue "Duration as number of hours" w
-        specific obj = do
-            mapping <- fromJSON obj
-            hours mapping <|> minutes mapping
-        hours mapping = Hours <$> getIntegralField "hours" mapping
-        minutes mapping = Minutes <$> getIntegralField "minutes" mapping
+        hours mapping =
+            Hours <$> getIntegralField "hours" mapping
+        minutes mapping =
+            Minutes
+                <$> getIntegralField "minutes" mapping
+
+-- | Parse a v0 wire format duration (plain number of
+-- hours). Used by versioned decoders to handle old
+-- on-chain facts.
+durationFromV0
+    :: ReportSchemaErrors m => JSValue -> m Duration
+durationFromV0 (JSNum n) =
+    pure $ Hours (fromIntegral n)
+durationFromV0 w =
+    expectedButGotValue
+        "Duration as number of hours (v0)"
+        w
 
 durationToTimeDiff :: Duration -> TimeDiff
 durationToTimeDiff (Hours h) = noTimeDiff{tdHour = h}

--- a/src/Core/Types/WireVersion.hs
+++ b/src/Core/Types/WireVersion.hs
@@ -1,0 +1,36 @@
+module Core.Types.WireVersion
+    ( currentWireVersion
+    , readWireVersion
+    , wireVersionField
+    )
+where
+
+import Data.Map.Strict (Map)
+import Lib.JSON.Canonical.Extra
+    ( getFieldWithDefault
+    , intJSON
+    )
+import Text.JSON.Canonical
+    ( Int54
+    , JSValue
+    , ReportSchemaErrors
+    )
+
+-- | Current wire format version for on-chain fact
+-- values.
+currentWireVersion :: Int54
+currentWireVersion = 1
+
+-- | Read the wire version from a JSON object mapping,
+-- defaulting to 0 for backwards compatibility with
+-- pre-versioned facts.
+readWireVersion
+    :: ReportSchemaErrors m
+    => Map String JSValue
+    -> m Int54
+readWireVersion = getFieldWithDefault "v" 0
+
+-- | Key-value pair for including the current version
+-- in a JSON object.
+wireVersionField :: Monad m => (String, m JSValue)
+wireVersionField = ("v", intJSON currentWireVersion)

--- a/src/Oracle/Config/Types.hs
+++ b/src/Oracle/Config/Types.hs
@@ -14,8 +14,13 @@ import Control.Applicative (Alternative, (<|>))
 import Core.Types.Basic (Owner)
 import Core.Types.Change (Change)
 import Core.Types.Operation (Op (OpI, OpU))
+import Core.Types.WireVersion
+    ( readWireVersion
+    , wireVersionField
+    )
 import Lib.JSON.Canonical.Extra
-    ( intJSON
+    ( getField
+    , intJSON
     , object
     , stringJSON
     , withObject
@@ -24,6 +29,7 @@ import Lib.JSON.Canonical.Extra
     )
 import Oracle.Validate.Requests.TestRun.Config
     ( TestRunValidationConfig
+    , testRunValidationConfigFromV0
     )
 import Text.JSON.Canonical
     ( FromJSON (..)
@@ -81,19 +87,34 @@ instance ReportSchemaErrors m => FromJSON m ConfigKey where
 instance Monad m => ToJSON m Config where
     toJSON (Config agent testRun protocolVersion) =
         object
-            [ "agent" .= agent
+            [ wireVersionField
+            , "agent" .= agent
             , "testRun" .= testRun
             , "protocolVersion" .= protocolVersion
             ]
 
 instance (Alternative m, ReportSchemaErrors m) => FromJSON m Config where
     fromJSON = withObject "Config" $ \o -> do
-        Config
-            <$> o .: "agent"
-            <*> o .: "testRun"
-            <*> ( (o .: "protocolVersion" >>= fromJSON)
-                    <|> pure (ProtocolVersion 0)
-                )
+        version <- readWireVersion o
+        case version of
+            0 -> do
+                agent <- o .: "agent"
+                testRunV <- getField "testRun" o
+                testRun <-
+                    testRunValidationConfigFromV0
+                        testRunV
+                pure
+                    $ Config
+                        agent
+                        testRun
+                        (ProtocolVersion 0)
+            _ ->
+                Config
+                    <$> o .: "agent"
+                    <*> o .: "testRun"
+                    <*> ( (o .: "protocolVersion" >>= fromJSON)
+                            <|> pure (ProtocolVersion 0)
+                        )
 
 type SetConfigChange = Change ConfigKey (OpI Config)
 type UpdateConfigChange = Change ConfigKey (OpU Config Config)

--- a/src/Oracle/Validate/Requests/TestRun/Config.hs
+++ b/src/Oracle/Validate/Requests/TestRun/Config.hs
@@ -2,14 +2,21 @@
 
 module Oracle.Validate.Requests.TestRun.Config
     ( TestRunValidationConfig (..)
+    , testRunValidationConfigFromV0
     ) where
 
 import Control.Applicative (Alternative)
-import Core.Types.Duration (Duration)
+import Core.Types.Duration (Duration, durationFromV0)
 import GHC.Generics (Generic)
 import Lib.JSON.Canonical.Extra
+    ( getField
+    , object
+    , withObject
+    , (.=)
+    )
 import Text.JSON.Canonical
     ( FromJSON (..)
+    , JSValue
     , ReportSchemaErrors
     , ToJSON (..)
     )
@@ -33,5 +40,21 @@ instance
     where
     fromJSON = withObject "TestRunValidationConfig" $ \o ->
         TestRunValidationConfig
-            <$> (o .: "maxDuration" >>= fromJSON)
-            <*> (o .: "minDuration" >>= fromJSON)
+            <$> (getField "maxDuration" o >>= fromJSON)
+            <*> (getField "minDuration" o >>= fromJSON)
+
+-- | Parse a v0 wire format 'TestRunValidationConfig'
+-- where durations are plain numbers of hours.
+testRunValidationConfigFromV0
+    :: ReportSchemaErrors m
+    => JSValue
+    -> m TestRunValidationConfig
+testRunValidationConfigFromV0 =
+    withObject "TestRunValidationConfig" $ \o ->
+        TestRunValidationConfig
+            <$> ( getField "maxDuration" o
+                    >>= durationFromV0
+                )
+            <*> ( getField "minDuration" o
+                    >>= durationFromV0
+                )

--- a/src/User/Types.hs
+++ b/src/User/Types.hs
@@ -41,7 +41,11 @@ import Core.Types.Basic
     , Platform (..)
     , Try (..)
     )
-import Core.Types.Duration (Duration (..))
+import Core.Types.Duration (Duration (..), durationFromV0)
+import Core.Types.WireVersion
+    ( readWireVersion
+    , wireVersionField
+    )
 import Core.Types.VKey (decodeVKey)
 import Crypto.Error (CryptoFailable (..))
 import Crypto.PubKey.Ed25519 qualified as Ed25519
@@ -73,6 +77,7 @@ import Lib.SSH.Public
     )
 import Text.JSON.Canonical
     ( FromJSON (..)
+    , Int54
     , JSValue (..)
     , ReportSchemaErrors
     , ToJSON (..)
@@ -203,6 +208,17 @@ instance (ReportSchemaErrors m) => FromJSON m TestRunRejection where
 newtype URL = URL String
     deriving (Show, Eq)
 
+-- | Select the appropriate duration decoder based on
+-- the wire version: v0 uses plain numbers, v1+ uses
+-- the standard object format.
+durationForVersion
+    :: (Alternative m, ReportSchemaErrors m)
+    => Int54
+    -> JSValue
+    -> m Duration
+durationForVersion 0 = durationFromV0
+durationForVersion _ = fromJSON
+
 data TestRunState a where
     Pending
         :: Duration
@@ -227,7 +243,8 @@ deriving instance Show (TestRunState a)
 instance Monad m => ToJSON m (TestRunState a) where
     toJSON (Pending d faultsEnabled hasInstrumentation signature) =
         object
-            [ ("phase", stringJSON "pending")
+            [ wireVersionField
+            , ("phase", stringJSON "pending")
             , ("duration", toJSON d)
             , ("signature", byteStringToJSON $ BA.convert signature)
             , "faults_enabled" .= faultsEnabled
@@ -235,18 +252,21 @@ instance Monad m => ToJSON m (TestRunState a) where
             ]
     toJSON (Rejected pending reasons) =
         object
-            [ ("phase", stringJSON "rejected")
+            [ wireVersionField
+            , ("phase", stringJSON "rejected")
             , ("from", toJSON pending)
             , ("reasons", traverse toJSON reasons >>= toJSON)
             ]
     toJSON (Accepted pending) =
         object
-            [ ("phase", stringJSON "accepted")
+            [ wireVersionField
+            , ("phase", stringJSON "accepted")
             , ("from", toJSON pending)
             ]
     toJSON (Finished running duration outcome url) =
         object
-            [ ("phase", stringJSON "finished")
+            [ wireVersionField
+            , ("phase", stringJSON "finished")
             , ("from", toJSON running)
             , ("duration", toJSON duration)
             , ("url", stringJSON $ case url of URL u -> u)
@@ -259,10 +279,13 @@ instance
     where
     fromJSON obj@(JSObject _) = do
         mapping <- fromJSON obj
+        version <- readWireVersion mapping
         phase <- getStringField "phase" mapping
         case phase of
             "pending" -> do
-                duration <- getField "duration" mapping >>= fromJSON
+                duration <-
+                    getField "duration" mapping
+                        >>= durationForVersion version
                 signatureJSValue <- getField "signature" mapping
                 signatureByteString <- byteStringFromJSON signatureJSValue
                 faultsEnabled <-
@@ -299,6 +322,7 @@ instance
     where
     fromJSON obj@(JSObject _) = do
         mapping <- fromJSON obj
+        version <- readWireVersion mapping
         phase <- getStringField "phase" mapping
         case phase of
             "rejected" -> do
@@ -308,8 +332,9 @@ instance
                 pure $ Rejected pending reasonList
             "finished" -> do
                 running <- getField "from" mapping >>= fromJSON
-                duration <- do
-                    getField "duration" mapping >>= fromJSON
+                duration <-
+                    getField "duration" mapping
+                        >>= durationForVersion version
                 url <- getStringField "url" mapping
                 outcome <- getFieldWithDefault "outcome" OutcomeUnknown mapping
                 pure $ Finished running duration outcome (URL url)


### PR DESCRIPTION
## Summary

- Add explicit `"v"` field to on-chain JSON values (TestRunState, Config)
- Make Duration FromJSON symmetric (object format only), move v0 plain-number parsing to `durationFromV0`
- Version dispatch: v0 (no `"v"` or `"v": 0`) uses legacy decoders, v1+ uses standard symmetric codecs

Closes #80