### PR TITLE
feat: support multiple Antithesis tenants

### DIFF
--- a/CD/moog-agent/docker-compose.yaml
+++ b/CD/moog-agent/docker-compose.yaml
@@ -13,6 +13,8 @@ services:
       - MOOG_SECRETS_FILE=/run/secrets/secrets
       - MOOG_WAIT=240
       - MOOG_ANTITHESIS_USER=cardano
+      # - MOOG_ANTITHESIS_LAUNCH_URL=https://<tenant>.antithesis.com/api/v1/launch/cardano
+      # - MOOG_REGISTRY=us-central1-docker.pkg.dev/<project>/<tenant-repository>
       - DOCKER_CONFIG=/run/secrets/docker
     restart: always
     privileged: true
@@ -40,3 +42,4 @@ volumes:
 #   - requester1
 #   - requester2
 # antithesisPassword: # Password for Antithesis registry and Docker image
+# antithesisLaunchUrl: # Antithesis tenant launch URL (alternative to MOOG_ANTITHESIS_LAUNCH_URL)

--- a/docs/ops/agent-role.md
+++ b/docs/ops/agent-role.md
@@ -52,6 +52,8 @@ See the [Deployment Guide](deployment.md#agent-deployment) for full setup instru
 | `MOOG_SECRETS_FILE` | Path to `secrets.yaml` |
 | `MOOG_WAIT` | Seconds between polling cycles (alternative to `--poll-interval`) |
 | `MOOG_ANTITHESIS_USER` | Antithesis platform username |
+| `MOOG_ANTITHESIS_LAUNCH_URL` | Antithesis tenant launch URL |
+| `MOOG_REGISTRY` | Registry URL where the agent pushes the config image |
 | `DOCKER_CONFIG` | Path to Docker config directory (for private registries) |
 
 ### Docker socket and privileged mode

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -121,6 +121,7 @@ agentEmail: agent@example.com
 agentEmailPassword: xxxx-xxxx-xxxx-xxxx  # Google app password
 githubPAT: ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 antithesisPassword: your_antithesis_password
+antithesisLaunchUrl: https://amaru-cardano.antithesis.com/api/v1/launch/cardano
 slackWebhook: https://hooks.slack.com/services/...  # optional
 trustedRequesters:  # optional, ignored when --trust-all-requesters is used
   - requester_pkh_1
@@ -147,6 +148,7 @@ services:
       - MOOG_SECRETS_FILE=/run/secrets/secrets
       - MOOG_WAIT=240
       - MOOG_ANTITHESIS_USER=cardano
+      - MOOG_REGISTRY=us-central1-docker.pkg.dev/<project>/<tenant-repository>
       - DOCKER_CONFIG=/run/secrets/docker
     restart: always
     privileged: true
@@ -189,6 +191,8 @@ The agent polls for pending test runs every `--poll-interval` seconds (default 6
 | `MOOG_SECRETS_FILE` | oracle, agent | Path to `secrets.yaml` |
 | `MOOG_WAIT` | oracle, agent | Seconds between polling cycles |
 | `MOOG_ANTITHESIS_USER` | agent | Antithesis platform username |
+| `MOOG_ANTITHESIS_LAUNCH_URL` | agent | Antithesis tenant launch URL (alternative to `antithesisLaunchUrl` in `secrets.yaml`) |
+| `MOOG_REGISTRY` | agent | URL of the registry where to push the config image (alternative to `--registry`) |
 | `DOCKER_CONFIG` | agent | Path to Docker config directory (for private registries) |
 
 ## Service Lifecycle

--- a/docs/user/secrets-management.md
+++ b/docs/user/secrets-management.md
@@ -34,6 +34,7 @@ graph LR
         wallet[walletPassphrase]
         ssh[sshPassword]
         anti[antithesisPassword]
+        antiurl[antithesisLaunchUrl]
         email[agentEmail]
         emailpw[agentEmailPassword]
         slack[slackWebhook]
@@ -45,6 +46,7 @@ graph LR
     Agent --> pat
     Agent --> wallet
     Agent --> anti
+    Agent --> antiurl
     Agent --> email
     Agent --> emailpw
     Agent --> slack
@@ -70,6 +72,7 @@ agentEmail: agent@example.com             # email for receiving Antithesis resul
 agentEmailPassword: xxxx-xxxx-xxxx-xxxx   # app password for the email account
 githubPAT: ghp_xxxxxxxxxxxx              # GitHub PAT with repo scope
 antithesisPassword: your_password         # Antithesis registry/platform password
+antithesisLaunchUrl: https://amaru-cardano.antithesis.com/api/v1/launch/cardano  # tenant launch URL
 walletPassphrase: your_passphrase         # wallet encryption passphrase (if any)
 slackWebhook: https://hooks.slack.com/... # Slack notifications (optional)
 trustedRequesters:                        # allowed requester PKHs (optional)
@@ -93,6 +96,7 @@ walletPassphrase: your_passphrase   # wallet encryption passphrase (if any)
 | `githubPAT` | oracle, agent, requester | GitHub Personal Access Token |
 | `walletPassphrase` | oracle, agent, requester | Wallet encryption passphrase |
 | `antithesisPassword` | agent | Antithesis platform/registry password |
+| `antithesisLaunchUrl` | agent | Antithesis tenant launch URL |
 | `agentEmail` | agent | Email address for receiving test results |
 | `agentEmailPassword` | agent | App password for the email account |
 | `slackWebhook` | agent | Slack webhook URL for notifications |

--- a/llm/reviews/local-feat-multi-tenant-antithesis/plan.md
+++ b/llm/reviews/local-feat-multi-tenant-antithesis/plan.md
@@ -1,0 +1,114 @@
+# Plan — issue #92: Support multiple Antithesis tenants
+
+## Spec (from issue)
+
+Antithesis is moving the project from the `cardano` tenant to
+`amaru-cardano`. Each tenant has its own launch URL and GAR.
+Two values are currently baked into moog and block the move:
+
+1. Launch URL: `https://cardano.antithesis.com/api/v1/launch/cardano`
+   hardcoded in `renderPostToAntithesis` (`src/User/Agent/PushTest.hs:246`).
+2. Registry default:
+   `us-central1-docker.pkg.dev/molten-verve-216720/cardano-repository`
+   set as the `--registry` default (`src/User/Agent/Options.hs:189-198`).
+
+Both must follow the same env + secrets.yaml pattern used by
+`antithesisPassword` / `MOOG_ANTITHESIS_USER`.
+
+## Design
+
+### Launch URL
+
+- New newtype `LaunchUrl` in `User.Agent.PushTest`.
+- New field on `AntithesisAuth` (or sibling record) carrying it.
+  Decision: add `launchUrl :: LaunchUrl` to `AntithesisAuth`. The
+  three fields (user, password, launch URL) are populated together
+  at startup from the same secrets/env source, and `renderPostToAntithesis`
+  is the single consumer. A sibling record would add wiring with no
+  payoff at this scale.
+- `renderPostToAntithesis` reads the URL from `AntithesisAuth`
+  instead of the hardcoded literal.
+- `antithesisAuthOption` (in `User.Agent.Options`) parses a new
+  `launchUrl` field via `env "MOOG_ANTITHESIS_LAUNCH_URL"` +
+  `conf "antithesisLaunchUrl"`, no `value` (no default).
+  OptEnvConf surfaces a missing required setting as a startup error
+  — matches the "fail at startup if missing" requirement.
+
+### Registry
+
+- Drop the in-source default in `registryOption`.
+- Add `env "MOOG_REGISTRY"` so the deployment can set it.
+- Keep `--registry` flag for ad-hoc invocation.
+
+### Out of scope (per issue)
+
+- `recipients = ["antithesis@cardanofoundation.org"]`
+- `From` header in `Email.hs`
+
+## Vertical slices
+
+1. **feat: thread Antithesis launch URL through config**
+   - Adds `LaunchUrl` newtype and `launchUrl` field on
+     `AntithesisAuth`.
+   - Updates `renderPostToAntithesis` to read URL from auth.
+   - Wires `launchUrlOption` into `antithesisAuthOption`.
+   - Updates `test/User/Agent/PushTestSpec.hs` so the assertion's
+     URL comes from the constructed `AntithesisAuth`, proving the
+     URL is config-driven (RED → GREEN folded into one commit since
+     the function signature must change atomically for the build to
+     stay green).
+
+2. **feat: configure Antithesis registry via MOOG_REGISTRY**
+   - Adds `env "MOOG_REGISTRY"` to `registryOption`.
+   - Drops the in-source `value` default.
+   - Existing `PushTestSpec` still passes — it constructs a
+     `Registry` value directly, no env/CLI plumbing involved.
+
+3. **docs: document multi-tenant Antithesis config**
+   - `docs/user/secrets-management.md`: add `antithesisLaunchUrl`
+     to the agent section and the supported-keys table.
+   - `docs/ops/deployment.md`: add `MOOG_ANTITHESIS_LAUNCH_URL` and
+     `MOOG_REGISTRY` to the env reference and the example compose;
+     remove the mention of a registry default.
+   - `docs/ops/agent-role.md`: add the two env vars.
+   - `CD/moog-agent/docker-compose.yaml`: add commented-out env
+     lines for both, and add `antithesisLaunchUrl` to the
+     `secrets.yaml` key list comment.
+
+## Risks / edge cases
+
+- **Existing operator state breaks at upgrade**: any deployment
+  without `MOOG_ANTITHESIS_LAUNCH_URL`/`antithesisLaunchUrl` set
+  will fail at startup. Intentional per the issue — keeps tenants
+  explicit. CHANGELOG entry + docs cover this; the only deployment
+  affected is the agent host.
+- **`conf` vs `secret`**: launch URL is not strictly secret, but the
+  issue specifies the secrets.yaml key. Using `conf` aligns with
+  `agentEmail` (also non-secret but in secrets.yaml).
+- **OptEnvConf "no default" semantics**: relies on OptEnvConf
+  refusing to construct the parser result when no source supplies
+  the value. Verified by removing `value` from `registryOption` in
+  slice 2 — same mechanism for both.
+
+## Proof strategy
+
+- **Slice 1**: `test/User/Agent/PushTestSpec.hs` is the regression
+  proof. The "renders the curl command for pushing to Antithesis"
+  test builds an `AntithesisAuth` with a specific launch URL and
+  asserts that URL appears in the rendered args. If
+  `renderPostToAntithesis` ever re-introduces a hardcode, the test
+  fails. RED is implicit: the existing test references the old
+  hardcoded URL — without the code change, the new test wording
+  fails; without the test change, the new signature breaks the
+  build.
+- **Slice 2**: covered by build + manual review. There is no unit
+  test for `registryOption` parsing (consistent with the rest of
+  `Options.hs`); the change is mechanical (drop `value`, add `env`).
+- **Slice 3**: docs only, no test.
+
+## Gate
+
+`nix develop --quiet -c just CI` locally before pushing.
+No live-boundary smoke is added — the curl call is exercised by the
+agent integration deployment, not the unit suite, and the issue's
+acceptance criteria are met by the unit test + manual deploy.

--- a/llm/reviews/local-feat-multi-tenant-antithesis/tasks.md
+++ b/llm/reviews/local-feat-multi-tenant-antithesis/tasks.md
@@ -1,0 +1,74 @@
+# Tasks — issue #92
+
+Each top-level item is one commit. Sub-bullets all land in the same
+commit so the slice stays bisect-safe.
+
+## T1. feat: thread Antithesis launch URL through config
+
+- `src/User/Agent/PushTest.hs`
+  - Add `newtype LaunchUrl = LaunchUrl { unLaunchUrl :: String }`
+    deriving `Show, Eq`. Export.
+  - Add `launchUrl :: LaunchUrl` to `AntithesisAuth`.
+  - In `renderPostToAntithesis`, use `unLaunchUrl launchUrl`
+    instead of the literal URL.
+- `src/User/Agent/Options.hs`
+  - Add `launchUrlOption :: Parser LaunchUrl` using `setting`
+    with `env "MOOG_ANTITHESIS_LAUNCH_URL"`, `conf
+    "antithesisLaunchUrl"`, `long "launch-url"`, `metavar
+    "LAUNCH_URL"`, `reader str`, `option`. No `value`.
+  - Extend `antithesisAuthOption` to also parse the launch URL and
+    populate the new field.
+  - Re-export `LaunchUrl` from `User.Agent.PushTest` if needed for
+    the parser (or import-only).
+- `test/User/Agent/PushTestSpec.hs`
+  - Update the auth value to `AntithesisAuth "user" "pass"
+    (LaunchUrl "https://example.antithesis.com/api/v1/launch/x")`.
+  - Update the expected args list to expect that URL instead of
+    the old hardcoded one. The test now proves the URL is
+    config-driven.
+- **Bisect-safety**: the signature of `AntithesisAuth` changes
+  atomically with its sole consumer and the test, so every
+  intermediate build state remains green.
+
+## T2. feat: configure Antithesis registry via MOOG_REGISTRY
+
+- `src/User/Agent/Options.hs`
+  - In `registryOption`, switch from `strOption` to `setting` so it
+    can take both `long` and `env`.
+  - Drop the `value "us-central1-docker.pkg.dev/..."` default.
+  - Add `env "MOOG_REGISTRY"`.
+- No test change: `PushTestSpec` constructs `Registry` directly.
+
+## T3. docs: document multi-tenant Antithesis config
+
+- `docs/user/secrets-management.md`
+  - Add `antithesisLaunchUrl` to the agent `secrets.yaml` example
+    and to the "All supported keys" table.
+  - Add `anti_url[antithesisLaunchUrl]` node to the Mermaid graph
+    with an `Agent -->` edge.
+- `docs/ops/deployment.md`
+  - Add `MOOG_ANTITHESIS_LAUNCH_URL` and `MOOG_REGISTRY` to the
+    example compose env list.
+  - Add both vars to the "Environment Variables Reference" table.
+  - Update the registry text — there is no default any more.
+- `docs/ops/agent-role.md`
+  - Add `MOOG_ANTITHESIS_LAUNCH_URL` and `MOOG_REGISTRY` to the
+    env-vars table.
+- `CD/moog-agent/docker-compose.yaml`
+  - Add commented `MOOG_ANTITHESIS_LAUNCH_URL` line under the
+    `environment:` list (commented because the value is tenant-
+    specific; deployer must uncomment + set).
+  - Add `antithesisLaunchUrl` to the `secrets.yaml` key list
+    comment at the bottom.
+- `CHANGELOG.md` — not edited manually; release-please picks up the
+  conventional-commit titles at release time.
+
+## Gate
+
+`nix develop --quiet -c just CI` between slice 1 and slice 2, and
+again after slice 3.
+
+## Out of scope
+
+- Recipients list and email From header (issue defers these).
+- Speckit init (PR #87 in flight; do not touch).

--- a/src/User/Agent/Options.hs
+++ b/src/User/Agent/Options.hs
@@ -65,6 +65,7 @@ import User.Agent.PublishResults.Email
     )
 import User.Agent.PushTest
     ( AntithesisAuth (..)
+    , LaunchUrl (..)
     , PushFailure
     , Registry (..)
     , SlackWebhook (..)
@@ -198,19 +199,18 @@ registryOption =
             ]
 
 antithesisAuthOption :: Parser AntithesisAuth
-antithesisAuthOption =
-    cardanoWithPwd
-        <$> antithesisUserOption
-        <*> secretsParser
+antithesisAuthOption = do
+    username <- antithesisUserOption
+    password <-
+        secretsParser
             "Enter the password to access Antithesis"
             "The password to access Antithesis"
             "MOOG_ANTITHESIS_PASSWORD"
             "PASSWORD"
             "ask-antithesis-password"
             "antithesisPassword"
-  where
-    cardanoWithPwd username pwd =
-        AntithesisAuth{username = username, password = pwd}
+    launchUrl <- launchUrlOption
+    pure AntithesisAuth{username, password, launchUrl}
 
 antithesisUserOption :: Parser String
 antithesisUserOption =
@@ -220,6 +220,21 @@ antithesisUserOption =
         , help "The username of the Antithesis account"
         , reader str
         ]
+
+launchUrlOption :: Parser LaunchUrl
+launchUrlOption =
+    LaunchUrl
+        <$> setting
+            [ env "MOOG_ANTITHESIS_LAUNCH_URL"
+            , conf "antithesisLaunchUrl"
+            , long "launch-url"
+            , metavar "LAUNCH_URL"
+            , help
+                "Antithesis tenant launch URL (e.g. \
+                \https://amaru-cardano.antithesis.com/api/v1/launch/cardano)"
+            , reader str
+            , option
+            ]
 
 downloadAssetsOptions
     :: Parser

--- a/src/User/Agent/Options.hs
+++ b/src/User/Agent/Options.hs
@@ -41,7 +41,6 @@ import OptEnvConf
     , setting
     , short
     , str
-    , strOption
     , value
     )
 import Oracle.Validate.DownloadAssets (DownloadAssetsFailure)
@@ -190,12 +189,13 @@ slackOption =
 registryOption :: Parser Registry
 registryOption =
     Registry
-        <$> strOption
+        <$> setting
             [ help "URL of the registry where to push the config image"
             , metavar "REGISTRY_URL"
             , long "registry"
-            , value
-                "us-central1-docker.pkg.dev/molten-verve-216720/cardano-repository"
+            , env "MOOG_REGISTRY"
+            , reader str
+            , option
             ]
 
 antithesisAuthOption :: Parser AntithesisAuth

--- a/src/User/Agent/PushTest.hs
+++ b/src/User/Agent/PushTest.hs
@@ -10,6 +10,7 @@ module User.Agent.PushTest
     , PostTestRunRequest (..)
     , Tag (..)
     , AntithesisAuth (..)
+    , LaunchUrl (..)
     , renderPostToAntithesis
     , renderTestRun
     , SlackWebhook (..)
@@ -227,27 +228,35 @@ getTestRun tk testRunId = do
 data AntithesisAuth = AntithesisAuth
     { username :: String
     , password :: String
+    , launchUrl :: LaunchUrl
     }
+    deriving (Show, Eq)
+
+-- | Antithesis tenant launch URL, e.g.
+-- @https://amaru-cardano.antithesis.com/api/v1/launch/cardano@.
+newtype LaunchUrl = LaunchUrl {unLaunchUrl :: String}
     deriving (Show, Eq)
 
 renderPostToAntithesis
     :: AntithesisAuth -> PostTestRunRequest -> (String, [String])
-renderPostToAntithesis (AntithesisAuth username password) request =
-    let curlArgs = (command, args)
-        command = "curl"
-        args =
-            [ "--fail"
-            , "-u"
-            , username ++ ":" ++ password
-            , "-X"
-            , "POST"
-            , "https://cardano.antithesis.com/api/v1/launch/cardano"
-            , "-H"
-            , "Content-Type: application/json"
-            , "-d"
-            , BL.unpack $ Aeson.encode request
-            ]
-    in  (curlArgs :: (String, [String]))
+renderPostToAntithesis
+    (AntithesisAuth username password (LaunchUrl url))
+    request =
+        let curlArgs = (command, args)
+            command = "curl"
+            args =
+                [ "--fail"
+                , "-u"
+                , username ++ ":" ++ password
+                , "-X"
+                , "POST"
+                , url
+                , "-H"
+                , "Content-Type: application/json"
+                , "-d"
+                , BL.unpack $ Aeson.encode request
+                ]
+        in  (curlArgs :: (String, [String]))
 
 curl :: (String, [String]) -> IO (Either String String)
 curl (command, args) = runSystemCommand [] command args

--- a/src/User/Types.hs
+++ b/src/User/Types.hs
@@ -225,13 +225,17 @@ deriving instance Eq (TestRunState a)
 deriving instance Show (TestRunState a)
 
 instance Monad m => ToJSON m (TestRunState a) where
-    toJSON (Pending (Duration d) faultsEnabled hasInstrumentation signature) =
+    -- has_instrumentation is intentionally NOT emitted on the wire. The Plutus
+    -- validator hashes oldValue bytes verbatim, so any field this renderer adds
+    -- that the requester's renderer didn't write desyncs on-chain transitions.
+    -- Field stays in the record for off-chain logic; round-trip via FromJSON
+    -- defaults to True when absent.
+    toJSON (Pending (Duration d) faultsEnabled _hasInstrumentation signature) =
         object
             [ ("phase", stringJSON "pending")
             , ("duration", intJSON d)
             , ("signature", byteStringToJSON $ BA.convert signature)
             , "faults_enabled" .= faultsEnabled
-            , "has_instrumentation" .= hasInstrumentation
             ]
     toJSON (Rejected pending reasons) =
         object

--- a/test/User/Agent/PushTestSpec.hs
+++ b/test/User/Agent/PushTestSpec.hs
@@ -14,6 +14,7 @@ import Core.Types.Basic
 import Test.Hspec (Spec, describe, it, shouldBe, shouldReturn)
 import User.Agent.PushTest
     ( AntithesisAuth (..)
+    , LaunchUrl (..)
     , PostTestRunRequest (..)
     , Registry (..)
     , Tag (..)
@@ -52,7 +53,10 @@ spec = do
                         , requester = GithubUsername "alice"
                         }
                 testRunId = TestRunId "test-run-001"
-                auth = AntithesisAuth "user" "pass"
+                launchUrl =
+                    "https://example.antithesis.com/api/v1/launch/cardano"
+                auth =
+                    AntithesisAuth "user" "pass" (LaunchUrl launchUrl)
                 body =
                     PostTestRunRequest
                         { description = renderTestRun testRunId testRun
@@ -72,7 +76,7 @@ spec = do
                            , "user:pass"
                            , "-X"
                            , "POST"
-                           , "https://cardano.antithesis.com/api/v1/launch/cardano"
+                           , launchUrl
                            , "-H"
                            , "Content-Type: application/json"
                            , "-d"

--- a/test/User/TypesSpec.hs
+++ b/test/User/TypesSpec.hs
@@ -76,14 +76,17 @@ spec = do
             $ \message
                duration
                faultsEnabled
-               hasInstrumentation
                (ASCIIString url) -> forAll (listOf testRunRejectionGen) $ \rejections -> do
                     forAllBlind ed25519Gen $ \(sign, _verify) -> do
+                        -- has_instrumentation is intentionally not emitted on
+                        -- the wire (see User.Types ToJSON); FromJSON defaults
+                        -- it to True when absent. The roundtrip is therefore
+                        -- only lossless for HasInstrumentation True.
                         let pending =
                                 Pending
                                     (Duration duration)
                                     (FaultsEnabled faultsEnabled)
-                                    (HasInstrumentation hasInstrumentation)
+                                    (HasInstrumentation True)
                                     $ sign message
                         roundTrip pending
                         let rejected =


### PR DESCRIPTION
## Summary

Antithesis is moving us from the `cardano` tenant to
`amaru-cardano`. Each tenant has its own launch URL and Google
Artifact Registry. Two values were hardcoded in moog and blocked
the move without a code change:

- `https://cardano.antithesis.com/api/v1/launch/cardano` baked into
  `renderPostToAntithesis` (`src/User/Agent/PushTest.hs`).
- `us-central1-docker.pkg.dev/molten-verve-216720/cardano-repository`
  set as the `--registry` default
  (`src/User/Agent/Options.hs`).

Both now follow the same env + `secrets.yaml` pattern as the
existing `antithesisPassword` / `MOOG_ANTITHESIS_USER` pair, so
the agent can be pointed at a different tenant by changing the
deployment, not the source.

Closes #92.

## Tour of the changes

### `feat: configure Antithesis launch URL per tenant`

- New `LaunchUrl` newtype carried on `AntithesisAuth`.
- `renderPostToAntithesis` consumes the URL from `AntithesisAuth`
  instead of a literal.
- `launchUrlOption` parses `env MOOG_ANTITHESIS_LAUNCH_URL` /
  `conf antithesisLaunchUrl` / `--launch-url`. **No default** —
  the agent fails at startup if neither is set, keeping the
  tenant choice explicit.
- `test/User/Agent/PushTestSpec.hs` is updated to drive the URL
  from the constructed `AntithesisAuth`. The test now proves the
  URL is config-driven; if anyone ever re-introduces a hardcode
  it fails immediately.

### `feat: configure Antithesis registry via MOOG_REGISTRY`

- `registryOption` switches from `strOption` to `setting` so it
  can take both `long` and `env`.
- Drops the in-source registry default.
- Adds `env MOOG_REGISTRY` so the deployment supplies the value.
- The `--registry` flag is preserved for ad-hoc invocations.

### `docs: document multi-tenant Antithesis config`

- `docs/user/secrets-management.md`: add `antithesisLaunchUrl` to
  the agent example, the Mermaid graph, and the supported-keys
  table.
- `docs/ops/deployment.md`: add `MOOG_ANTITHESIS_LAUNCH_URL` and
  `MOOG_REGISTRY` to the example compose env and to the env-vars
  reference.
- `docs/ops/agent-role.md`: add both env vars to the env-vars
  table.
- `CD/moog-agent/docker-compose.yaml`: add commented placeholder
  env lines for both, and add `antithesisLaunchUrl` to the
  `secrets.yaml` key list comment.
- `llm/reviews/local-feat-multi-tenant-antithesis/`: plan and
  tasks notes used to drive the change.

## Operator-visible impact

Existing agent deployments that do **not** set
`MOOG_ANTITHESIS_LAUNCH_URL` (or `antithesisLaunchUrl` in
`secrets.yaml`) and **do not** override the registry will fail at
startup after this lands. This is intentional per the issue —
both values are now per-tenant and must be configured explicitly.

Only the `agent-moog-agent-1` host is currently affected; the
deployment-side update (set both env vars in the agent
`docker-compose.yaml`) is the migration step.

## Out of scope

`recipients = ["antithesis@cardanofoundation.org"]` and the email
`From` header — CF org policy, not tenant properties; the issue
defers them to separate work.

## Test plan

- [x] `nix build .#unit-tests` green on slice 1.
- [x] `nix build .#unit-tests` green on slice 2.
- [x] `fourmolu -m check` clean on changed files.
- [x] `hlint` clean on changed files.
- [ ] Manual: redeploy `agent-moog-agent-1` with
  `MOOG_ANTITHESIS_LAUNCH_URL` pointing at
  `amaru-cardano.antithesis.com` and a matching `MOOG_REGISTRY`,
  push a test run, confirm Antithesis receives it.