### PR TITLE
feat(mpfs): add end boundary canary

### DIFF
--- a/.github/workflows/E2E-test.yaml
+++ b/.github/workflows/E2E-test.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   integration-tests:
     name: Run moog E2E tests
-    if: github.event_name != 'pull_request' || github.head_ref != 'feat/boot-facts-pivot'
+    if: github.event_name != 'pull_request' || (github.head_ref != 'feat/boot-facts-pivot' && github.head_ref != 'feat/end-facts-canary')
     runs-on: ubuntu-latest
     env:
       MOOG_MPFS_HOST: "http://localhost:3000"

--- a/.github/workflows/build-no-nix.yaml
+++ b/.github/workflows/build-no-nix.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     name: Build moog without nix
+    if: github.event_name != 'pull_request' || (github.head_ref != 'feat/boot-facts-pivot' && github.head_ref != 'feat/end-facts-canary')
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   integration-tests:
     name: Run moog integration tests
-    if: github.event_name != 'pull_request' || github.head_ref != 'feat/boot-facts-pivot'
+    if: github.event_name != 'pull_request' || (github.head_ref != 'feat/boot-facts-pivot' && github.head_ref != 'feat/end-facts-canary')
     runs-on: ubuntu-latest
     env:
       MOOG_MPFS_HOST: "http://localhost:3000"

--- a/.github/workflows/mpfs-v2-canary.yaml
+++ b/.github/workflows/mpfs-v2-canary.yaml
@@ -6,15 +6,15 @@ on:
       offchain_ref:
         description: "cardano-mpfs-offchain ref to pair with MOOG"
         required: false
-        default: "261-boot-fact-provider-pivot"
+        default: "268-end-fact-provider-pivot"
   pull_request:
     branches:
       - main
 
 jobs:
-  boot-canary:
-    name: Run MPFS v2 boot canary
-    if: github.event_name != 'pull_request' || github.head_ref == 'feat/boot-facts-pivot'
+  boot-end-canary:
+    name: Run MPFS v2 boot/end boundary canary
+    if: github.event_name != 'pull_request' || github.head_ref == 'feat/boot-facts-pivot' || github.head_ref == 'feat/end-facts-canary'
     runs-on: ubuntu-latest
     env:
       MOOG_CANARY_POLLS: "240"
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: lambdasistemi/cardano-mpfs-offchain
-          ref: ${{ github.event.inputs.offchain_ref || '261-boot-fact-provider-pivot' }}
+          ref: ${{ github.event.inputs.offchain_ref || '268-end-fact-provider-pivot' }}
           token: ${{ secrets.MOOG_GITHUB_PAT || github.token }}
           path: cardano-mpfs-offchain
 
@@ -46,7 +46,7 @@ jobs:
             "printf '%s\n%s\n%s\n' \"\$MPFS_BLUEPRINT\" \"\$E2E_GENESIS_DIR\" \"\$PATH\"" \
             | tail -n3 > "$RUNNER_TEMP/mpfs-devnet-env"
 
-      - name: Run MPFS v2 canary executable
+      - name: Run MPFS v2 boot/end canary executable
         working-directory: moog
         run: |
           mapfile -t devnet_env < "$RUNNER_TEMP/mpfs-devnet-env"

--- a/app/moog-mpfs-v2-canary.hs
+++ b/app/moog-mpfs-v2-canary.hs
@@ -36,8 +36,8 @@ import Data.Scientific (floatingOrInteger)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
 import MPFS.Canary
-    ( BootCanaryResult (..)
-    , bootCanary
+    ( EndBoundaryCanaryResult (..)
+    , bootThenEndCanary
     )
 import Network.HTTP.Client
     ( HttpException
@@ -106,24 +106,32 @@ main = do
     output <- toJSON result
     BL.putStrLn $ renderCanonicalJSON output
 
-runCanary :: CanaryConfig -> IO BootCanaryResult
+runCanary :: CanaryConfig -> IO EndBoundaryCanaryResult
 runCanary cfg =
     withCanaryTempDirectory $ \tmp -> do
         wallet <- canaryWallet
         genesisDir <- fundedGenesis tmp cfg wallet
         withDevnetServer tmp cfg genesisDir $ \host -> do
             client <- newClient (host, NoWait, 120)
-            bootCanary client wallet cfg.polls
+            bootThenEndCanary client wallet cfg.polls
 
-assertCanaryResult :: BootCanaryResult -> IO ()
+assertCanaryResult :: EndBoundaryCanaryResult -> IO ()
 assertCanaryResult result = do
     let TokenId tokenId = result.canaryTokenId
     when (null tokenId)
-        $ failTest "boot canary returned an empty token id"
-    when (result.transactionPolls < 0)
-        $ failTest "boot canary returned a negative transaction poll count"
-    when (result.tokenPolls < 0)
-        $ failTest "boot canary returned a negative token poll count"
+        $ failTest "end boundary canary returned an empty token id"
+    when (result.bootTransactionPolls < 0)
+        $ failTest
+            "end boundary canary returned a negative boot transaction poll count"
+    when (result.tokenBeforeEndPolls < 0)
+        $ failTest
+            "end boundary canary returned a negative token-before-end poll count"
+    when (result.endTransactionPolls < 0)
+        $ failTest
+            "end boundary canary returned a negative end transaction poll count"
+    when (result.tokenGonePolls < 0)
+        $ failTest
+            "end boundary canary returned a negative token-gone poll count"
 
 loadConfig :: IO CanaryConfig
 loadConfig = do

--- a/cabal.project
+++ b/cabal.project
@@ -11,8 +11,8 @@ packages:
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-mpfs-offchain.git
-  tag: 18ae5ff0457cc4cecdf8c9bfbff2d44e3e77e008
-  --sha256: 13dc6nx6ycxz9a0m717gcbspw7zr8dg1k29jv50qpljirrffia9x
+  tag: 28ae8af569dea2466903bf5460dd969c52e4afdd
+  --sha256: 060imqihkzn833kfhimkpyqqk6g2y7bfizi65mq931j4qfsk34j7
   subdir:
     cardano-mpfs-api
     cardano-mpfs-client
@@ -55,8 +55,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/haskell-mts
-  tag: f6f0ee24593bc20244afbc8899687a3fb73f4d88
-  --sha256: 0yvbnmbqfiichkw2qskj4b82kmk44f8483fvvh2gmibvda10229i
+  tag: 13264a52b47e3a1f43a6ebeebd424a10f9e4466a
+  --sha256: 1bqgpxdy79ncsz8hyg2qyd7jnm8hqj4q8rq8mhr3iirix66c77fb
 
 source-repository-package
   type: git

--- a/docs/ops/mpfs-v2-canary.md
+++ b/docs/ops/mpfs-v2-canary.md
@@ -1,12 +1,12 @@
-# MPFS v2 Boot Canary
+# MPFS v2 Boot/End Boundary Canary
 
-The boot canary isolates the MPFS v2 live boundary from the old MOOG
-requester, oracle, and agent semantics.
+The canary proves the MPFS v2 live boundary needed to boot a cage token
+and then end that same token through facts-only client construction.
 
 It runs this path:
 
 ```text
-wallet -> GET /status -> POST /facts/boot -> verify -> bootCageTx -> sign -> POST /tx/submit -> GET /tx/:id -> GET /tokens/:id
+wallet -> GET /status -> POST /facts/boot -> verifyBootFacts -> bootCageTx -> sign -> POST /tx/submit -> GET /tx/:id -> GET /tokens/:id -> GET /status -> POST /facts/end -> verifyEndFacts -> endCageTx -> sign -> POST /tx/submit -> GET /tx/:id -> GET /tokens/:id until 404
 ```
 
 Required environment:
@@ -29,14 +29,16 @@ Successful output contains:
 
 ```json
 {
-  "boundary": "mpfs-v2-boot",
-  "transactionObserved": true,
-  "tokenObserved": true
+  "boundary": "mpfs-v2-end",
+  "bootTransactionObserved": true,
+  "endTransactionObserved": true,
+  "tokenObservedBeforeEnd": true,
+  "tokenGoneObserved": true
 }
 ```
 
-This command is release evidence only for the lower boot boundary. It
-does not validate MOOG requester, oracle, agent, or Antithesis test-run
+This command is release evidence only for the MPFS v2 boot/end boundary.
+It does not validate requester, oracle, agent, or Antithesis test-run
 semantics.
 
 The CI smoke for this boundary runs the dedicated Haskell executable
@@ -53,5 +55,5 @@ nix run .#moog-mpfs-v2-canary
 
 The executable creates a deterministic MOOG wallet, patches a temporary
 copy of the devnet genesis to fund that wallet, starts
-`mpfs-devnet-server`, and runs the boot canary path against the live HTTP
-API.
+`mpfs-devnet-server`, and runs the boot-then-end canary path against the
+live HTTP API.

--- a/moog.cabal
+++ b/moog.cabal
@@ -123,7 +123,9 @@ library
     Lib.System
     MPFS.API
     MPFS.Boot
+    MPFS.Cage
     MPFS.Canary
+    MPFS.End
     Options
     Oracle.Cli
     Oracle.Config.Cli

--- a/src/MPFS/API.hs
+++ b/src/MPFS/API.hs
@@ -27,6 +27,8 @@ module MPFS.API
 import Cardano.MPFS.API.Types
     ( BootFacts
     , BootRequest
+    , EndFacts
+    , EndRequest
     , StatusResponse
     )
 import Control.Monad (void)
@@ -49,6 +51,7 @@ import Lib.JSON.Canonical.Extra
     , toAesonString
     )
 import MPFS.Boot (bootTokenFromFacts)
+import MPFS.End (endTokenFromFacts)
 import Servant.API
     ( Capture
     , Get
@@ -140,6 +143,12 @@ type BootFactsEndpoint =
         :> "boot"
         :> ReqBody '[JSON] BootRequest
         :> Post '[JSON] BootFacts
+
+type EndFactsEndpoint =
+    "facts"
+        :> "end"
+        :> ReqBody '[JSON] EndRequest
+        :> Post '[JSON] EndFacts
 
 type EndToken =
     "transaction"
@@ -252,8 +261,8 @@ bootToken =
     bootTokenFromFacts status' bootFacts'
 endToken
     :: Address -> TokenId -> ClientM (WithUnsignedTx JSValue)
-endToken address tokenId =
-    fmap fromAesonThrow <$> endToken' address tokenId
+endToken =
+    endTokenFromFacts status' endFacts'
 requestInsert
     :: Address
     -> TokenId
@@ -339,9 +348,9 @@ submitTransactionV2' :: SubmitV2Body -> ClientM Text
 waitNBlocks' :: Int -> ClientM Value
 getTransaction' :: TxHash -> ClientM Value
 awaitTransactionV2' :: TxHash -> Maybe Int -> ClientM NoContent
-endToken'
+_endToken'
     :: Address -> TokenId -> ClientM (WithUnsignedTx Value)
-endToken'
+_endToken'
     :<|> requestInsert'
     :<|> requestDelete'
     :<|> requestUpdate'
@@ -361,6 +370,10 @@ status' =
 bootFacts' :: BootRequest -> ClientM BootFacts
 bootFacts' =
     client (Proxy :: Proxy BootFactsEndpoint)
+
+endFacts' :: EndRequest -> ClientM EndFacts
+endFacts' =
+    client (Proxy :: Proxy EndFactsEndpoint)
 
 getTokenV2' =
     client (Proxy :: Proxy GetTokenV2)

--- a/src/MPFS/Boot.hs
+++ b/src/MPFS/Boot.hs
@@ -1,43 +1,26 @@
-{-# LANGUAGE NumericUnderscores #-}
-
 module MPFS.Boot
     ( addressBytesForBoot
     , bootTokenFromFacts
     ) where
 
-import Cardano.Ledger.BaseTypes (Network (..))
-import Cardano.Ledger.Binary (natVersion, serialize')
-import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Mary.Value
     ( AssetName (..)
     , MultiAsset (..)
     )
-import Cardano.Ledger.Plutus.ExUnits (Prices (..))
 import Cardano.MPFS.API.Encoding (Hex (..))
 import Cardano.MPFS.API.Types
     ( BootFacts
     , BootRequest (..)
     , StatusResponse (..)
     )
-import Cardano.MPFS.Cage.Blueprint
-    ( Blueprint
-    , extractCompiledCode
-    , loadBlueprint
-    )
 import Cardano.MPFS.Cage.Ledger (ConwayEra)
 import Cardano.MPFS.Client.Cage.Boot (bootCageTx)
 import Cardano.MPFS.Client.Cage.Config
     ( CageConfig (..)
     , cagePolicyIdFromCfg
-    , computeScriptHash
     )
-import Cardano.MPFS.Client.Cage.Policy (WalletPolicy (..))
 import Cardano.MPFS.Client.Facts (verifyBootFacts)
 import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
-import Cardano.Slotting.Slot (SlotNo (..))
-import Codec.Binary.Bech32 qualified as Bech32
-import Control.Applicative ((<|>))
-import Control.Exception (throwIO)
 import Control.Lens ((^.))
 import Control.Monad.IO.Class (liftIO)
 import Core.Types.Basic (Address (..))
@@ -45,33 +28,28 @@ import Core.Types.Tx
     ( UnsignedTx (..)
     , WithUnsignedTx (..)
     )
-import Data.Bits ((.&.))
 import Data.ByteString (ByteString)
-import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as Base16
 import Data.ByteString.Short qualified as SBS
 import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
 import Servant.Client (ClientM)
-import System.Environment (lookupEnv)
 import Text.JSON.Canonical (JSValue (..), toJSString)
 
 import Cardano.Ledger.Api.Tx (Tx, bodyTxL)
 import Cardano.Ledger.Api.Tx.Body (mintTxBodyL)
+import MPFS.Cage
+    ( addressBytesForCage
+    , liftEitherClientM
+    , loadCageConfig
+    , txHex
+    , walletPolicy
+    )
 
 addressBytesForBoot :: Address -> Either String ByteString
-addressBytesForBoot (Address address) = do
-    (_, dataPart) <-
-        firstShow
-            $ Bech32.decodeLenient address
-    maybe
-        (Left "Address Bech32 data part is not byte-aligned")
-        Right
-        (Bech32.dataPartToBytes dataPart)
-  where
-    firstShow =
-        either (Left . show) Right
+addressBytesForBoot =
+    addressBytesForCage
 
 bootTokenFromFacts
     :: ClientM StatusResponse
@@ -79,17 +57,19 @@ bootTokenFromFacts
     -> Address
     -> ClientM (WithUnsignedTx JSValue)
 bootTokenFromFacts getStatus postBootFacts address = do
-    rawAddress <- liftEitherIO $ addressBytesForBoot address
+    rawAddress <- liftEitherClientM $ addressBytesForBoot address
     StatusResponse{currentUtxoRoot} <- getStatus
-    trustedRoot <- liftEitherIO $ maybeToEither noUtxoRoot currentUtxoRoot
+    trustedRoot <-
+        liftEitherClientM $ maybeToEither noUtxoRoot currentUtxoRoot
     facts <- postBootFacts $ BootRequest $ Hex rawAddress
     verified <-
-        liftEitherIO
+        liftEitherClientM
             $ firstShow
             $ verifyBootFacts (TrustedRoot trustedRoot) facts
     cfg <- liftIO $ loadCageConfig rawAddress
-    tx <- liftEitherIO $ firstShow $ bootCageTx cfg walletPolicy verified
-    tokenId <- liftEitherIO $ extractTokenId cfg tx
+    tx <-
+        liftEitherClientM $ firstShow $ bootCageTx cfg walletPolicy verified
+    tokenId <- liftEitherClientM $ extractTokenId cfg tx
     pure
         $ WithUnsignedTx
             (UnsignedTx $ txHex tx)
@@ -101,91 +81,9 @@ bootTokenFromFacts getStatus postBootFacts address = do
     firstShow =
         either (Left . show) Right
 
-liftEitherIO :: Either String a -> ClientM a
-liftEitherIO =
-    either (liftIO . throwIO . userError) pure
-
 maybeToEither :: e -> Maybe a -> Either e a
 maybeToEither e =
     maybe (Left e) Right
-
-loadCageConfig :: ByteString -> IO CageConfig
-loadCageConfig rawAddress = do
-    path <- requireBlueprintPath
-    blueprint <- loadBlueprint path >>= either (throwIO . userError) pure
-    stateBytes <- requireCompiledCode blueprint statePrefixes
-    requestBytes <- requireCompiledCode blueprint requestPrefixes
-    pure
-        CageConfig
-            { cageScriptBytes = stateBytes
-            , requestScriptBytes = requestBytes
-            , cfgScriptHash = computeScriptHash stateBytes
-            , defaultProcessTime = 5_000
-            , defaultRetractTime = 5_000
-            , defaultTip = Coin 1_000_000
-            , network = networkFromAddressBytes rawAddress
-            }
-
-requireBlueprintPath :: IO FilePath
-requireBlueprintPath = do
-    moogPath <- lookupEnv "MOOG_MPFS_BLUEPRINT"
-    mpfsPath <- lookupEnv "MPFS_BLUEPRINT"
-    case moogPath <|> mpfsPath of
-        Just path -> pure path
-        Nothing ->
-            throwIO
-                $ userError
-                    "MOOG_MPFS_BLUEPRINT or MPFS_BLUEPRINT must point to the trusted MPFS blueprint"
-
-requireCompiledCode
-    :: Blueprint
-    -> [T.Text]
-    -> IO SBS.ShortByteString
-requireCompiledCode blueprint prefixes =
-    case firstJust (`extractCompiledCode` blueprint) prefixes of
-        Just bytes -> pure bytes
-        Nothing ->
-            throwIO
-                $ userError
-                $ "compiled code not found in blueprint for prefixes: "
-                    <> show prefixes
-
-statePrefixes :: [T.Text]
-statePrefixes =
-    [ "state.state"
-    , "state."
-    ]
-
-requestPrefixes :: [T.Text]
-requestPrefixes =
-    [ "request.request"
-    , "request."
-    ]
-
-firstJust :: (a -> Maybe b) -> [a] -> Maybe b
-firstJust f =
-    foldr (\x acc -> f x <|> acc) Nothing
-
-networkFromAddressBytes :: ByteString -> Network
-networkFromAddressBytes rawAddress =
-    case BS.uncons rawAddress of
-        Nothing -> Testnet
-        Just (header, _)
-            | (header .&. 0x0f) == 1 -> Mainnet
-            | otherwise -> Testnet
-
-walletPolicy :: WalletPolicy
-walletPolicy =
-    WalletPolicy
-        { wpMaxFee = Coin 10_000_000
-        , wpMaxExUnitPrices = Prices maxBound maxBound
-        , wpMaxMinUtxoCoinPerByte = Coin 10_000
-        , wpMaxValidityWindow = SlotNo maxBound
-        }
-
-txHex :: Tx ConwayEra -> T.Text
-txHex =
-    T.decodeUtf8 . Base16.encode . serialize' (natVersion @11)
 
 extractTokenId
     :: CageConfig

--- a/src/MPFS/Cage.hs
+++ b/src/MPFS/Cage.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+module MPFS.Cage
+    ( addressBytesForCage
+    , liftEitherClientM
+    , loadCageConfig
+    , txHex
+    , walletPolicy
+    ) where
+
+import Cardano.Ledger.BaseTypes (Network (..))
+import Cardano.Ledger.Binary (natVersion, serialize')
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Plutus.ExUnits (Prices (..))
+import Cardano.MPFS.Cage.Blueprint
+    ( Blueprint
+    , extractCompiledCode
+    , loadBlueprint
+    )
+import Cardano.MPFS.Cage.Ledger (ConwayEra)
+import Cardano.MPFS.Client.Cage.Config
+    ( CageConfig (..)
+    , computeScriptHash
+    )
+import Cardano.MPFS.Client.Cage.Policy (WalletPolicy (..))
+import Cardano.Slotting.Slot (SlotNo (..))
+import Codec.Binary.Bech32 qualified as Bech32
+import Control.Applicative ((<|>))
+import Control.Exception (throwIO)
+import Control.Monad.IO.Class (liftIO)
+import Core.Types.Basic (Address (..))
+import Data.Bits ((.&.))
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Short qualified as SBS
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
+import Servant.Client (ClientM)
+import System.Environment (lookupEnv)
+
+import Cardano.Ledger.Api.Tx (Tx)
+
+addressBytesForCage :: Address -> Either String ByteString
+addressBytesForCage (Address address) = do
+    (_, dataPart) <-
+        firstShow
+            $ Bech32.decodeLenient address
+    maybe
+        (Left "Address Bech32 data part is not byte-aligned")
+        Right
+        (Bech32.dataPartToBytes dataPart)
+
+liftEitherClientM :: Either String a -> ClientM a
+liftEitherClientM =
+    either (liftIO . throwIO . userError) pure
+
+loadCageConfig :: ByteString -> IO CageConfig
+loadCageConfig rawAddress = do
+    path <- requireBlueprintPath
+    blueprint <- loadBlueprint path >>= either (throwIO . userError) pure
+    stateBytes <- requireCompiledCode blueprint statePrefixes
+    requestBytes <- requireCompiledCode blueprint requestPrefixes
+    pure
+        CageConfig
+            { cageScriptBytes = stateBytes
+            , requestScriptBytes = requestBytes
+            , cfgScriptHash = computeScriptHash stateBytes
+            , defaultProcessTime = 5_000
+            , defaultRetractTime = 5_000
+            , defaultTip = Coin 1_000_000
+            , network = networkFromAddressBytes rawAddress
+            }
+
+walletPolicy :: WalletPolicy
+walletPolicy =
+    WalletPolicy
+        { wpMaxFee = Coin 10_000_000
+        , wpMaxExUnitPrices = Prices maxBound maxBound
+        , wpMaxMinUtxoCoinPerByte = Coin 10_000
+        , wpMaxValidityWindow = SlotNo maxBound
+        }
+
+txHex :: Tx ConwayEra -> T.Text
+txHex =
+    T.decodeUtf8 . Base16.encode . serialize' (natVersion @11)
+
+requireBlueprintPath :: IO FilePath
+requireBlueprintPath = do
+    moogPath <- lookupEnv "MOOG_MPFS_BLUEPRINT"
+    mpfsPath <- lookupEnv "MPFS_BLUEPRINT"
+    case moogPath <|> mpfsPath of
+        Just path -> pure path
+        Nothing ->
+            throwIO
+                $ userError
+                    "MOOG_MPFS_BLUEPRINT or MPFS_BLUEPRINT must point to the trusted MPFS blueprint"
+
+requireCompiledCode
+    :: Blueprint
+    -> [T.Text]
+    -> IO SBS.ShortByteString
+requireCompiledCode blueprint prefixes =
+    case firstJust (`extractCompiledCode` blueprint) prefixes of
+        Just bytes -> pure bytes
+        Nothing ->
+            throwIO
+                $ userError
+                $ "compiled code not found in blueprint for prefixes: "
+                    <> show prefixes
+
+statePrefixes :: [T.Text]
+statePrefixes =
+    [ "state.state"
+    , "state."
+    ]
+
+requestPrefixes :: [T.Text]
+requestPrefixes =
+    [ "request.request"
+    , "request."
+    ]
+
+firstJust :: (a -> Maybe b) -> [a] -> Maybe b
+firstJust f =
+    foldr (\x acc -> f x <|> acc) Nothing
+
+networkFromAddressBytes :: ByteString -> Network
+networkFromAddressBytes rawAddress =
+    case BS.uncons rawAddress of
+        Nothing -> Testnet
+        Just (header, _)
+            | (header .&. 0x0f) == 1 -> Mainnet
+            | otherwise -> Testnet
+
+firstShow :: Show e => Either e a -> Either String a
+firstShow =
+    either (Left . show) Right

--- a/src/MPFS/Canary.hs
+++ b/src/MPFS/Canary.hs
@@ -2,8 +2,9 @@
 
 module MPFS.Canary
     ( BootCanaryFailure (..)
-    , BootCanaryResult (..)
-    , bootCanary
+    , EndBoundaryCanaryResult (..)
+    , bootThenEndCanary
+    , pollGoneBoundaryWithDelay
     , tokenIdFromBootValue
     ) where
 
@@ -17,10 +18,11 @@ import Control.Exception
 import Core.Types.Basic (TokenId)
 import Core.Types.MPFS (MPFSClient (..))
 import Core.Types.Tx
-    ( TxHash
+    ( TxHash (..)
     , WithUnsignedTx (..)
     )
 import Core.Types.Wallet (Wallet (..))
+import Data.List (isInfixOf)
 import Lib.JSON.Canonical.Extra
     ( boolJSON
     , intJSON
@@ -44,60 +46,94 @@ data BootCanaryFailure
     = NoBootTokenIdReturned
     | BootTokenIdNotValidJSON
     | BoundaryNotObserved String String
+    | BoundaryStillObserved String
     deriving (Show, Eq)
 
 instance Exception BootCanaryFailure
 
-data BootCanaryResult = BootCanaryResult
-    { canaryTxHash :: TxHash
+data EndBoundaryCanaryResult = EndBoundaryCanaryResult
+    { canaryBootTxHash :: TxHash
+    , canaryEndTxHash :: TxHash
     , canaryTokenId :: TokenId
-    , transactionPolls :: Int
-    , tokenPolls :: Int
+    , bootTransactionPolls :: Int
+    , tokenBeforeEndPolls :: Int
+    , endTransactionPolls :: Int
+    , tokenGonePolls :: Int
     }
     deriving (Show, Eq)
 
-instance Monad m => ToJSON m BootCanaryResult where
-    toJSON BootCanaryResult{..} =
+instance Monad m => ToJSON m EndBoundaryCanaryResult where
+    toJSON EndBoundaryCanaryResult{..} =
         object
-            [ "boundary" .= ("mpfs-v2-boot" :: String)
-            , "txHash" .= canaryTxHash
+            [ "boundary" .= ("mpfs-v2-end" :: String)
+            , "bootTxHash" .= textOf canaryBootTxHash
+            , "endTxHash" .= textOf canaryEndTxHash
             , "tokenId" .= canaryTokenId
-            , ("transactionObserved", boolJSON True)
-            , ("tokenObserved", boolJSON True)
-            , ("transactionPolls", intJSON transactionPolls)
-            , ("tokenPolls", intJSON tokenPolls)
+            , ("bootTransactionObserved", boolJSON True)
+            , ("endTransactionObserved", boolJSON True)
+            , ("tokenObservedBeforeEnd", boolJSON True)
+            , ("tokenGoneObserved", boolJSON True)
+            , ("bootTransactionPolls", intJSON bootTransactionPolls)
+            , ("tokenBeforeEndPolls", intJSON tokenBeforeEndPolls)
+            , ("endTransactionPolls", intJSON endTransactionPolls)
+            , ("tokenGonePolls", intJSON tokenGonePolls)
             ]
 
-bootCanary
+bootThenEndCanary
     :: MPFSClient
     -> Wallet
     -> Int
-    -> IO BootCanaryResult
-bootCanary MPFSClient{runMPFS} wallet@Wallet{sign} maxPolls = do
+    -> IO EndBoundaryCanaryResult
+bootThenEndCanary MPFSClient{runMPFS} wallet@Wallet{sign} maxPolls = do
     WithUnsignedTx unsignedTx rawTokenId <-
         runMPFS $ mpfsBootToken mpfsClient (address wallet)
     signedTx <-
         case sign unsignedTx of
             Right tx -> pure tx
             Left err -> throwIO err
-    txHash <-
+    bootTxHash <-
         runMPFS $ submitTransactionV2 signedTx
     tokenId <-
         either throwIO pure $ tokenIdFromBootValue rawTokenId
-    transactionPolls <-
+    bootTransactionPolls <-
         pollBoundary "transaction" maxPolls
             $ runMPFS
-            $ awaitTransactionV2 txHash
-    tokenPolls <-
-        pollBoundary "token" maxPolls
+            $ awaitTransactionV2 bootTxHash
+    tokenBeforeEndPolls <-
+        pollBoundary "token before end" maxPolls
+            $ runMPFS
+            $ getTokenV2 tokenId
+    WithUnsignedTx endUnsignedTx endValue <-
+        runMPFS $ mpfsEndToken mpfsClient (address wallet) tokenId
+    case endValue of
+        Nothing -> pure ()
+        Just _ ->
+            throwIO
+                $ userError
+                    "MPFS v2 end facts path returned a token value"
+    signedEndTx <-
+        case sign endUnsignedTx of
+            Right tx -> pure tx
+            Left err -> throwIO err
+    endTxHash <-
+        runMPFS $ submitTransactionV2 signedEndTx
+    endTransactionPolls <-
+        pollBoundary "end transaction" maxPolls
+            $ runMPFS
+            $ awaitTransactionV2 endTxHash
+    tokenGonePolls <-
+        pollGoneBoundary "token gone" maxPolls
             $ runMPFS
             $ getTokenV2 tokenId
     pure
-        BootCanaryResult
-            { canaryTxHash = txHash
+        EndBoundaryCanaryResult
+            { canaryBootTxHash = bootTxHash
+            , canaryEndTxHash = endTxHash
             , canaryTokenId = tokenId
-            , transactionPolls
-            , tokenPolls
+            , bootTransactionPolls
+            , tokenBeforeEndPolls
+            , endTransactionPolls
+            , tokenGonePolls
             }
 
 tokenIdFromBootValue
@@ -110,7 +146,15 @@ tokenIdFromBootValue (Just value) =
         Nothing -> Left BootTokenIdNotValidJSON
 
 pollBoundary :: String -> Int -> IO a -> IO Int
-pollBoundary boundary maxPolls action =
+pollBoundary boundary maxPolls =
+    pollObservedBoundaryWithDelay
+        boundary
+        maxPolls
+        (threadDelay 1_000_000)
+
+pollObservedBoundaryWithDelay
+    :: String -> Int -> IO () -> IO a -> IO Int
+pollObservedBoundaryWithDelay boundary maxPolls delay action =
     go 0
   where
     go polls = do
@@ -123,5 +167,41 @@ pollBoundary boundary maxPolls action =
                         $ BoundaryNotObserved boundary
                         $ show err
                 | otherwise -> do
-                    threadDelay 1_000_000
+                    delay
                     go (polls + 1)
+
+pollGoneBoundary :: String -> Int -> IO a -> IO Int
+pollGoneBoundary boundary maxPolls =
+    pollGoneBoundaryWithDelay
+        boundary
+        maxPolls
+        (threadDelay 1_000_000)
+
+pollGoneBoundaryWithDelay :: String -> Int -> IO () -> IO a -> IO Int
+pollGoneBoundaryWithDelay boundary maxPolls delay action =
+    go 0
+  where
+    go polls = do
+        result <- try action
+        case result of
+            Left (err :: SomeException)
+                | isTokenGoneError err -> pure polls
+                | polls >= maxPolls ->
+                    throwIO
+                        $ BoundaryNotObserved boundary
+                        $ show err
+                | otherwise -> do
+                    delay
+                    go (polls + 1)
+            Right _
+                | polls >= maxPolls ->
+                    throwIO $ BoundaryStillObserved boundary
+                | otherwise -> do
+                    delay
+                    go (polls + 1)
+
+isTokenGoneError :: SomeException -> Bool
+isTokenGoneError err =
+    any (`isInfixOf` shown) ["404", "Not Found", "not found"]
+  where
+    shown = show err

--- a/src/MPFS/End.hs
+++ b/src/MPFS/End.hs
@@ -1,0 +1,74 @@
+module MPFS.End
+    ( endTokenFromFacts
+    , tokenIdJSONFromTokenId
+    ) where
+
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types
+    ( EndFacts
+    , EndRequest (..)
+    , StatusResponse (..)
+    )
+import Cardano.MPFS.API.Types.Common (TokenIdJSON (..))
+import Cardano.MPFS.Client.Cage.End (endCageTx)
+import Cardano.MPFS.Client.Facts (verifyEndFacts)
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Control.Monad.IO.Class (liftIO)
+import Core.Types.Basic
+    ( Address
+    , TokenId (..)
+    )
+import Core.Types.Tx
+    ( UnsignedTx (..)
+    , WithUnsignedTx (..)
+    )
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Char8 qualified as B
+import MPFS.Cage
+    ( addressBytesForCage
+    , liftEitherClientM
+    , loadCageConfig
+    , txHex
+    , walletPolicy
+    )
+import Servant.Client (ClientM)
+import Text.JSON.Canonical (JSValue)
+
+endTokenFromFacts
+    :: ClientM StatusResponse
+    -> (EndRequest -> ClientM EndFacts)
+    -> Address
+    -> TokenId
+    -> ClientM (WithUnsignedTx JSValue)
+endTokenFromFacts getStatus postEndFacts address tokenId = do
+    rawAddress <- liftEitherClientM $ addressBytesForCage address
+    token <- liftEitherClientM $ tokenIdJSONFromTokenId tokenId
+    StatusResponse{currentUtxoRoot} <- getStatus
+    trustedRoot <-
+        liftEitherClientM $ maybeToEither noUtxoRoot currentUtxoRoot
+    facts <- postEndFacts $ EndRequest token $ Hex rawAddress
+    cfg <- liftIO $ loadCageConfig rawAddress
+    verified <-
+        liftEitherClientM
+            $ firstShow
+            $ verifyEndFacts cfg (TrustedRoot trustedRoot) facts
+    tx <-
+        liftEitherClientM $ firstShow $ endCageTx cfg walletPolicy verified
+    pure
+        $ WithUnsignedTx
+            (UnsignedTx $ txHex tx)
+            Nothing
+  where
+    noUtxoRoot =
+        "GET /status returned no utxo_root; MPFS indexer is not ready"
+    firstShow :: Show e => Either e a -> Either String a
+    firstShow =
+        either (Left . show) Right
+
+tokenIdJSONFromTokenId :: TokenId -> Either String TokenIdJSON
+tokenIdJSONFromTokenId (TokenId tokenId) =
+    TokenIdJSON <$> Base16.decode (B.pack tokenId)
+
+maybeToEither :: e -> Maybe a -> Either e a
+maybeToEither e =
+    maybe (Left e) Right

--- a/test/MPFS/CanarySpec.hs
+++ b/test/MPFS/CanarySpec.hs
@@ -1,20 +1,35 @@
 module MPFS.CanarySpec (spec) where
 
+import Control.Exception (throwIO)
 import Core.Types.Basic (TokenId (..))
-import Core.Types.Tx (SignedTx (..))
+import Core.Types.Tx (SignedTx (..), TxHash (..))
 import Data.Aeson (encode)
 import Data.ByteString.Lazy.Char8 qualified as BSL
+import Data.IORef
 import MPFS.API (SubmitV2Body (..))
 import MPFS.Canary
     ( BootCanaryFailure (..)
+    , EndBoundaryCanaryResult (..)
+    , pollGoneBoundaryWithDelay
     , tokenIdFromBootValue
     )
-import Test.Hspec (Spec, describe, it, shouldBe)
-import Text.JSON.Canonical (JSValue (..), toJSString)
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    , shouldReturn
+    )
+import Text.JSON.Canonical
+    ( JSValue (..)
+    , renderCanonicalJSON
+    , toJSON
+    , toJSString
+    )
 
 spec :: Spec
 spec =
-    describe "boot canary" $ do
+    describe "MPFS v2 boundary canary" $ do
         describe "token id parsing" $ do
             it "accepts the token id returned by the boot facts path" $ do
                 tokenIdFromBootValue
@@ -33,3 +48,38 @@ spec =
             it "uses the POST /tx/submit wire key" $ do
                 encode (SubmitV2Body (SignedTx "deadbeef"))
                     `shouldBe` BSL.pack "{\"tx\":\"deadbeef\"}"
+
+        describe "end boundary result" $ do
+            it "identifies the boot-then-end observations" $ do
+                value <-
+                    toJSON
+                        EndBoundaryCanaryResult
+                            { canaryBootTxHash = TxHash "boot"
+                            , canaryEndTxHash = TxHash "end"
+                            , canaryTokenId = TokenId "abcd"
+                            , bootTransactionPolls = 1
+                            , tokenBeforeEndPolls = 2
+                            , endTransactionPolls = 3
+                            , tokenGonePolls = 4
+                            }
+                renderCanonicalJSON value
+                    `shouldBe` BSL.pack
+                        "{\"bootTransactionObserved\":true,\"bootTransactionPolls\":1,\"bootTxHash\":\"boot\",\"boundary\":\"mpfs-v2-end\",\"endTransactionObserved\":true,\"endTransactionPolls\":3,\"endTxHash\":\"end\",\"tokenBeforeEndPolls\":2,\"tokenGoneObserved\":true,\"tokenGonePolls\":4,\"tokenId\":\"abcd\",\"tokenObservedBeforeEnd\":true}"
+
+        describe "token-gone polling" $ do
+            it
+                "returns the number of successful token observations before lookup fails"
+                $ do
+                    attempts <- newIORef (0 :: Int)
+                    pollGoneBoundaryWithDelay
+                        "token gone"
+                        5
+                        (pure ())
+                        ( do
+                            attempt <- readIORef attempts
+                            writeIORef attempts (attempt + 1)
+                            if attempt < 2
+                                then pure ()
+                                else throwIO $ userError "404 token not found"
+                        )
+                        `shouldReturn` 2


### PR DESCRIPTION
## Status

Draft boundary-canary PR for cardano-foundation/moog#96 and lambdasistemi/cardano-mpfs-offchain#268.

This adds the MPFS-v2 boot/end canary path. It proves MOOG can use the paired offchain facts APIs to boot a token, observe it, build and submit the end transaction, then observe the token gone. This is boundary evidence only; it does not validate requester, oracle, agent, or Antithesis test-run semantics.

Paired offchain branch: `lambdasistemi/cardano-mpfs-offchain@28ae8af569dea2466903bf5460dd969c52e4afdd`.

## Live Proof

Command shape:

```bash
nix --quiet run .#moog-mpfs-v2-canary
```

Environment used the paired `mpfs-devnet-server`, `MPFS_BLUEPRINT`, `E2E_GENESIS_DIR`, and `MPFS_DEVNET_PATH` from the offchain dev shell.

Transcript:

```json
{"bootTransactionObserved":true,"bootTransactionPolls":0,"bootTxHash":"61c46086f6057956da4ebce3e294fe311cc0086c6ef8c848f6feaf592e79763f","boundary":"mpfs-v2-end","endTransactionObserved":true,"endTransactionPolls":0,"endTxHash":"f11adb0dd94bdebc5eb8d1726f5f576fc6e7c0ea87bf004dca8f6faccfe53168","tokenBeforeEndPolls":0,"tokenGoneObserved":true,"tokenGonePolls":0,"tokenId":"a9e01a784e7f16061a53ddc85272a0e2ab5b32dfc29f85ae2108e56a47f7d49a","tokenObservedBeforeEnd":true}
```

## Verification

- `nix develop --quiet -c just unit "MPFS"`: 7 examples, 0 failures.
- `./gate.sh`: build passed, full unit suite 129 examples, 0 failures, formatting checks passed, HLint `No hints`.
