### PR TITLE
Make moog-agent configuration file-backed

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+cabal build all --enable-tests
+cabal test unit-tests --test-show-details=direct
+cabal-fmt -c moog.cabal CI/rewrite-libs/rewrite-libs.cabal
+fourmolu -m check src app test CI/rewrite-libs
+hlint -c src app test CI/rewrite-libs
+

--- a/specs/102-agent-file-backed-config/plan.md
+++ b/specs/102-agent-file-backed-config/plan.md
@@ -1,0 +1,59 @@
+# Implementation Plan: Agent File-backed Configuration
+
+## Technical Context
+
+- Language: Haskell
+- Option parser: `opt-env-conf`
+- Main affected parsers:
+  - `Core.Options.tokenIdOption`
+  - `Core.Types.MPFS`
+  - `Oracle.Process.pollIntervalOption`
+  - `User.Agent.Options`
+  - `User.Agent.Process`
+- Documentation:
+  - `docs/ops/deployment.md`
+  - `docs/user/secrets-management.md`
+
+## Design
+
+Add `conf` entries to existing settings instead of inventing a new config
+loader. This keeps one precedence model and lets `--help` document the file
+keys automatically.
+
+The config keys are:
+
+- `tokenId`
+- `mpfsHost`
+- `wait`
+- `mpfsTimeoutSeconds`
+- `pollIntervalSeconds`
+- `minutes`
+- `registry`
+- `antithesisUser`
+- `antithesisLaunchUrl`
+- existing keys such as `githubPAT`, `agentEmail`, `agentEmailPassword`,
+  `antithesisPassword`, `trustedRequesters`, `slackWebhook`, and wallet keys
+
+`DOCKER_CONFIG` remains a container/runtime environment concern because the
+Docker CLI reads it directly. Compose can still keep this stable by mounting
+`/secrets/moog-agent/current/docker/config.json` at `/run/secrets/docker/config.json`
+and setting `DOCKER_CONFIG=/run/secrets/docker`.
+
+## Slices
+
+### Slice 1: Parser support and tests
+
+Add missing `conf` keys to the relevant parsers and unit tests covering YAML
+parsing plus env-over-config precedence.
+
+### Slice 2: Deployment docs
+
+Update operator docs with a complete file-backed agent configuration and
+current-directory rotation pattern.
+
+## Verification
+
+- `./gate.sh`
+- Focused unit test during development:
+  `cabal test unit-tests --test-show-details=direct --test-option=--match --test-option="agent file-backed configuration"`
+

--- a/specs/102-agent-file-backed-config/spec.md
+++ b/specs/102-agent-file-backed-config/spec.md
@@ -1,0 +1,47 @@
+# Feature Specification: Agent File-backed Configuration
+
+## P1 User Story
+
+As a `MOOG operator`, I switch a deployed `moog-agent` between old and new
+Antithesis configuration files and observe the agent use the selected
+configuration without editing Docker Compose environment variables.
+
+## Scope
+
+`moog-agent` already loads a YAML secrets/config file through
+`--secrets-file` / `MOOG_SECRETS_FILE`, but several runtime settings are only
+available through environment variables or CLI options. This feature makes the
+agent deployment configuration file-backed wherever the parser already has a
+natural config surface.
+
+## Functional Requirements
+
+- FR-001: The agent process accepts config-file keys for token id, MPFS host,
+  MPFS wait behavior, MPFS timeout, polling interval, result email lookback
+  minutes, registry, Antithesis username, Antithesis launch URL, Antithesis
+  password, email credentials, GitHub PAT, requester trust list, and optional
+  Slack webhook.
+- FR-002: Existing CLI flags and environment variables continue to parse.
+- FR-003: Explicit CLI/env configuration keeps precedence over YAML
+  configuration.
+- FR-004: `moog-agent --help` documents the new YAML config keys via
+  `config:` entries.
+- FR-005: Deployment documentation shows a stable compose mount that points at
+  a switchable `/secrets/moog-agent/current` directory or symlink.
+
+## Success Criteria
+
+- A unit test proves the new YAML keys parse for the agent option parsers.
+- A unit test proves an environment value overrides a YAML value for at least
+  one newly file-backed setting.
+- The docs contain a complete file-backed agent config example and a rotation
+  pattern.
+
+## Non-goals
+
+- Do not implement full multi-tenant scheduling or tenant selection.
+- Do not remove existing environment variables or CLI options.
+- Do not change wallet formats, Antithesis APIs, or Docker registry
+  authentication semantics.
+- Do not require raw Docker credentials inside the YAML file.
+

--- a/specs/102-agent-file-backed-config/tasks.md
+++ b/specs/102-agent-file-backed-config/tasks.md
@@ -1,0 +1,14 @@
+# Tasks: Agent File-backed Configuration
+
+## Slice 1 — Parser Support And Tests
+
+- [ ] T102-S1 Add config-file keys for missing agent runtime parsers.
+- [ ] T102-S1 Add unit tests for YAML parsing and env-over-config precedence.
+- [ ] T102-S1 Run the focused parser tests and full gate.
+
+## Slice 2 — Deployment Docs
+
+- [ ] T102-S2 Document complete file-backed agent configuration.
+- [ ] T102-S2 Document the `/secrets/moog-agent/current -> old|new` rotation pattern.
+- [ ] T102-S2 Run the full gate.
+


### PR DESCRIPTION
## Summary

Resolve #102 by making moog-agent deployment/runtime settings loadable from YAML config where possible, while preserving CLI/env compatibility.

## Plan

- Add missing config keys to existing opt-env-conf parsers.
- Cover YAML parsing and env-over-config precedence with unit tests.
- Document stable compose mounts and `/secrets/moog-agent/current` rotation.

## Verification

Pending implementation.
