### PR TITLE
Fix missed Antithesis result email recovery

### DIFF
--- a/src/User/Agent/Options.hs
+++ b/src/User/Agent/Options.hs
@@ -132,10 +132,10 @@ minutesOption =
         <$> setting
             [ long "minutes"
             , help
-                "Number of minutes in the past to check for test results (default: 7)"
+                "Number of minutes in the past to check for test results (default: 1440)"
             , metavar "MINUTES"
             , reader auto
-            , value 10
+            , value 1440
             , option
             ]
 

--- a/src/User/Agent/Process.hs
+++ b/src/User/Agent/Process.hs
@@ -37,6 +37,7 @@ import Core.Types.MPFS (MPFSClient (..), mpfsClientOption)
 import Core.Types.Tx (WithTxHash)
 import Core.Types.Wallet (Wallet)
 import Data.CaseInsensitive (mk)
+import Data.Either (partitionEithers)
 import Data.Foldable (find, for_)
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.String.QQ (s)
@@ -82,8 +83,10 @@ import User.Agent.Options
     )
 import User.Agent.PublishResults.Email
     ( EmailPassword
+    , EmailReadSummary (..)
     , EmailUser
     , Result (..)
+    , readEmailsWithSummary
     )
 import User.Agent.PushTest
     ( AntithesisAuth
@@ -144,6 +147,11 @@ data ProcessOptions = ProcessOptions
     , poRegistry :: Registry
     , poAntithesisAuth :: AntithesisAuth
     , poVerbose :: Bool
+    }
+
+data EmailPoll = EmailPoll
+    { emailPollResults :: [Result]
+    , emailPollSummary :: EmailReadSummary
     }
 
 processOptionsParser :: Parser ProcessOptions
@@ -220,9 +228,12 @@ agentProcess
         } = do
         putStrLn "Starting agent process service..."
         forever $ runExceptT $ do
-            results <- liftIO $ pollEmails opts
-            loggin
-                $ "Found " ++ show (length results) ++ " email results."
+            EmailPoll
+                { emailPollResults = results
+                , emailPollSummary
+                } <-
+                liftIO $ pollEmails opts
+            loggin $ emailPollSummaryMessage emailPollSummary
             efacts <- liftIO $ pollTestRuns opts
             (pendingTests, runningTests, doneTests, stateChanging) <- case efacts of
                 ValidationFailure err -> do
@@ -359,28 +370,46 @@ agentProcess
 loggin :: MonadIO m => String -> m ()
 loggin = liftIO . putStrLn
 
-pollEmails :: ProcessOptions -> IO [Result]
+emailPollSummaryMessage :: EmailReadSummary -> String
+emailPollSummaryMessage
+    EmailReadSummary
+        { emailCandidateCount
+        , emailWithinWindowCount
+        , emailParsedCount
+        , emailRejectedCount
+        , emailDroppedByWindowCount
+        } =
+        "Found "
+            ++ show emailParsedCount
+            ++ " email results from "
+            ++ show emailCandidateCount
+            ++ " Antithesis candidate emails ("
+            ++ show emailWithinWindowCount
+            ++ " inside recovery window, "
+            ++ show emailRejectedCount
+            ++ " parse failures, "
+            ++ show emailDroppedByWindowCount
+            ++ " outside recovery window)."
+
+pollEmails :: ProcessOptions -> IO EmailPoll
 pollEmails
     ProcessOptions
-        { poMPFSClient
-        , poAuth
-        , poAntithesisEmail
+        { poAntithesisEmail
         , poAntithesisEmailPassword
         , poMinutes
         } = do
         eresults <-
-            cmd
-                $ AgentCommand
-                    poAuth
-                    poMPFSClient
-                $ CheckAllResults
+            runExceptT
+                $ readEmailsWithSummary
                     poAntithesisEmail
                     poAntithesisEmailPassword
                     poMinutes
 
         case eresults of
-            ValidationFailure err -> error $ "Failed to get email results: " ++ show err
-            ValidationSuccess results -> pure results
+            Left err -> error $ "Failed to get email results: " ++ show err
+            Right (resultsOrErrors, emailPollSummary) -> do
+                let (_, emailPollResults) = partitionEithers resultsOrErrors
+                pure EmailPoll{emailPollResults, emailPollSummary}
 
 pollTestRuns
     :: ProcessOptions

--- a/src/User/Agent/PublishResults/Email.hs
+++ b/src/User/Agent/PublishResults/Email.hs
@@ -3,10 +3,12 @@ This is a module to check emails for test results.
 -}
 module User.Agent.PublishResults.Email
     ( readEmails
+    , readEmailsWithSummary
     , readEmail
     , printEmails
     , clockTimeToUTCTime
     , utcTimeToClockTime
+    , EmailReadSummary (..)
     , Result (..)
     , Parameters (..)
     , EmailException (..)
@@ -37,6 +39,7 @@ import Core.Types.Duration
     )
 import Data.ByteString qualified as B
 import Data.ByteString.Lazy qualified as BL
+import Data.Either (partitionEithers)
 import Data.IMF
     ( Message
     , body
@@ -183,6 +186,57 @@ data Parameters
     }
     deriving (Show, Eq)
 
+data EmailReadSummary = EmailReadSummary
+    { emailCandidateCount :: Int
+    , emailWithinWindowCount :: Int
+    , emailParsedCount :: Int
+    , emailRejectedCount :: Int
+    , emailDroppedByWindowCount :: Int
+    }
+    deriving (Show, Eq)
+
+emptyEmailReadSummary :: EmailReadSummary
+emptyEmailReadSummary =
+    EmailReadSummary
+        { emailCandidateCount = 0
+        , emailWithinWindowCount = 0
+        , emailParsedCount = 0
+        , emailRejectedCount = 0
+        , emailDroppedByWindowCount = 0
+        }
+
+appendEmailReadSummary
+    :: EmailReadSummary -> EmailReadSummary -> EmailReadSummary
+appendEmailReadSummary a b =
+    EmailReadSummary
+        { emailCandidateCount =
+            emailCandidateCount a + emailCandidateCount b
+        , emailWithinWindowCount =
+            emailWithinWindowCount a + emailWithinWindowCount b
+        , emailParsedCount = emailParsedCount a + emailParsedCount b
+        , emailRejectedCount =
+            emailRejectedCount a + emailRejectedCount b
+        , emailDroppedByWindowCount =
+            emailDroppedByWindowCount a + emailDroppedByWindowCount b
+        }
+
+summarizeEmails
+    :: Int
+    -> [Either ParsingError Result]
+    -> [Either ParsingError Result]
+    -> EmailReadSummary
+summarizeEmails candidates sorted kept =
+    let
+        (rejected, parsed) = partitionEithers kept
+    in
+        EmailReadSummary
+            { emailCandidateCount = candidates
+            , emailWithinWindowCount = length kept
+            , emailParsedCount = length parsed
+            , emailRejectedCount = length rejected
+            , emailDroppedByWindowCount = length sorted - length kept
+            }
+
 parameters :: Parameters
 parameters =
     Parameters
@@ -207,10 +261,24 @@ readEmails
         (Of (Either ParsingError Result))
         (ExceptT EmailException IO)
         ()
-readEmails (EmailUser username) (EmailPassword password) past = do
-    conn <- lift $ tryX ConnectionFailed $ connectIMAPSSL "imap.gmail.com"
-    _ <- lift $ tryX LoginFailed $ login conn username password
-    _ <- lift $ tryX SelectFailed $ select conn allMail
+readEmails emailUser emailPassword past = do
+    (results, _) <-
+        lift $ readEmailsWithSummary emailUser emailPassword past
+    each results
+
+readEmailsWithSummary
+    :: EmailUser
+    -> EmailPassword
+    -> Duration
+    -- ^ limit to emails since this time
+    -> ExceptT
+        EmailException
+        IO
+        ([Either ParsingError Result], EmailReadSummary)
+readEmailsWithSummary (EmailUser username) (EmailPassword password) past = do
+    conn <- tryX ConnectionFailed $ connectIMAPSSL "imap.gmail.com"
+    _ <- tryX LoginFailed $ login conn username password
+    _ <- tryX SelectFailed $ select conn allMail
     now <- liftIO getCurrentTime
     let limit =
             addUTCTime
@@ -219,23 +287,33 @@ readEmails (EmailUser username) (EmailPassword password) past = do
     let clockLimit = utcTimeToClockTime limit
     tz <- liftIO getCurrentTimeZone -- wrong, should be the email server's timezone
     let localTimeLimit = utcToLocalTime tz limit
-    let go from
-            | from < clockLimit = pure ()
+    let go from summary found
+            | from < clockLimit = pure (found, summary)
             | otherwise = do
                 (timeSearch, to) <- liftIO $ nextSlot from (paramDuration parameters)
                 uids <-
-                    lift
-                        $ tryX SearchFailed
+                    tryX SearchFailed
                         $ search conn
                         $ antithesisMail : timeSearch
                 results <- forM uids $ \uid -> do
-                    content <- lift $ tryX FetchFailed $ fetch conn uid
+                    content <- tryX FetchFailed $ fetch conn uid
                     if B.null content
                         then pure Nothing
                         else pure $ Just $ readEmail content
-                each $ keepInLimit localTimeLimit $ sortResults $ catMaybes results
-                go to
-    liftIO getClockTime >>= go . addToClockTime noTimeDiff{tdDay = 1}
+                let sorted = sortResults $ catMaybes results
+                    kept = keepInLimit localTimeLimit sorted
+                    summary' =
+                        summary
+                            `appendEmailReadSummary` summarizeEmails
+                                (length uids)
+                                sorted
+                                kept
+                go to summary' (found <> kept)
+    from <- liftIO getClockTime
+    go
+        (addToClockTime noTimeDiff{tdDay = 1} from)
+        emptyEmailReadSummary
+        []
 
 nextSlot :: ClockTime -> Duration -> IO ([SearchQuery], ClockTime)
 nextSlot now duration = do

--- a/test/User/Agent/PublishResults/EmailSpec.hs
+++ b/test/User/Agent/PublishResults/EmailSpec.hs
@@ -136,6 +136,37 @@ spec = do
                                     [s|https://cardano.antithesis.com/report/nDSj3YOUtIvcco1HRmK7iz2w/YudEq2ITbl0xxDqYNgdrT2gHUMtQDXYkNtDMyRwT61A.html?auth=v2.public.eyJuYmYiOiIyMDI1LTA5LTEzVDExOjAyOjM2LjIwNzY1ODk2NFoiLCJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0IjoiWXVkRXEySVRibDB4eERxWU5nZHJUMmdIVU10UURYWWtOdERNeVJ3VDYxQS5odG1sIiwicmVwb3J0X2lkIjoibkRTajNZT1V0SXZjY28xSFJtSzdpejJ3In19fUQUQv8zIXJj1FqNehObRCWcj22nLkUqxHJCTuO5FN4TK_xN4P9o8luQnFgbwPKH1eAmwrFtC7qMUzlp3kqpoQI|]
                             , outcome = OutcomeFailure
                             }
+        it "parses no-findings result email from overtime run"
+            $ case readEmail noFindingsOvertimeRun of
+                Left err -> expectationFailure $ "should parse: " <> show err
+                Right r ->
+                    r
+                        `shouldBe` Result
+                            { description =
+                                TestRun
+                                    { commitId = Commit "fcda6bcf1859a15a83a39ec837b9fef1db58f9d1"
+                                    , directory = Directory "testnets/cardano_node_master"
+                                    , platform = Platform "github"
+                                    , repository =
+                                        GithubRepository
+                                            { organization =
+                                                "cardano-foundation"
+                                            , project =
+                                                "cardano-node-antithesis"
+                                            }
+                                    , requester = GithubUsername "cfhal"
+                                    , tryIndex = 1
+                                    }
+                            , date =
+                                fromJust
+                                    $ parseTimeM
+                                        True
+                                        defaultTimeLocale
+                                        "%Y-%m-%d %H:%M:%S"
+                                        "2026-04-28 23:00:07"
+                            , link = incidentLink
+                            , outcome = OutcomeSuccess
+                            }
 
         describe "parses test outcomes" $ do
             let shouldHaveOutcome :: B.ByteString -> Outcome -> Expectation
@@ -152,6 +183,8 @@ spec = do
                 $ outcomeSuccess `shouldHaveOutcome` OutcomeSuccess
             it "outcomeSuccess2"
                 $ outcomeSuccess `shouldHaveOutcome` OutcomeSuccess
+            it "noFindingsOvertimeRun"
+                $ noFindingsOvertimeRun `shouldHaveOutcome` OutcomeSuccess
             it "outcomeErrorReport"
                 $ outcomeErrorReport `shouldHaveOutcome` OutcomeFailure
 
@@ -172,6 +205,10 @@ expectedLink =
 https://cardano.antithesis.com/report/zMNsYjs1lOgRg0IijZGTB1GN/mcuSRCDOzItEqm33oW5hyJHB-GLiVUEItcy_QHALwNg.html?auth=v2.public.eyJuYmYiOiIyMDI1LTA5LTA1VDE2OjI3OjAwLjE3OTczNTk5OFoiLCJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0IjoibWN1U1JDRE96SXRFcW0zM29XNWh5SkhCLUdMaVZVRUl0Y3lfUUhBTHdOZy5odG1sIiwicmVwb3J0X2lkIjoiek1Oc1lqczFsT2dSZzBJaWpaR1RCMUdOIn19fXphuf6Ej7hBlNswCpx1nhpDqVndh8T9e-0_huYlJKnckuN9bTSlL8YrbjwBx6J5NrW50gs2EQClq15Ze2J7qQQ
 |]
 
+incidentLink :: Text
+incidentLink =
+    "https://cardano.antithesis.com/report/overtime/success.html?auth=redacted"
+
 goldenEmail :: B.ByteString
 goldenEmail =
     [s|
@@ -187,6 +224,19 @@ Date: Fri, 5 Sep 2025 17:27:03 +0000
 
     <a href="https://cardano.antithesis.com/report/zMNsYjs1lOgRg0IijZGTB1GN/mcuSRCDOzItEqm33oW5hyJHB-GLiVUEItcy_QHALwNg.html?auth=v2.public.eyJuYmYiOiIyMDI1LTA5LTA1VDE2OjI3OjAwLjE3OTczNTk5OFoiLCJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0IjoibWN1U1JDRE96SXRFcW0zM29XNWh5SkhCLUdMaVZVRUl0Y3lfUUhBTHdOZy5odG1sIiwicmVwb3J0X2lkIjoiek1Oc1lqczFsT2dSZzBJaWpaR1RCMUdOIn19fXphuf6Ej7hBlNswCpx1nhpDqVndh8T9e-0_huYlJKnckuN9bTSlL8YrbjwBx6J5NrW50gs2EQClq15Ze2J7qQQ#/run/156ddbac4c6eede1268ca1995cb18c4a-37-4/findings/2f95173b159955ee457c5f52cbb711791c742ef1,961d3c463f5ef7640df4b3f30c6d7d9d2759b9c7">Look into 2 ongoing findings.</a>
 
+|]
+
+noFindingsOvertimeRun :: B.ByteString
+noFindingsOvertimeRun =
+    [s|
+From: "'Antithesis Reports' via list_antithesis_external" <antithesis@cardanofoundation.org>
+Subject: 2026-04-28 Cardano Foundation Test
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+Date: Tue, 28 Apr 2026 23:00:07 +0000
+
+Run by cardano on 2026-04-28 19:44 UTC<br> Description: {"testRun":{"commitId":"fcda6bcf1859a15a83a39ec837b9fef1db58f9d1","directory":"testnets/cardano_node_master","platform":"github","repository":{"organization":"cardano-foundation","repo":"cardano-node-antithesis"},"requester":"cfhal","try":1,"type":"test-run"},"testRunId":"51daa32a454ac4df6b3729e0b505ae7dbea449437a1466c432ae4e6744e5eb90"}<br><span style="font-size:larger;font-weight:bold"><a href="https://cardano.antithesis.com/report/overtime/success.html?auth=redacted">View report - overtime-run</a></span><br><h3>No findings introduced this run.<br>0 ongoing issues.</h3>
 |]
 
 noDate :: B.ByteString


### PR DESCRIPTION
Closes #88

## Summary
- increase the agent email recovery default from 10 minutes to 24 hours
- add safe mailbox poll counters so logs show candidates, parsed results, rejected emails, and window drops without printing signed report URLs
- add a regression fixture for the no-findings overtime Antithesis result email

## Validation
- /nix/store/m3sg3z5600mjw39mrrmslbhs85abssnc-fourmolu-exe-fourmolu-0.18.0.0/bin/fourmolu -m check src/User/Agent/Options.hs src/User/Agent/PublishResults/Email.hs src/User/Agent/Process.hs test/User/Agent/PublishResults/EmailSpec.hs
- git diff --check origin/main..HEAD
- nix build .#unit-tests
- result/bin/unit-tests --match "User.Agent.PublishResults.Email" (14 examples, 0 failures)
- result/bin/unit-tests (128 examples, 0 failures)

## CI note
- Integration and E2E failures seen on the previous run were GitHub API 401 Bad credentials from MOOG_GITHUB_PAT while reading public fixture repositories, not the email recovery code path.