### PR TITLE
fix: correct readEmailsWithSummary parameter type to Minutes

### DIFF
--- a/src/User/Agent/PublishResults/Email.hs
+++ b/src/User/Agent/PublishResults/Email.hs
@@ -270,7 +270,7 @@ readEmails emailUser emailPassword past = do
 readEmailsWithSummary
     :: EmailUser
     -> EmailPassword
-    -> Duration
+    -> Minutes
     -- ^ limit to emails since this time
     -> ExceptT
         EmailException


### PR DESCRIPTION
## Summary

The signature of `readEmailsWithSummary` in `src/User/Agent/PublishResults/Email.hs` declares the `past` parameter as `Duration`, but:

- the body uses `Num` arithmetic (`past * 60`) — `Duration` has no `Num` instance
- both callers pass `Minutes`: the local `readEmails` (line 260) and `Process.pollEmails` (`poMinutes :: Minutes`)

As a result, `origin/main` does not compile.

This restores the parameter type to `Minutes`, matching usage. Typo introduced in 67771227 (`fix: recover missed antithesis result emails`).

## Test plan

- [x] `nix build .#moog-agent-docker-image` succeeds