### PR TITLE
Spike Darwin Homebrew packaging action

### DIFF
--- a/.github/workflows/tarballs.yaml
+++ b/.github/workflows/tarballs.yaml
@@ -110,10 +110,6 @@ jobs:
             trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
             substituters = https://cache.iog.io https://cache.nixos.org/
             accept-flake-config = true
-      - uses: cachix/cachix-action@v15
-        with:
-          name: paolino
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Build and smoke test Homebrew artifacts
         uses: paolino/dev-assets/darwin-homebrew-release@spike/darwin-homebrew-action
         with:
@@ -126,15 +122,17 @@ jobs:
           release-artifact-name: darwin-release-bundle
           dev-artifact-name: darwin-dev-homebrew-artifacts
           tarball-pattern: moog-*-aarch64-darwin.tar.gz
-          installed-commands: moog moog-oracle
+          installed-commands: moog moog-oracle moog-agent
           cleanup-formulae: moog moog-dev
           tap-name: cardano-foundation/moog
           tap-repository: cardano-foundation/moog
           tarball-smoke-script: |
             moog --help
             moog-oracle --help
+            moog-agent --help
           brew-smoke-script: |
             moog --help
             moog-oracle --help
+            moog-agent --help
             test -x "$(command -v moog)"
             otool -L "$(which moog)"

--- a/.github/workflows/tarballs.yaml
+++ b/.github/workflows/tarballs.yaml
@@ -96,3 +96,45 @@ jobs:
         with:
           name: darwin-tarball
           path: ./darwin-tarball
+  macos-homebrew-artifacts:
+    name: Build and test macOS Homebrew artifacts
+    if: github.event_name == 'pull_request'
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+            substituters = https://cache.iog.io https://cache.nixos.org/
+            accept-flake-config = true
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - name: Build and smoke test Homebrew artifacts
+        uses: paolino/dev-assets/darwin-homebrew-release@spike/darwin-homebrew-action
+        with:
+          mode: dev-homebrew
+          update-tap: "no"
+          release-package: darwin-release-artifacts
+          dev-package: darwin-dev-homebrew-artifacts
+          release-formula: moog.rb
+          dev-formula: moog-dev.rb
+          release-artifact-name: darwin-release-bundle
+          dev-artifact-name: darwin-dev-homebrew-artifacts
+          tarball-pattern: moog-*-aarch64-darwin.tar.gz
+          installed-commands: moog moog-oracle
+          cleanup-formulae: moog moog-dev
+          tap-name: cardano-foundation/moog
+          tap-repository: cardano-foundation/moog
+          tarball-smoke-script: |
+            moog --help
+            moog-oracle --help
+          brew-smoke-script: |
+            moog --help
+            moog-oracle --help
+            test -x "$(command -v moog)"
+            otool -L "$(which moog)"

--- a/docs/dev/release-packaging.md
+++ b/docs/dev/release-packaging.md
@@ -1,0 +1,84 @@
+# Release Packaging
+
+Moog currently has two packaging paths.
+
+The existing release path builds platform tarballs from the flake outputs and
+uploads them to a GitHub release:
+
+```bash
+nix build .#linux64.tarball
+nix build .#linux-aarch64.tarball
+nix build .#darwin64.tarball
+```
+
+Those outputs are still the release contract used by `CI/release.sh` and the
+`release-linux` / `release-macos` just recipes.
+
+The macOS Homebrew spike adds two Darwin-only flake outputs:
+
+```bash
+nix build .#darwin-release-artifacts
+nix build .#darwin-dev-homebrew-artifacts
+```
+
+Both are built with `paolino/dev-assets` through
+`lib.mkDarwinHomebrewBundle`. The output directory contains:
+
+- a relocatable `aarch64-darwin` tarball with `moog` and `moog-oracle` under
+  `bin/`
+- a generated Homebrew formula
+- `SHA256SUMS`
+- `release-metadata.json`
+
+`darwin-release-artifacts` produces `moog.rb` and uses the Cabal package
+version as the Homebrew version. `darwin-dev-homebrew-artifacts` produces
+`moog-dev.rb`, embeds the source revision in the artifact and formula version,
+and points the formula at the moving `dev-homebrew` release tag.
+
+## Pull Request Verification
+
+The existing `Build tarballs` workflow runs on pull requests. It keeps the
+legacy Linux and macOS tarball jobs and adds a PR-only
+`macos-homebrew-artifacts` job.
+
+That job invokes the shared action:
+
+```yaml
+uses: paolino/dev-assets/darwin-homebrew-release@spike/darwin-homebrew-action
+```
+
+In pull requests the action is intentionally local-only:
+
+- it builds `.#darwin-dev-homebrew-artifacts`
+- it extracts the tarball and checks the listed commands exist
+- it runs Moog's tarball smoke commands
+- it copies the generated formula into a local tap checkout
+- it rewrites the formula URL to `file://<built-tarball>`
+- it runs `brew install`, `brew test`, and Moog's brew smoke commands
+- it uploads the generated tarball and formula as workflow artifacts
+- it does not create GitHub releases or push tap commits
+
+Moog does not currently have a visible `cardano-foundation/homebrew-tap`
+repository. During the spike the PR job uses `cardano-foundation/moog` as a
+temporary local tap source only. This is enough to prove the generated formula
+and Homebrew install path before merge. Before enabling publication, replace the
+workflow inputs with the real tap name and tap repository.
+
+## Release Impact
+
+Merging the spike as-is does not change the current release command:
+
+```bash
+just release-macos
+```
+
+That command still builds `.#darwin64.tarball` and uploads the legacy tarball
+asset. The new Homebrew outputs are additive.
+
+To turn the spike into the release path:
+
+1. Merge or pin the shared `paolino/dev-assets` action and Nix helper.
+2. Create or identify the Cardano Foundation Homebrew tap repository.
+3. Change `tap-name` and `tap-repository` in `tarballs.yaml` to that tap.
+4. Replace the spike action ref with `@main` or a pinned commit SHA.
+5. Add a controlled dispatch or tag publishing path with a tap write token.

--- a/docs/dev/release-packaging.md
+++ b/docs/dev/release-packaging.md
@@ -24,8 +24,8 @@ nix build .#darwin-dev-homebrew-artifacts
 Both are built with `paolino/dev-assets` through
 `lib.mkDarwinHomebrewBundle`. The output directory contains:
 
-- a relocatable `aarch64-darwin` tarball with `moog` and `moog-oracle` under
-  `bin/`
+- a relocatable `aarch64-darwin` tarball with the release executables under
+  `bin/`: `moog`, `moog-oracle`, and `moog-agent`
 - a generated Homebrew formula
 - `SHA256SUMS`
 - `release-metadata.json`
@@ -34,6 +34,11 @@ Both are built with `paolino/dev-assets` through
 version as the Homebrew version. `darwin-dev-homebrew-artifacts` produces
 `moog-dev.rb`, embeds the source revision in the artifact and formula version,
 and points the formula at the moving `dev-homebrew` release tag.
+
+The release executable set is defined once in `nix/moog-project.nix` as
+`releaseExecutables`. Linux tarballs, macOS tarballs, and Homebrew artifacts
+all consume that set so a new first-party executable is not exposed on only one
+platform by accident.
 
 ## Pull Request Verification
 

--- a/flake.lock
+++ b/flake.lock
@@ -401,6 +401,22 @@
         "type": "github"
       }
     },
+    "dev-assets": {
+      "locked": {
+        "lastModified": 1778081689,
+        "narHash": "sha256-qv4fLPZk5hWGwsRo7HQke3fHuLFMAGRPgd0w5Jbrh30=",
+        "owner": "paolino",
+        "repo": "dev-assets",
+        "rev": "9746af456f56048844fb81195e11dce1ef9cc82b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "paolino",
+        "ref": "spike/darwin-homebrew-action",
+        "repo": "dev-assets",
+        "type": "github"
+      }
+    },
     "devshell": {
       "inputs": {
         "flake-utils": [
@@ -2284,6 +2300,7 @@
         "CHaP": "CHaP",
         "asciinema": "asciinema",
         "cardano-node-runtime": "cardano-node-runtime",
+        "dev-assets": "dev-assets",
         "flake-parts": "flake-parts_2",
         "flake-utils": "flake-utils_5",
         "haskellNix": "haskellNix_2",

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,8 @@
     };
     mkdocs.url = "github:paolino/dev-assets?dir=mkdocs";
     asciinema.url = "github:paolino/dev-assets?dir=asciinema";
+    dev-assets.url =
+      "github:paolino/dev-assets?ref=spike/darwin-homebrew-action";
   };
 
   outputs = inputs@{ self, nixpkgs, flake-utils, haskellNix, CHaP, iohkNix
@@ -93,8 +95,10 @@
                   inherit (inputs) nixpkgs flake-utils haskellNix;
                 };
               in import ./nix/moog-macos-artifacts.nix {
-                inherit pkgs project node-project version;
+                inherit pkgs project version;
                 rewrite-libs = rewrite-libs.packages.default;
+                mkDarwinHomebrewBundle =
+                  inputs.dev-assets.lib.mkDarwinHomebrewBundle { inherit pkgs; };
               }
             else { packages = { }; };
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,5 +92,6 @@ nav:
     - Troubleshooting: ops/troubleshooting.md
   - Developers:
     - Code Design: dev/code-design.md
+    - Release Packaging: dev/release-packaging.md
   - Blog:
     - blog/index.md

--- a/nix/moog-linux-aarch64-artifacts.nix
+++ b/nix/moog-linux-aarch64-artifacts.nix
@@ -1,16 +1,24 @@
-{ pkgs, version, project, ... }:
+{
+  pkgs,
+  version,
+  project,
+  ...
+}:
 let
-  moog = project.aarch64-musl.moog.components.exes.moog;
-  moog-oracle = project.aarch64-musl.moog.components.exes.moog-oracle;
-  moog-agent = project.aarch64-musl.moog.components.exes.moog-agent;
+  releaseExecutables = project.releaseExecutables.aarch64-musl;
+  executableNames = project.releaseExecutables.names;
+  copyExecutables = pkgs.lib.concatMapStringsSep "\n" (name: ''
+    cp ${releaseExecutables.${name}}/bin/${name} $out/unpacked
+  '') executableNames;
   tarball-derivation = pkgs.stdenv.mkDerivation rec {
     pname = "moog";
     inherit version;
+    passthru = {
+      inherit executableNames;
+    };
     unpackPhase = ''
       mkdir -p $out/unpacked
-      cp ${moog}/bin/moog $out/unpacked
-      cp ${moog-oracle}/bin/moog-oracle $out/unpacked
-      cp ${moog-agent}/bin/moog-agent $out/unpacked
+      ${copyExecutables}
       chmod -R +w $out/unpacked/*
     '';
     installPhase = ''
@@ -18,4 +26,7 @@ let
       rm -rf $out/unpacked
     '';
   };
-in { packages.linux-aarch64.tarball = tarball-derivation; }
+in
+{
+  packages.linux-aarch64.tarball = tarball-derivation;
+}

--- a/nix/moog-linux-artifacts.nix
+++ b/nix/moog-linux-artifacts.nix
@@ -1,16 +1,25 @@
-{ pkgs, node-project, version, project, ... }:
+{
+  pkgs,
+  node-project,
+  version,
+  project,
+  ...
+}:
 let
-  moog = project.musl64.moog.components.exes.moog;
-  moog-oracle = project.musl64.moog.components.exes.moog-oracle;
-  moog-agent = project.musl64.moog.components.exes.moog-agent;
+  releaseExecutables = project.releaseExecutables.musl64;
+  executableNames = project.releaseExecutables.names;
+  copyExecutables = pkgs.lib.concatMapStringsSep "\n" (name: ''
+    cp ${releaseExecutables.${name}}/bin/${name} $out/unpacked
+  '') executableNames;
   tarball-derivation = pkgs.stdenv.mkDerivation rec {
     pname = "moog";
     inherit version;
+    passthru = {
+      inherit executableNames;
+    };
     unpackPhase = ''
       mkdir -p $out/unpacked
-      cp ${moog}/bin/moog $out/unpacked
-      cp ${moog-oracle}/bin/moog-oracle $out/unpacked
-      cp ${moog-agent}/bin/moog-agent $out/unpacked
+      ${copyExecutables}
       chmod -R +w $out/unpacked/*
     '';
     installPhase = ''
@@ -18,4 +27,7 @@ let
       rm -rf $out/unpacked
     '';
   };
-in { packages.linux64.tarball = tarball-derivation; }
+in
+{
+  packages.linux64.tarball = tarball-derivation;
+}

--- a/nix/moog-macos-artifacts.nix
+++ b/nix/moog-macos-artifacts.nix
@@ -8,21 +8,18 @@
 }:
 
 let
-  moog = project.packages.moog;
-  moog-oracle = project.packages.moog-oracle;
+  releaseExecutables = project.releaseExecutables.native;
+  executableNames = project.releaseExecutables.names;
+  moog = releaseExecutables.moog;
   packageVersion = moog.version or version;
   devArtifactVersion = "${packageVersion}-${version}";
-  darwinExecutables = {
-    inherit moog moog-oracle;
-  };
-  darwinExecutableNames = [
-    "moog"
-    "moog-oracle"
-  ];
-  darwinFormulaTest = ''
-    system "#{bin}/moog", "--help"
-    system "#{bin}/moog-oracle", "--help"
-  '';
+  darwinFormulaTest = pkgs.lib.concatMapStringsSep "\n" (name: ''
+    system "#{bin}/${name}", "--help"
+  '') executableNames;
+  smokeCommands = map (name: "${name} --help >/dev/null") executableNames;
+  copyExecutables = pkgs.lib.concatMapStringsSep "\n" (name: ''
+    cp ${releaseExecutables.${name}}/bin/${name} $out/unpacked
+  '') executableNames;
   mkMoogDarwinHomebrewBundle =
     args:
     mkDarwinHomebrewBundle (
@@ -33,19 +30,19 @@ let
         desc = "Administer Antithesis test execution for Cardano";
         homepage = "https://github.com/cardano-foundation/moog";
         formulaClass = "Moog";
-        executables = darwinExecutables;
-        executableNames = darwinExecutableNames;
+        executables = releaseExecutables;
+        inherit executableNames;
         formulaTest = darwinFormulaTest;
-        smokeCommands = [
-          "moog --help >/dev/null"
-          "moog-oracle --help >/dev/null"
-        ];
+        inherit smokeCommands;
       }
       // args
     );
   tarball-derivation = pkgs.stdenv.mkDerivation {
     pname = "moog";
     inherit version;
+    passthru = {
+      inherit executableNames;
+    };
     buildInputs = with pkgs.buildPackages; [ nix ];
     phases = [
       "unpackPhase"
@@ -53,8 +50,7 @@ let
     ];
     unpackPhase = ''
       mkdir -p $out/unpacked
-      cp ${moog}/bin/moog $out/unpacked
-      cp ${moog-oracle}/bin/moog-oracle $out/unpacked
+      ${copyExecutables}
       ( cd $out/unpacked ;
         ${rewrite-libs}/bin/rewrite-libs . `ls -1 | grep -Fv .dylib`
         for a in *; do /usr/bin/codesign -f -s - $a; done

--- a/nix/moog-macos-artifacts.nix
+++ b/nix/moog-macos-artifacts.nix
@@ -1,14 +1,56 @@
-{ pkgs, project, node-project, version, rewrite-libs, ... }:
+{
+  pkgs,
+  project,
+  version,
+  rewrite-libs,
+  mkDarwinHomebrewBundle,
+  ...
+}:
 
 let
-  inherit (pkgs) lib;
   moog = project.packages.moog;
   moog-oracle = project.packages.moog-oracle;
+  packageVersion = moog.version or version;
+  devArtifactVersion = "${packageVersion}-${version}";
+  darwinExecutables = {
+    inherit moog moog-oracle;
+  };
+  darwinExecutableNames = [
+    "moog"
+    "moog-oracle"
+  ];
+  darwinFormulaTest = ''
+    system "#{bin}/moog", "--help"
+    system "#{bin}/moog-oracle", "--help"
+  '';
+  mkMoogDarwinHomebrewBundle =
+    args:
+    mkDarwinHomebrewBundle (
+      {
+        pname = "moog";
+        version = packageVersion;
+        owner = "cardano-foundation";
+        desc = "Administer Antithesis test execution for Cardano";
+        homepage = "https://github.com/cardano-foundation/moog";
+        formulaClass = "Moog";
+        executables = darwinExecutables;
+        executableNames = darwinExecutableNames;
+        formulaTest = darwinFormulaTest;
+        smokeCommands = [
+          "moog --help >/dev/null"
+          "moog-oracle --help >/dev/null"
+        ];
+      }
+      // args
+    );
   tarball-derivation = pkgs.stdenv.mkDerivation {
     pname = "moog";
     inherit version;
     buildInputs = with pkgs.buildPackages; [ nix ];
-    phases = [ "unpackPhase" "installPhase" ];
+    phases = [
+      "unpackPhase"
+      "installPhase"
+    ];
     unpackPhase = ''
       mkdir -p $out/unpacked
       cp ${moog}/bin/moog $out/unpacked
@@ -25,4 +67,18 @@ let
     '';
   };
 
-in { packages.darwin64.tarball = tarball-derivation; }
+in
+{
+  packages = {
+    darwin64.tarball = tarball-derivation;
+    darwin-release-artifacts = mkMoogDarwinHomebrewBundle { };
+    darwin-dev-homebrew-artifacts = mkMoogDarwinHomebrewBundle {
+      artifactVersion = devArtifactVersion;
+      releaseTag = "dev-homebrew";
+      formulaName = "moog-dev";
+      formulaClass = "MoogDev";
+      formulaVersion = devArtifactVersion;
+      formulaExtraLines = "\n  conflicts_with \"moog\", because: \"both install the same command-line tools\"";
+    };
+  };
+}

--- a/nix/moog-project.nix
+++ b/nix/moog-project.nix
@@ -1,83 +1,157 @@
-{ CHaP, indexState, pkgs, cardano-cli ? null, mkdocs, asciinema, ... }:
+{
+  CHaP,
+  indexState,
+  pkgs,
+  cardano-cli ? null,
+  mkdocs,
+  asciinema,
+  ...
+}:
 
 let
-  libOverlay = { lib, pkgs, ... }: {
-    # Use our forked libsodium from iohk-nix crypto overlay.
-    packages.plutus-tx.components.library.pkgconfig =
-      lib.mkForce [[ pkgs.libsodium-vrf pkgs.secp256k1 ]];
-    packages.byron-spec-ledger.components.library.pkgconfig =
-      lib.mkForce [[ pkgs.libsodium-vrf pkgs.secp256k1 ]];
-    packages.cardano-crypto-praos.components.library.pkgconfig =
-      lib.mkForce [[ pkgs.libsodium-vrf pkgs.secp256k1 ]];
-    packages.cardano-crypto-class.components.library.pkgconfig =
-      lib.mkForce [[ pkgs.libsodium-vrf pkgs.secp256k1 pkgs.libblst ]];
-  };
-
-  shell = { pkgs, ... }: {
-    tools = {
-      cabal = { index-state = indexState; };
-      cabal-fmt = { index-state = indexState; };
-      haskell-language-server = { index-state = indexState; };
-      hoogle = { index-state = indexState; };
-      fourmolu = { index-state = indexState; };
-      hlint = { index-state = indexState; };
+  libOverlay =
+    { lib, pkgs, ... }:
+    {
+      # Use our forked libsodium from iohk-nix crypto overlay.
+      packages.plutus-tx.components.library.pkgconfig = lib.mkForce [
+        [
+          pkgs.libsodium-vrf
+          pkgs.secp256k1
+        ]
+      ];
+      packages.byron-spec-ledger.components.library.pkgconfig = lib.mkForce [
+        [
+          pkgs.libsodium-vrf
+          pkgs.secp256k1
+        ]
+      ];
+      packages.cardano-crypto-praos.components.library.pkgconfig = lib.mkForce [
+        [
+          pkgs.libsodium-vrf
+          pkgs.secp256k1
+        ]
+      ];
+      packages.cardano-crypto-class.components.library.pkgconfig = lib.mkForce [
+        [
+          pkgs.libsodium-vrf
+          pkgs.secp256k1
+          pkgs.libblst
+        ]
+      ];
     };
-    withHoogle = true;
-    buildInputs = [
-      pkgs.gitAndTools.git
-      pkgs.just
-    ] ++ pkgs.lib.optional (cardano-cli != null) cardano-cli ++ [
-      project.hsPkgs.cardano-addresses.components.exes.cardano-address
-      project.hsPkgs.bech32.components.exes.bech32
-      pkgs.nixfmt-classic
-      pkgs.mkdocs
-      mkdocs.from-nixpkgs
-      mkdocs.asciinema-plugin
-      mkdocs.markdown-callouts
-      mkdocs.markdown-graphviz
-      asciinema.compress
-      asciinema.resize
-      pkgs.asciinema
-    ];
-    shellHook = ''
-      echo "Entering shell for moog CLI development"
-    '';
-  };
 
-  fullyStaticOptions = { pkgs, ... }:
-    let libs = with pkgs; [ zlib openssl libffi gmp6 pkgs.secp256k1 ];
-    in {
+  shell =
+    { pkgs, ... }:
+    {
+      tools = {
+        cabal = {
+          index-state = indexState;
+        };
+        cabal-fmt = {
+          index-state = indexState;
+        };
+        haskell-language-server = {
+          index-state = indexState;
+        };
+        hoogle = {
+          index-state = indexState;
+        };
+        fourmolu = {
+          index-state = indexState;
+        };
+        hlint = {
+          index-state = indexState;
+        };
+      };
+      withHoogle = true;
+      buildInputs = [
+        pkgs.gitAndTools.git
+        pkgs.just
+      ]
+      ++ pkgs.lib.optional (cardano-cli != null) cardano-cli
+      ++ [
+        project.hsPkgs.cardano-addresses.components.exes.cardano-address
+        project.hsPkgs.bech32.components.exes.bech32
+        pkgs.nixfmt-classic
+        pkgs.mkdocs
+        mkdocs.from-nixpkgs
+        mkdocs.asciinema-plugin
+        mkdocs.markdown-callouts
+        mkdocs.markdown-graphviz
+        asciinema.compress
+        asciinema.resize
+        pkgs.asciinema
+      ];
+      shellHook = ''
+        echo "Entering shell for moog CLI development"
+      '';
+    };
+
+  fullyStaticOptions =
+    { pkgs, ... }:
+    let
+      libs = with pkgs; [
+        zlib
+        openssl
+        libffi
+        gmp6
+        pkgs.secp256k1
+      ];
+    in
+    {
       enableShared = false;
       enableStatic = true;
       configureFlags = map (l: "--ghc-option=-optl=-L${l}/lib") (libs);
     };
-  musl = { pkgs, ... }: {
-    packages.moog.components.exes.moog = (fullyStaticOptions { inherit pkgs; });
-    doHaddock = false;
-  };
-  mkProject = ctx@{ lib, pkgs, ... }: {
-    name = "moog";
-    src = ./..;
-    compiler-nix-name = "ghc984";
-    shell = shell { inherit pkgs; };
-    modules = [ libOverlay ];
-    inputMap = { "https://chap.intersectmbo.org/" = CHaP; };
-  };
+  musl =
+    { pkgs, ... }:
+    {
+      packages.moog.components.exes.moog = (fullyStaticOptions { inherit pkgs; });
+      doHaddock = false;
+    };
+  mkProject =
+    ctx@{ lib, pkgs, ... }:
+    {
+      name = "moog";
+      src = ./..;
+      compiler-nix-name = "ghc984";
+      shell = shell { inherit pkgs; };
+      modules = [ libOverlay ];
+      inputMap = {
+        "https://chap.intersectmbo.org/" = CHaP;
+      };
+    };
   project = pkgs.haskell-nix.cabalProject' mkProject;
+  releaseExecutableNames = [
+    "moog"
+    "moog-oracle"
+    "moog-agent"
+  ];
+  nativeReleaseExecutables = pkgs.lib.genAttrs releaseExecutableNames (
+    name: project.hsPkgs.moog.components.exes.${name}
+  );
 
-in {
+in
+{
   devShells.default = project.shell;
   inherit project;
-  packages.moog = project.hsPkgs.moog.components.exes.moog;
-  packages.moog-oracle = project.hsPkgs.moog.components.exes.moog-oracle;
-  packages.moog-agent = project.hsPkgs.moog.components.exes.moog-agent;
-  packages.bech32 = project.hsPkgs.bech32.components.exes.bech32;
-  packages.cardano-address =
-    project.hsPkgs.cardano-addresses.components.exes.cardano-address;
-  packages.unit-tests = project.hsPkgs.moog.components.tests.unit-tests;
-  packages.integration-tests =
-    project.hsPkgs.moog.components.tests.integration-tests;
-  packages.e2e-tests = project.hsPkgs.moog.components.tests.e2e-tests;
+  releaseExecutables = {
+    names = releaseExecutableNames;
+    native = nativeReleaseExecutables;
+    musl64 = pkgs.lib.genAttrs releaseExecutableNames (
+      name: project.projectCross.musl64.hsPkgs.moog.components.exes.${name}
+    );
+    aarch64-musl = pkgs.lib.genAttrs releaseExecutableNames (
+      name: project.projectCross.aarch64-multiplatform-musl.hsPkgs.moog.components.exes.${name}
+    );
+  };
+  packages = nativeReleaseExecutables // {
+    bech32 = project.hsPkgs.bech32.components.exes.bech32;
+    cardano-address = project.hsPkgs.cardano-addresses.components.exes.cardano-address;
+    unit-tests = project.hsPkgs.moog.components.tests.unit-tests;
+    integration-tests = project.hsPkgs.moog.components.tests.integration-tests;
+    e2e-tests = project.hsPkgs.moog.components.tests.e2e-tests;
+  };
   musl64 = project.projectCross.musl64.hsPkgs;
   aarch64-musl = project.projectCross.aarch64-multiplatform-musl.hsPkgs;
 }


### PR DESCRIPTION
## Summary
- add Darwin Homebrew release/dev artifact flake outputs via paolino/dev-assets
- reuse the existing Build tarballs workflow with a PR-only Homebrew install proof
- document the artifact structure, PR verification path, and release impact

## Notes
- This is a spike and still references paolino/dev-assets/darwin-homebrew-release@spike/darwin-homebrew-action.
- No current cardano-foundation/homebrew-tap repository is visible, so PR verification uses cardano-foundation/moog only as a temporary local tap source. The action rewrites the formula URL to the built file:// tarball and does not push a tap commit on PRs.
- The legacy .#darwin64.tarball output and just release-macos path are preserved.

## Local verification
- actionlint .github/workflows/tarballs.yaml
- git diff --check
- nix eval of legacy Linux/macOS tarball outputs
- nix eval/instantiate of darwin-release-artifacts and darwin-dev-homebrew-artifacts
