### PR TITLE
feat(canary): poll /ready instead of /status (paired with mpfs-offchain#275)

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# gate.sh — mechanical gate for the MPFS v2 readiness-gate canary slice
+# (paired with cardano-mpfs-offchain#276 / issue #275).
+# Ephemeral; dropped in the final commit before the PR is marked ready.
+set -euo pipefail
+
+git diff --check
+
+nix develop --quiet -c just build
+nix develop --quiet -c just unit
+nix develop --quiet -c cabal-fmt -c moog.cabal CI/rewrite-libs/rewrite-libs.cabal
+nix develop --quiet -c fourmolu -m check src app test CI/rewrite-libs
+nix develop --quiet -c just hlint
+
+# Validate the workflow yaml we touch in this PR.
+nix shell nixpkgs#actionlint --quiet -c \
+  actionlint -shellcheck '' \
+    .github/workflows/mpfs-v2-canary.yaml
+
+echo "gate: OK"


### PR DESCRIPTION
Boundary-canary PR paired with [lambdasistemi/cardano-mpfs-offchain#276](https://github.com/lambdasistemi/cardano-mpfs-offchain/pull/276) (issue #275: mpfs-v2 cannot enter replay phase before serving).

## Status

- Phase: bootstrapping. `gate.sh` committed; canary code change and workflow-default pointer land next.
- Pairs against `lambdasistemi/cardano-mpfs-offchain@4a57908` (https://github.com/lambdasistemi/cardano-mpfs-offchain/commit/4a57908b8028a582d2c0b3ace2ca5745ac6bb6de9 — `fix(mpfs-v2): hold HTTP-ready until restoration→following phase transition`).

## Why

The merged canary (cardano-foundation/moog#99) polls `/status` for HTTP 200 before booting/ending a token. On the fix branch, `/status` is **always** 200; the new contract is exposed on `/ready` (200 / 503). So the canary as-shipped never actually exercises the new readiness gate — it would proceed as soon as the HTTP server starts, with or without the indexer being caught up.

## What changes

- `app/moog-mpfs-v2-canary.hs` — switch `waitForStatus` to poll `/ready` (200 only), rename accordingly, refresh the timeout message.
- `.github/workflows/mpfs-v2-canary.yaml` — change the default `offchain_ref` from `main` to `275-mpfs-v2-startup-replay` for the lifetime of this PR, so the PR-triggered CI builds the paired `mpfs-devnet-server` from the fix branch. Reverted at finalisation when the offchain PR has merged.

## Live proof (filled in once CI runs)

- `MPFS v2 Canary` workflow run: <link added after first push of the canary change>
- Expected transcript: identical to moog#99's, but `bootTransactionPolls` non-zero (the indexer takes a moment to cross the stability window).

## Non-goals

- No requester / oracle / agent / Antithesis test-run semantics — boundary evidence only, matching moog#99 scope.
- No cabal.project pin bump on `cardano-mpfs-offchain` API/client; canary uses raw HTTP and does not import the new `ReadyResponse` type.