### PR TITLE
Specify moog-agent file-backed configuration

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,86 +1,231 @@
 <!--
 Sync Impact Report
-Version change: none -> 0.1.0
-Modified principles: none; initial constitution
+Version change: 0.1.0 -> 0.2.0
+Modified principles:
+- Workflow Contracts Are Binding -> Workflow Governance And Reviewable History
+- Specification Precedes Implementation -> Specification Precedes Implementation
+- Test-First Slices And Evidence-Based Verification -> Verification Mirrors Risk
+- Explicit, File-Backed Operations -> External Boundaries Are Explicit Effects
+- Haskell And Nix Quality Is The Baseline -> Haskell, Nix, And CLI Quality
+Added principles:
+- Cardano-Certified Antithesis Coordination
+- Role-Separated Protocol Authority
+- MPFS Fact Integrity And Fail-Closed Validation
+- Security And Operational Safety
+- Documentation And Deployment Are Product Surface
 Added sections:
-- Core Principles
-- Development Workflow
-- Quality Gates
-- Governance
+- Purpose And System Model
 Removed sections: none
 Templates requiring updates:
-- ⚠ pending: .specify/templates/plan-template.md (template directory not present)
-- ⚠ pending: .specify/templates/spec-template.md (template directory not present)
-- ⚠ pending: .specify/templates/tasks-template.md (template directory not present)
-- ⚠ pending: .specify/templates/commands/*.md (template directory not present)
-Follow-up TODOs:
-- TODO(SPEC_KIT_TEMPLATES): decide whether this repo should adopt full
-  Spec Kit templates or keep only the constitution artifact.
+- not present: .specify/templates/plan-template.md
+- not present: .specify/templates/spec-template.md
+- not present: .specify/templates/tasks-template.md
+- not present: .specify/templates/commands/*.md
+Deferred items: none
 -->
 
 # Moog Constitution
 
+## Purpose And System Model
+
+Moog exists to make Antithesis testing available to Cardano ecosystem
+developers while recording the resulting identities, permissions, test-run
+requests, state transitions, and result references in Cardano-certified MPFS
+state. The repository is therefore both an operator-facing Haskell CLI and a
+protocol participant implementation for three roles: requester, agent, and
+oracle.
+
+The system boundary is broader than the `moog` executable. It includes the
+long-running `moog-agent` and `moog-oracle` services, MPFS REST interaction,
+Cardano transaction signing and submission, GitHub identity and repository
+checks, Docker Compose validation of submitted test assets, Antithesis API and
+registry access, email result ingestion, Nix/Cabal packaging, Docker images,
+deployment Compose files, and operator/user documentation. Changes MUST treat
+those surfaces as one product unless a specification explicitly narrows scope.
+
+The repository's default platform assumptions are GitHub for identity,
+CODEOWNERS for repository role authority, MPFS for facts and transactions,
+Cardano preprod for current chain interaction, and Antithesis for execution.
+Any new platform, network, tenant, registry, or state backend MUST be explicit
+in configuration, documentation, validation, and tests.
+
 ## Core Principles
 
-### I. Workflow Contracts Are Binding
+### I. Cardano-Certified Antithesis Coordination
 
-When a workflow skill or repository process defines roles, phases, or stop
-points, those rules are mandatory. An agent acting as an orchestrator MUST NOT
-perform work assigned to a driver, reviewer, or release operator. If a required
-workflow tool, pane, credential, or context is unavailable, the agent MUST stop
-and report the blocker instead of silently substituting a different workflow.
+Moog MUST preserve its central purpose: coordinating Antithesis test execution
+for Cardano components while making the coordination auditable through MPFS
+facts certified on Cardano. User registration, repository role registration,
+repository whitelisting, test creation, agent acceptance or rejection, and
+result publication are protocol events, not incidental application state.
 
-Rationale: Moog development often touches operator-facing commands and live
-deployment paths. Substituting a local shortcut for the agreed process produces
-unreviewable work and breaks trust in the artifact chain.
+Every behavior-changing feature MUST state which protocol event, role, and
+state transition it affects. Changes that only improve packaging, docs, or
+operator ergonomics MUST still avoid weakening the traceability of test-run
+state and result references.
 
-### II. Specification Precedes Implementation
+Rationale: Moog is valuable because it connects scarce Antithesis access with
+transparent Cardano ecosystem governance. Losing the on-chain trace or making
+execution state ambiguous undermines the repository's reason to exist.
+
+### II. Role-Separated Protocol Authority
+
+Requester, agent, and oracle responsibilities MUST remain separate.
+Requesters create user, role, and test-run requests. Agents whitelist or
+blacklist repositories, validate and download assets, push tests to
+Antithesis, accept or reject runs, and report encrypted result references.
+Oracles validate pending requests against GitHub, signatures, protocol
+configuration, and current MPFS state before committing state updates.
+
+Code MUST NOT move oracle authority into requester or agent paths, bypass
+agent whitelisting for real test execution, or let a convenience command submit
+state transitions that the protocol requires another role to validate. Shared
+helpers are allowed only when their call sites preserve role-specific
+authorization and failure behavior.
+
+Rationale: The protocol relies on different actors having different powers.
+Role shortcuts create invisible trust changes and can turn a CLI convenience
+into a governance bypass.
+
+### III. MPFS Fact Integrity And Fail-Closed Validation
+
+MPFS facts, changes, operations, token requests, and request-zoo constructors
+are the canonical representation of Moog state. Serialization MUST remain
+canonical JSON where the existing protocol uses canonical JSON, fact keys MUST
+remain hash-addressable, and parsers MUST fail closed for malformed, unknown,
+or unsupported requests.
+
+Validation MUST remain centralized around explicit request validators and MUST
+keep configuration absence, protocol-version mismatch, duplicate pending
+requests, missing GitHub evidence, invalid signatures, and illegal state
+transitions as first-class failures. Unknown insert, update, or delete requests
+MUST NOT be treated as successful no-ops.
+
+Rationale: MPFS gives Moog a verifiable state root only if the application
+keeps its own fact schema, parser, and validator semantics precise. Silent
+acceptance or ad hoc JSON compatibility creates false state history.
+
+### IV. External Boundaries Are Explicit Effects
+
+GitHub, MPFS, Antithesis, Docker, email, filesystem, wallet, SSH key, and
+network interactions MUST remain behind explicit parser, context, effect, or
+service boundaries. Business validation SHOULD be testable with mock effects
+where practical; live-boundary behavior MUST have either an integration, E2E,
+canary, smoke test, or documented operator verification path proportional to
+the risk.
+
+Configuration MUST be explicit and fail closed when required MPFS host, token,
+wallet, tenant, registry, secret, or Docker setting is missing. Shipped
+operator paths MUST NOT depend on hidden tenant-specific source defaults.
+Secrets and runtime settings SHOULD be file-backed through stable mounted
+paths when that makes rotation and deployment safer.
+
+Rationale: Moog spends most of its time at system boundaries. The repository's
+effect model is how pure protocol decisions stay reviewable while operators
+can still run real services.
+
+### V. Security And Operational Safety
+
+Wallet files, wallet passphrases, GitHub PATs, Antithesis credentials, Docker
+registry credentials, Slack webhooks, and result URLs MUST be treated as
+operator secrets. Documentation and deployment files MUST preserve restricted
+secret mounts, minimum wallet balance guidance, PAT rotation guidance, and
+clear separation between oracle and agent credentials.
+
+Agent Docker privileges and Docker socket access are high-risk operational
+choices required for local Docker Compose validation. Changes that expand
+agent filesystem, network, Docker, registry, or host access MUST name the
+threat model impact and mitigation. Remote MPFS use MUST remain documented as
+a trust decision because Moog signs transactions produced by that boundary.
+
+Rationale: The services can spend funds, consume rate limits, publish private
+registry artifacts, and run untrusted test assets locally. Security rules are
+part of the product contract, not deployment afterthoughts.
+
+### VI. Haskell, Nix, And CLI Quality
+
+Production code MUST follow the repository's existing Haskell architecture:
+typed command GADTs, `opt-env-conf` parsing for CLI/env/config-file inputs,
+explicit module exports, canonical JSON rendering for command results, and
+Reader/effect boundaries for MPFS submission and validation. New abstractions
+MUST extend existing local patterns unless the specification justifies a
+replacement.
+
+Build and packaging changes MUST respect Cabal, haskell.nix, CHaP, the pinned
+compiler, Docker image definitions, tarball outputs, formatter configuration,
+and the existing warning profile. Operator-facing CLI help, environment
+variables, config-file keys, Docker image entry points, and Compose examples
+are public interfaces and MUST be updated together with behavior changes.
+
+Rationale: Moog's correctness depends on making commands, configuration, and
+protocol outputs explicit. The current Haskell/Nix shape is deliberate and
+keeps binaries, containers, tests, and docs aligned.
+
+### VII. Verification Mirrors Risk
+
+Pure serialization, encryption, validation, parser, and state-transition logic
+MUST be covered by unit tests using the existing Hspec, QuickCheck, EGen, and
+MockMPFS style where applicable. Changes crossing MPFS, GitHub, wallet,
+Docker, email, Antithesis, or packaging boundaries MUST add or update the
+strongest feasible integration, E2E, canary, smoke, or operator verification
+evidence.
+
+Completion claims MUST cite fresh command evidence from the current tree. If
+credentials or infrastructure prevent integration, E2E, or live-boundary
+verification, the PR MUST record the limitation and MUST NOT claim equivalent
+coverage from unit tests alone.
+
+Rationale: Parser-only confidence is not enough for a tool that signs
+transactions, pulls GitHub assets, starts Docker Compose projects, pushes to
+Antithesis, and runs as long-lived infrastructure.
+
+### VIII. Documentation And Deployment Are Product Surface
+
+User manuals, ops guides, security notes, troubleshooting docs, deployment
+Compose files, Nix packages, Docker images, GitHub workflows, and command
+examples MUST stay consistent with code behavior. A change to role semantics,
+configuration, secrets, deployment layout, token lifecycle, test-run lifecycle,
+or external service assumptions MUST update the relevant docs and deploy
+artifacts in the same PR unless the PR records a maintainer-approved deferral.
+
+Documentation MUST distinguish current implementation from future intent.
+Examples that name Cardano Foundation defaults, public MPFS hosts, Antithesis
+tenant values, or `/secrets` layouts MUST either remain correct for shipped
+deployment files or be clearly marked as illustrative.
+
+Rationale: Operators experience Moog through docs, Compose files, service
+logs, and CLI help as much as through library code. Stale deployment guidance
+is a production defect.
+
+### IX. Specification Precedes Implementation
 
 Behavior-changing work MUST be issue-backed and represented by explicit
 specification, plan, and task artifacts before implementation begins, unless a
 human maintainer explicitly scopes the change as documentation-only or
-one-line maintenance. The artifacts MUST state the P1 user story, acceptance
-criteria, non-goals, owned paths, slice boundaries, and verification commands.
+one-line maintenance. The artifacts MUST state the primary user story,
+acceptance criteria, non-goals, owned paths, slice boundaries, external
+boundaries, security implications, and verification commands.
 
-Rationale: Spec-first development keeps Cardano, Antithesis, and deployment
-assumptions visible before code changes make them expensive to correct.
+Rationale: Spec-first development keeps Cardano, MPFS, Antithesis, GitHub,
+Docker, wallet, and deployment assumptions visible before code changes make
+them expensive to correct.
 
-### III. Test-First Slices And Evidence-Based Verification
+### X. Workflow Governance And Reviewable History
 
-Each behavior-changing slice MUST be independently reviewable, bisect-safe, and
-covered by a failing test or documented RED-skip rationale before GREEN work
-starts. Completion claims MUST cite fresh command evidence from the current
-tree. Shipped CLI and operator command changes MUST include command-recovery
-proof that exercises the operator-facing surface, not only internal helpers.
+When a workflow skill or repository process defines roles, phases, stop
+points, or delegation rules, those rules are mandatory. An orchestrator MUST
+NOT perform work assigned to a driver, reviewer, or release operator. If a
+required workflow tool, pane, credential, or context is unavailable, the agent
+MUST stop and report the blocker instead of silently substituting a different
+workflow.
 
-Rationale: Parser-only confidence is not enough for an operator command. Moog
-coordinates wallets, MPFS, Docker, GitHub, and Antithesis, so proof must match
-the boundary the operator depends on.
+Issue-backed PR history MUST remain reviewable. Behavior-changing slices MUST
+be independently reviewable and bisect-safe, and task completion MUST be tied
+to the commit that completes the task.
 
-### IV. Explicit, File-Backed Operations
-
-Deployment configuration MUST be explicit, documented, and fail closed when a
-required tenant, registry, token, wallet, or MPFS setting is absent. Secrets and
-runtime settings SHOULD be file-backed through stable mounted paths when that
-reduces operational rotation risk. Hard-coded tenant-specific values are not
-allowed in shipped operator paths unless the path is deliberately test-only and
-the name makes that clear.
-
-Rationale: Moog is operated across live deployment boundaries. Operators must
-be able to rotate credentials and tenant settings without hidden source defaults
-or ad hoc Compose edits.
-
-### V. Haskell And Nix Quality Is The Baseline
-
-Production Haskell code MUST follow the repository's existing module style,
-explicit exports, formatter configuration, and Nix/Cabal workflow. Shared
-parser, CLI, MPFS, wallet, and Antithesis behavior MUST prefer existing local
-abstractions over new parallel mechanisms. Dependency, formatting, and build
-changes MUST be justified by the slice that needs them.
-
-Rationale: Moog is small enough that local consistency matters more than
-inventing new layers. The safest changes extend the existing parser, command,
-and validation patterns.
+Rationale: Moog development changes operator-facing behavior and live service
+paths. Reviewable history and role discipline are how maintainers can trust
+agent-assisted changes.
 
 ## Development Workflow
 
@@ -95,15 +240,16 @@ All issue-backed implementation work follows this sequence:
    completion into the slice commit.
 7. Keep the PR draft until every task is complete and the final gate is green.
 
-The orchestrator owns specifications, plans, tasks, worker briefs, PR metadata,
-and verification review. Workers own behavior-changing implementation inside
-the paths assigned by their brief. This boundary is mandatory unless a human
-maintainer explicitly changes the workflow for the current ticket.
+The orchestrator owns specifications, plans, tasks, worker briefs, PR
+metadata, and verification review. Workers own behavior-changing
+implementation inside the paths assigned by their brief. This boundary is
+mandatory unless a human maintainer explicitly changes the workflow for the
+current ticket.
 
 ## Quality Gates
 
 Every behavior-changing PR MUST define a branch gate before implementation.
-For this repository, the default gate is:
+For this repository, the default local gate is:
 
 ```bash
 git diff --check
@@ -114,15 +260,22 @@ nix develop --quiet -c fourmolu -m check src app test CI/rewrite-libs
 nix develop --quiet -c hlint -c src app test CI/rewrite-libs
 ```
 
+Boundary-specific changes MUST extend that gate or the task verification with
+the relevant command: MPFS canary or integration tests for MPFS changes,
+GitHub integration tests for GitHub validation changes, E2E scenarios for
+role protocol changes, Docker image smoke tests for packaging changes, and
+Compose or operator command recovery for deployment changes.
+
 If full CI, integration, E2E, or live-boundary checks require unavailable
 operator credentials or infrastructure, the PR MUST record the limitation and
 the strongest completed local evidence. It MUST NOT claim equivalent coverage.
 
 ## Governance
 
-This constitution governs issue-backed development, operator-facing changes,
-and agent-assisted workflow in this repository. Pull requests that conflict
-with a MUST-level rule require either a constitution amendment or an explicit
+This constitution governs repository purpose, protocol behavior, security
+posture, operator-facing deployment, issue-backed development, and
+agent-assisted workflow in this repository. Pull requests that conflict with a
+MUST-level rule require either a constitution amendment or an explicit
 maintainer-approved exception documented in the PR.
 
 Amendments require:
@@ -135,7 +288,6 @@ Amendments require:
    - MINOR for new principles or materially expanded obligations.
    - PATCH for clarifications that do not change obligations.
 
-Version: 0.1.0
+Version: 0.2.0
 Ratified: 2026-05-25
 Last Amended: 2026-05-25
-

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,0 +1,141 @@
+<!--
+Sync Impact Report
+Version change: none -> 0.1.0
+Modified principles: none; initial constitution
+Added sections:
+- Core Principles
+- Development Workflow
+- Quality Gates
+- Governance
+Removed sections: none
+Templates requiring updates:
+- ⚠ pending: .specify/templates/plan-template.md (template directory not present)
+- ⚠ pending: .specify/templates/spec-template.md (template directory not present)
+- ⚠ pending: .specify/templates/tasks-template.md (template directory not present)
+- ⚠ pending: .specify/templates/commands/*.md (template directory not present)
+Follow-up TODOs:
+- TODO(SPEC_KIT_TEMPLATES): decide whether this repo should adopt full
+  Spec Kit templates or keep only the constitution artifact.
+-->
+
+# Moog Constitution
+
+## Core Principles
+
+### I. Workflow Contracts Are Binding
+
+When a workflow skill or repository process defines roles, phases, or stop
+points, those rules are mandatory. An agent acting as an orchestrator MUST NOT
+perform work assigned to a driver, reviewer, or release operator. If a required
+workflow tool, pane, credential, or context is unavailable, the agent MUST stop
+and report the blocker instead of silently substituting a different workflow.
+
+Rationale: Moog development often touches operator-facing commands and live
+deployment paths. Substituting a local shortcut for the agreed process produces
+unreviewable work and breaks trust in the artifact chain.
+
+### II. Specification Precedes Implementation
+
+Behavior-changing work MUST be issue-backed and represented by explicit
+specification, plan, and task artifacts before implementation begins, unless a
+human maintainer explicitly scopes the change as documentation-only or
+one-line maintenance. The artifacts MUST state the P1 user story, acceptance
+criteria, non-goals, owned paths, slice boundaries, and verification commands.
+
+Rationale: Spec-first development keeps Cardano, Antithesis, and deployment
+assumptions visible before code changes make them expensive to correct.
+
+### III. Test-First Slices And Evidence-Based Verification
+
+Each behavior-changing slice MUST be independently reviewable, bisect-safe, and
+covered by a failing test or documented RED-skip rationale before GREEN work
+starts. Completion claims MUST cite fresh command evidence from the current
+tree. Shipped CLI and operator command changes MUST include command-recovery
+proof that exercises the operator-facing surface, not only internal helpers.
+
+Rationale: Parser-only confidence is not enough for an operator command. Moog
+coordinates wallets, MPFS, Docker, GitHub, and Antithesis, so proof must match
+the boundary the operator depends on.
+
+### IV. Explicit, File-Backed Operations
+
+Deployment configuration MUST be explicit, documented, and fail closed when a
+required tenant, registry, token, wallet, or MPFS setting is absent. Secrets and
+runtime settings SHOULD be file-backed through stable mounted paths when that
+reduces operational rotation risk. Hard-coded tenant-specific values are not
+allowed in shipped operator paths unless the path is deliberately test-only and
+the name makes that clear.
+
+Rationale: Moog is operated across live deployment boundaries. Operators must
+be able to rotate credentials and tenant settings without hidden source defaults
+or ad hoc Compose edits.
+
+### V. Haskell And Nix Quality Is The Baseline
+
+Production Haskell code MUST follow the repository's existing module style,
+explicit exports, formatter configuration, and Nix/Cabal workflow. Shared
+parser, CLI, MPFS, wallet, and Antithesis behavior MUST prefer existing local
+abstractions over new parallel mechanisms. Dependency, formatting, and build
+changes MUST be justified by the slice that needs them.
+
+Rationale: Moog is small enough that local consistency matters more than
+inventing new layers. The safest changes extend the existing parser, command,
+and validation patterns.
+
+## Development Workflow
+
+All issue-backed implementation work follows this sequence:
+
+1. Refresh the canonical base from `origin/main`.
+2. Read the issue, linked issues, current PR state, and affected code paths.
+3. Produce or update `spec.md`, `plan.md`, and `tasks.md`.
+4. Review cross-artifact consistency before implementation.
+5. Dispatch behavior-changing slices only through the agreed worker workflow.
+6. Review each slice diff, run the gate, mark matching tasks, and amend task
+   completion into the slice commit.
+7. Keep the PR draft until every task is complete and the final gate is green.
+
+The orchestrator owns specifications, plans, tasks, worker briefs, PR metadata,
+and verification review. Workers own behavior-changing implementation inside
+the paths assigned by their brief. This boundary is mandatory unless a human
+maintainer explicitly changes the workflow for the current ticket.
+
+## Quality Gates
+
+Every behavior-changing PR MUST define a branch gate before implementation.
+For this repository, the default gate is:
+
+```bash
+git diff --check
+nix develop --quiet -c cabal build all --enable-tests
+nix develop --quiet -c cabal test unit-tests --test-show-details=direct
+nix develop --quiet -c cabal-fmt -c moog.cabal CI/rewrite-libs/rewrite-libs.cabal
+nix develop --quiet -c fourmolu -m check src app test CI/rewrite-libs
+nix develop --quiet -c hlint -c src app test CI/rewrite-libs
+```
+
+If full CI, integration, E2E, or live-boundary checks require unavailable
+operator credentials or infrastructure, the PR MUST record the limitation and
+the strongest completed local evidence. It MUST NOT claim equivalent coverage.
+
+## Governance
+
+This constitution governs issue-backed development, operator-facing changes,
+and agent-assisted workflow in this repository. Pull requests that conflict
+with a MUST-level rule require either a constitution amendment or an explicit
+maintainer-approved exception documented in the PR.
+
+Amendments require:
+
+1. A PR that updates this file.
+2. A Sync Impact Report at the top of this file.
+3. Review of affected spec, plan, task, and workflow templates if they exist.
+4. A semantic version bump:
+   - MAJOR for incompatible governance changes or principle removals.
+   - MINOR for new principles or materially expanded obligations.
+   - PATCH for clarifications that do not change obligations.
+
+Version: 0.1.0
+Ratified: 2026-05-25
+Last Amended: 2026-05-25
+

--- a/CD/moog-agent/docker-compose.yaml
+++ b/CD/moog-agent/docker-compose.yaml
@@ -7,18 +7,15 @@ services:
       - source: docker
         target: /run/secrets/docker/config.json
     environment:
-      - MOOG_MPFS_HOST=https://mpfs.plutimus.com
-      - MOOG_WALLET_FILE=/run/secrets/agent-wallet
-      - MOOG_TOKEN_ID=21c523c3b4565f1fc1ad7e54e82ca976f60997d8e7e9946826813fabf341069b
+      # Path to the YAML carrying both secrets and runtime settings.
+      # All tenant-specific values (tokenId, mpfsHost, registry,
+      # antithesisUser, antithesisLaunchUrl, poll/timeout tunables) live
+      # in that file, not here.
       - MOOG_SECRETS_FILE=/run/secrets/secrets
-      - MOOG_WAIT=240
-      - MOOG_ANTITHESIS_USER=cardano
-      # - MOOG_ANTITHESIS_LAUNCH_URL=https://<tenant>.antithesis.com/api/v1/launch/cardano
-      # - MOOG_REGISTRY=us-central1-docker.pkg.dev/<project>/<tenant-repository>
       - DOCKER_CONFIG=/run/secrets/docker
     restart: always
     privileged: true
-    command: "--poll-interval 60 --minutes 1440 --trust-all-requesters"
+    command: "--trust-all-requesters"
     volumes:
       - tmp:/tmp
         # Mount CA certificates, curl seems not to find them when the pkgs.cacert is included in the image
@@ -26,20 +23,36 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:rw
 secrets:
   agent-wallet:
-    file: /secrets/moog-agent/agent.json # Path to a file containing the wallet
+    file: /secrets/moog-agent/current/agent.json # Wallet JSON (via stable symlink)
   secrets:
-    file: /secrets/moog-agent/secrets.yaml # Path to a file containing the secrets
+    file: /secrets/moog-agent/current/secrets.yaml # Agent YAML (via stable symlink)
   docker:
-    file: /secrets/moog-agent/docker/config.json # Path to a file containing Docker config (for private registries)
+    file: /secrets/moog-agent/current/docker/config.json # Docker config (via stable symlink)
 
 volumes:
   tmp:
 ### Keys of the secrets.yaml file:
-# agentEmail: # Email address where url links are received
+# --- Runtime settings (file-backed; CLI / env still override) ---
+# tokenId: # Moog token asset ID on Cardano
+# mpfsHost: # URL of the MPFS service
+# walletFile: # Path to wallet JSON inside the container (usually /run/secrets/agent-wallet)
+# wait: # Number of MPFS poll cycles to wait for tx inclusion (omit to skip waiting)
+# mpfsTimeoutSeconds: # Per-request MPFS HTTP timeout in seconds (default 120)
+# pollIntervalSeconds: # Agent poll interval in seconds (default 30)
+# minutes: # Email lookback window in minutes (default 1440)
+# registry: # Registry URL where the agent pushes the config image
+# antithesisUser: # Antithesis platform username
+# antithesisLaunchUrl: # Antithesis tenant launch URL
+#
+# --- Secrets ---
+# agentEmail: # Email address where Antithesis result URLs are received
 # agentEmailPassword: # App password for the email account
 # githubPAT: # GitHub Personal Access Token
-# trustedRequesters:
+# antithesisPassword: # Antithesis registry/platform password
+# walletPassphrase: # Wallet encryption passphrase (if any)
+# slackWebhook: # Slack webhook URL (optional)
+# trustedRequesters: # Optional list of trusted requester GitHub usernames
 #   - requester1
 #   - requester2
-# antithesisPassword: # Password for Antithesis registry and Docker image
-# antithesisLaunchUrl: # Antithesis tenant launch URL (alternative to MOOG_ANTITHESIS_LAUNCH_URL)
+# mnemonics: # Wallet mnemonics in clear text (alternative to walletFile)
+# encryptedMnemonics: # Encrypted wallet mnemonics (alternative to walletFile)

--- a/docs/ops/agent-role.md
+++ b/docs/ops/agent-role.md
@@ -44,17 +44,21 @@ See the [Deployment Guide](deployment.md#agent-deployment) for full setup instru
 
 ### Environment variables
 
-| Variable | Description |
-|---|---|
-| `MOOG_MPFS_HOST` | URL of the MPFS service |
-| `MOOG_WALLET_FILE` | Path to the agent wallet JSON file |
-| `MOOG_TOKEN_ID` | The moog token asset ID |
-| `MOOG_SECRETS_FILE` | Path to `secrets.yaml` |
-| `MOOG_WAIT` | Seconds between polling cycles (alternative to `--poll-interval`) |
-| `MOOG_ANTITHESIS_USER` | Antithesis platform username |
-| `MOOG_ANTITHESIS_LAUNCH_URL` | Antithesis tenant launch URL |
-| `MOOG_REGISTRY` | Registry URL where the agent pushes the config image |
-| `DOCKER_CONFIG` | Path to Docker config directory (for private registries) |
+Each of the variables below — except `MOOG_SECRETS_FILE` and `DOCKER_CONFIG` — has a matching YAML key in `secrets.yaml` and a matching CLI flag. The parser combines all three sources in the order **CLI > env > YAML**, so a value set on the command line wins over an env variable, which in turn wins over the YAML file. See [Secrets management](../user/secrets-management.md#all-supported-keys) for the full key reference.
+
+| Variable | YAML key | Description |
+|---|---|---|
+| `MOOG_MPFS_HOST` | `mpfsHost` | URL of the MPFS service |
+| `MOOG_WALLET_FILE` | `walletFile` | Path to the agent wallet JSON file |
+| `MOOG_TOKEN_ID` | `tokenId` | The moog token asset ID |
+| `MOOG_SECRETS_FILE` | — | Path to `secrets.yaml` (bootstrap; cannot itself live in the YAML) |
+| `MOOG_WAIT` | `wait` | Number of MPFS poll cycles to wait for tx inclusion |
+| `MOOG_MPFS_TIMEOUT_SECONDS` | `mpfsTimeoutSeconds` | Per-request MPFS HTTP timeout in seconds |
+| `POLL_INTERVAL_SECONDS` | `pollIntervalSeconds` | Agent poll interval (alternative to `--poll-interval`) |
+| `MOOG_ANTITHESIS_USER` | `antithesisUser` | Antithesis platform username |
+| `MOOG_ANTITHESIS_LAUNCH_URL` | `antithesisLaunchUrl` | Antithesis tenant launch URL |
+| `MOOG_REGISTRY` | `registry` | Registry URL where the agent pushes the config image |
+| `DOCKER_CONFIG` | — | Path to Docker config directory (for private registries) |
 
 ### Docker socket and privileged mode
 

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -102,28 +102,61 @@ Look for log lines showing successful polling and validation cycles. The oracle 
 
 ## Agent Deployment
 
-### Secrets setup
+### Stable-path layout for rotation
 
-Create the secrets directory:
+The agent's secrets directory uses a stable-path layout so that rotating credentials, the wallet, or tenant-specific configuration never requires editing the compose file. The compose file always mounts `/secrets/moog-agent/current/...`; `current` is a symlink that the operator points at the version currently in use.
 
-```bash
-mkdir -p /secrets/moog-agent/docker
+```text
+/secrets/moog-agent/
+├── current -> new/                      # symlink: active version
+├── new/
+│   ├── agent.json                       # wallet JSON
+│   ├── secrets.yaml                     # runtime settings + secrets
+│   └── docker/
+│       └── config.json                  # Docker registry credentials
+└── old/
+    ├── agent.json
+    ├── secrets.yaml
+    └── docker/
+        └── config.json
 ```
 
-**`/secrets/moog-agent/agent.json`** — the agent wallet file.
+Create the layout once at install time:
 
-**`/secrets/moog-agent/docker/config.json`** — Docker registry credentials for pulling/pushing Antithesis images.
+```bash
+sudo mkdir -p /secrets/moog-agent/old/docker /secrets/moog-agent/new/docker
+sudo ln -sfn new /secrets/moog-agent/current
+```
 
-**`/secrets/moog-agent/secrets.yaml`**:
+Then populate `/secrets/moog-agent/new/` with the three files described below. Subsequent rotations alternate which side is "live" — see [Rotation](#rotation) below.
+
+**`/secrets/moog-agent/current/agent.json`** — the agent wallet file (from `moog wallet create`).
+
+**`/secrets/moog-agent/current/docker/config.json`** — Docker registry credentials for pulling/pushing Antithesis images.
+
+**`/secrets/moog-agent/current/secrets.yaml`** — runtime settings and secrets together. The full key reference lives in [Secrets management](../user/secrets-management.md#all-supported-keys); a typical agent file looks like:
 
 ```yaml
+# --- Runtime settings (file-backed) ---
+tokenId: <moog-token-asset-id>
+mpfsHost: https://mpfs.plutimus.com
+walletFile: /run/secrets/agent-wallet
+wait: 240
+mpfsTimeoutSeconds: 120
+pollIntervalSeconds: 60
+minutes: 1440
+registry: us-central1-docker.pkg.dev/<project>/<tenant-repository>
+antithesisUser: cardano
+antithesisLaunchUrl: https://amaru-cardano.antithesis.com/api/v1/launch/cardano
+
+# --- Secrets ---
 agentEmail: agent@example.com
-agentEmailPassword: xxxx-xxxx-xxxx-xxxx  # Google app password
+agentEmailPassword: xxxx-xxxx-xxxx-xxxx     # Google app password
 githubPAT: ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 antithesisPassword: your_antithesis_password
-antithesisLaunchUrl: https://amaru-cardano.antithesis.com/api/v1/launch/cardano
-slackWebhook: https://hooks.slack.com/services/...  # optional
-trustedRequesters:  # optional, ignored when --trust-all-requesters is used
+walletPassphrase: your_wallet_passphrase    # if wallet is encrypted
+slackWebhook: https://hooks.slack.com/services/...   # optional
+trustedRequesters:                                    # optional, ignored under --trust-all-requesters
   - requester_pkh_1
   - requester_pkh_2
 ```
@@ -142,31 +175,27 @@ services:
       - source: docker
         target: /run/secrets/docker/config.json
     environment:
-      - MOOG_MPFS_HOST=https://mpfs.plutimus.com
-      - MOOG_WALLET_FILE=/run/secrets/agent-wallet
-      - MOOG_TOKEN_ID=<your-token-id>
       - MOOG_SECRETS_FILE=/run/secrets/secrets
-      - MOOG_WAIT=240
-      - MOOG_ANTITHESIS_USER=cardano
-      - MOOG_REGISTRY=us-central1-docker.pkg.dev/<project>/<tenant-repository>
       - DOCKER_CONFIG=/run/secrets/docker
     restart: always
     privileged: true
-    command: "--poll-interval 60 --minutes 1440 --trust-all-requesters"
+    command: "--trust-all-requesters"
     volumes:
       - tmp:/tmp
       - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
       - /var/run/docker.sock:/var/run/docker.sock:rw
 secrets:
   agent-wallet:
-    file: /secrets/moog-agent/agent.json
+    file: /secrets/moog-agent/current/agent.json
   secrets:
-    file: /secrets/moog-agent/secrets.yaml
+    file: /secrets/moog-agent/current/secrets.yaml
   docker:
-    file: /secrets/moog-agent/docker/config.json
+    file: /secrets/moog-agent/current/docker/config.json
 volumes:
   tmp:
 ```
+
+All tenant-specific values (`tokenId`, `mpfsHost`, `registry`, `antithesisUser`, `antithesisLaunchUrl`, poll/timeout tunables) live in `secrets.yaml` and are rotated with it; the compose file itself is identical across tenants.
 
 !!! warning "Privileged mode and Docker socket"
     The agent container requires privileged mode and access to the Docker socket because it runs `docker compose` to validate test assets locally before pushing them to Antithesis. See [Security](security.md#docker-security) for implications.
@@ -180,6 +209,29 @@ docker compose logs -f moog-agent
 ```
 
 The agent polls for pending test runs every `--poll-interval` seconds (default 60) and checks for email results within the `--minutes` window.
+
+### Rotation
+
+To rotate credentials, the wallet, or any tenant-specific runtime setting (`tokenId`, `antithesisLaunchUrl`, `registry`, …), prepare the new files alongside the current ones and flip the `current` symlink — the compose file never changes.
+
+1. Populate the inactive side (`new/` if `current` points at `old/`, and vice versa):
+   ```bash
+   sudo cp /path/to/new-secrets.yaml /secrets/moog-agent/new/secrets.yaml
+   sudo cp /path/to/new-agent.json   /secrets/moog-agent/new/agent.json
+   sudo cp /path/to/new-config.json  /secrets/moog-agent/new/docker/config.json
+   ```
+2. Atomically repoint `current`:
+   ```bash
+   sudo ln -sfn new /secrets/moog-agent/current
+   ```
+3. Re-create the container so it re-reads the symlink target:
+   ```bash
+   docker compose up -d --force-recreate moog-agent
+   ```
+4. To roll back, repoint `current` at `old/` and run the same `--force-recreate` command.
+
+!!! warning "`restart` is not enough"
+    Docker materialises swarm-style `secrets:` entries into a tmpfs at container *create* time, not at start time. `docker compose restart moog-agent` reuses the existing container, which still carries the *previous* symlink target. **You must `docker compose up -d --force-recreate moog-agent`** (or `down`/`up`) to pick up the new files. Operators have repeatedly tripped on this: a rotation appears to "do nothing" until the next full recreate.
 
 ## Environment Variables Reference
 
@@ -294,10 +346,12 @@ docker compose up -d
 
 ### Configuration changes
 
-For changes to `secrets.yaml` or environment variables, restart the service:
+For changes to environment variables in `docker-compose.yaml`, restart the service:
 
 ```bash
 docker compose restart
 ```
 
-No state is lost on restart — the service resumes polling from the current on-chain state.
+For changes to `secrets.yaml`, the wallet file, or `docker/config.json` on the agent, follow the [stable-path rotation procedure](#rotation) above — `docker compose restart` is **not** enough because the secrets tmpfs is captured at container create time. The oracle has the same caveat: update its files in place and run `docker compose up -d --force-recreate moog-oracle`.
+
+No state is lost across rotation or recreate — both services resume polling from the current on-chain state.

--- a/docs/user/secrets-management.md
+++ b/docs/user/secrets-management.md
@@ -25,6 +25,16 @@ secrets:
     file: ./secrets.yaml
 ```
 
+## Configuration precedence
+
+`moog-agent` and `moog-oracle` parse their settings through `opt-env-conf`, which combines three sources in this order (highest wins):
+
+1. **CLI flags** — e.g. `--token-id <id>`, `--launch-url <url>`.
+2. **Environment variables** — e.g. `MOOG_TOKEN_ID`, `MOOG_ANTITHESIS_LAUNCH_URL`.
+3. **YAML keys** in the file pointed at by `MOOG_SECRETS_FILE` / `--secrets-file`.
+
+Anything that has a YAML key can also be supplied via the CLI or env, and vice-versa. Operators are encouraged to keep tenant-specific values in YAML and reserve the env section of the compose file for non-tenant defaults.
+
 ## Secrets by Role
 
 ```mermaid
@@ -67,18 +77,34 @@ walletPassphrase: your_passphrase   # wallet encryption passphrase (if any)
 
 ### Agent secrets.yaml
 
+The agent YAML carries two groups of keys. **Secrets** are values that must never live in a compose file (PATs, passwords, webhooks). **Runtime settings** are non-secret values that the agent used to receive only through compose `environment:` entries; they are now also accepted as YAML keys so that tenant-specific configuration can travel alongside the secrets and be rotated as one file.
+
 ```yaml
-agentEmail: agent@example.com             # email for receiving Antithesis results
-agentEmailPassword: xxxx-xxxx-xxxx-xxxx   # app password for the email account
-githubPAT: ghp_xxxxxxxxxxxx              # GitHub PAT with repo scope
-antithesisPassword: your_password         # Antithesis registry/platform password
-antithesisLaunchUrl: https://amaru-cardano.antithesis.com/api/v1/launch/cardano  # tenant launch URL
-walletPassphrase: your_passphrase         # wallet encryption passphrase (if any)
-slackWebhook: https://hooks.slack.com/... # Slack notifications (optional)
-trustedRequesters:                        # allowed requester PKHs (optional)
+# --- Runtime settings (file-backed; also accept CLI / env overrides) ---
+tokenId: <moog-token-asset-id>
+mpfsHost: https://mpfs.plutimus.com
+walletFile: /run/secrets/agent-wallet
+wait: 240                                                  # MPFS poll cycles
+mpfsTimeoutSeconds: 120                                    # MPFS request timeout
+pollIntervalSeconds: 60                                    # agent poll interval
+minutes: 1440                                              # email lookback window
+registry: us-central1-docker.pkg.dev/<project>/<repo>
+antithesisUser: <tenant-user>
+antithesisLaunchUrl: https://<tenant>.antithesis.com/api/v1/launch/cardano
+
+# --- Secrets ---
+githubPAT: ghp_xxxxxxxxxxxx
+walletPassphrase: your_passphrase
+antithesisPassword: your_antithesis_password
+agentEmail: agent@example.com
+agentEmailPassword: xxxx-xxxx-xxxx-xxxx
+slackWebhook: https://hooks.slack.com/services/...         # optional
+trustedRequesters:                                         # optional
   - pkh_1
   - pkh_2
 ```
+
+Either `walletFile` or one of `mnemonics` / `encryptedMnemonics` must resolve to a wallet at startup; the agent does not generate one on the fly.
 
 ### Requester secrets.yaml
 
@@ -90,14 +116,25 @@ walletPassphrase: your_passphrase   # wallet encryption passphrase (if any)
 
 ### All supported keys
 
-| Key | Used by | Description |
-|---|---|---|
-| `sshPassword` | requester | SSH password for Git operations |
-| `githubPAT` | oracle, agent, requester | GitHub Personal Access Token |
-| `walletPassphrase` | oracle, agent, requester | Wallet encryption passphrase |
-| `antithesisPassword` | agent | Antithesis platform/registry password |
-| `antithesisLaunchUrl` | agent | Antithesis tenant launch URL |
-| `agentEmail` | agent | Email address for receiving test results |
-| `agentEmailPassword` | agent | App password for the email account |
-| `slackWebhook` | agent | Slack webhook URL for notifications |
-| `trustedRequesters` | agent | List of trusted requester public key hashes |
+| Key | Used by | Kind | Description |
+|---|---|---|---|
+| `tokenId` | oracle, agent | runtime | Moog token asset ID on Cardano |
+| `mpfsHost` | oracle, agent | runtime | URL of the MPFS service |
+| `wait` | oracle, agent | runtime | Number of MPFS poll cycles to wait for a tx to be included (omit to skip waiting) |
+| `mpfsTimeoutSeconds` | oracle, agent | runtime | Per-request MPFS HTTP timeout in seconds (default 120) |
+| `walletFile` | oracle, agent | runtime | Path to wallet JSON file inside the container |
+| `pollIntervalSeconds` | oracle, agent | runtime | Agent / oracle poll interval in seconds (default 30) |
+| `minutes` | agent | runtime | Lookback window in minutes when scanning the mailbox (default 1440) |
+| `registry` | agent | runtime | Registry URL where the agent pushes the config image |
+| `antithesisUser` | agent | runtime | Antithesis platform username |
+| `antithesisLaunchUrl` | agent | runtime | Antithesis tenant launch URL |
+| `githubPAT` | oracle, agent, requester | secret | GitHub Personal Access Token |
+| `walletPassphrase` | oracle, agent, requester | secret | Wallet encryption passphrase |
+| `mnemonics` | oracle, agent, requester | secret | Wallet mnemonics in clear text (alternative to `walletFile`) |
+| `encryptedMnemonics` | oracle, agent, requester | secret | Encrypted wallet mnemonics (alternative to `walletFile`) |
+| `antithesisPassword` | agent | secret | Antithesis platform/registry password |
+| `agentEmail` | agent | secret | Email address for receiving test results |
+| `agentEmailPassword` | agent | secret | App password for the email account |
+| `slackWebhook` | agent | secret | Slack webhook URL for notifications |
+| `trustedRequesters` | agent | secret | List of trusted requester GitHub usernames |
+| `sshPassword` | requester | secret | SSH password for Git operations |

--- a/gate.sh
+++ b/gate.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-git diff --check
-nix develop --quiet -c cabal build all --enable-tests
-nix develop --quiet -c cabal test unit-tests --test-show-details=direct
-nix develop --quiet -c cabal-fmt -c moog.cabal CI/rewrite-libs/rewrite-libs.cabal
-nix develop --quiet -c fourmolu -m check src app test CI/rewrite-libs
-nix develop --quiet -c hlint -c src app test CI/rewrite-libs

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+nix develop --quiet -c cabal build all --enable-tests
+nix develop --quiet -c cabal test unit-tests --test-show-details=direct
+nix develop --quiet -c cabal-fmt -c moog.cabal CI/rewrite-libs/rewrite-libs.cabal
+nix develop --quiet -c fourmolu -m check src app test CI/rewrite-libs
+nix develop --quiet -c hlint -c src app test CI/rewrite-libs

--- a/moog.cabal
+++ b/moog.cabal
@@ -404,6 +404,7 @@ test-suite unit-tests
     Oracle.Validate.Requests.TestRun.FinishSpec
     Oracle.Validate.Requests.TestRun.Lib
     Oracle.Validate.Requests.TestRun.RejectSpec
+    User.Agent.ProcessOptionsSpec
     User.Agent.PublishResults.EmailSpec
     User.Agent.PushTestSpec
     User.Agent.TypesSpec
@@ -433,6 +434,7 @@ test-suite unit-tests
     , case-insensitive
     , crypton
     , directory
+    , filepath
     , hspec
     , lens
     , memory

--- a/nix/moog-project.nix
+++ b/nix/moog-project.nix
@@ -31,7 +31,7 @@ let
       hlint = { index-state = indexState; };
     };
     withHoogle = true;
-    buildInputs = [ pkgs.gitAndTools.git pkgs.just ]
+    buildInputs = [ pkgs.git pkgs.just ]
       ++ pkgs.lib.optional (cardano-cli != null) cardano-cli ++ [
         project.hsPkgs.cardano-addresses.components.exes.cardano-address
         project.hsPkgs.bech32.components.exes.bech32

--- a/specs/102-agent-file-backed-config/plan.md
+++ b/specs/102-agent-file-backed-config/plan.md
@@ -1,0 +1,155 @@
+# Implementation Plan: moog-agent File-backed Configuration
+
+## Issue
+
+cardano-foundation/moog#102
+
+## Goal
+
+Make one deployed `moog-agent` instance configurable from file-backed YAML
+settings so operators can rotate old/new Antithesis configuration by changing
+mounted files or a stable `current` symlink, without editing Docker Compose.
+
+## Technical Context
+
+- Language: Haskell
+- Parser framework: `opt-env-conf`
+- Config entry point: `withYamlConfig secretsFileOption`
+- Existing agent process entry point: `User.Agent.Process.parseArgs`
+- Existing shipped command: `moog-agent`
+- Existing deployment docs: `docs/ops/deployment.md` and
+  `docs/user/secrets-management.md`
+
+## Proposed YAML Keys
+
+The implementation should use explicit config keys that are visible in
+`moog-agent --help` through `config:` documentation:
+
+- `tokenId`
+- `mpfsHost`
+- `wait`
+- `mpfsTimeoutSeconds`
+- `pollIntervalSeconds`
+- `minutes`
+- `registry`
+- `antithesisUser`
+- `antithesisLaunchUrl`
+- Existing keys already supported by the secrets parser:
+  `githubPAT`, `agentEmail`, `agentEmailPassword`, `antithesisPassword`,
+  `trustedRequesters`, `slackWebhook`, `walletPassphrase`, `mnemonics`, and
+  `encryptedMnemonics`
+
+`DOCKER_CONFIG` should remain a stable container runtime environment variable
+because Docker reads it directly. Compose can still avoid per-rotation edits by
+mounting `/secrets/moog-agent/current/docker/config.json` at
+`/run/secrets/docker/config.json` and setting `DOCKER_CONFIG=/run/secrets/docker`.
+
+## Design
+
+Extend the existing `opt-env-conf` parsers with `conf` entries instead of
+adding a second configuration loader. That preserves current parser behavior,
+help generation, environment support, and CLI flag support.
+
+Per-tenant values that currently have source-level defaults or hard-coded
+values should become explicit configuration. In particular:
+
+- Registry should be configurable through `--registry`, `MOOG_REGISTRY`, and
+  `registry`.
+- Antithesis launch URL should be configurable through `--launch-url`,
+  `MOOG_ANTITHESIS_LAUNCH_URL`, and `antithesisLaunchUrl`, then threaded into
+  the code path that renders the Antithesis launch request.
+- Required tenant values should fail closed when absent instead of silently
+  targeting the previous tenant.
+
+Environment variables and CLI flags must remain supported. Precedence should
+follow existing `opt-env-conf` semantics and must be covered by tests.
+
+## Slice Breakdown
+
+### Slice 1: Parser Config Keys And Tests
+
+Add config-file keys to existing parser settings for token id, MPFS settings,
+poll interval, result lookback minutes, registry, Antithesis username, and
+wallet file path if needed for the process path. Add focused unit tests proving
+YAML parsing and env-over-YAML precedence.
+
+Owned paths for worker brief:
+
+- `src/Core/Options.hs`
+- `src/Core/Types/MPFS.hs`
+- `src/Core/Types/Mnemonics/Options.hs`
+- `src/Oracle/Process.hs`
+- `src/User/Agent/Options.hs`
+- `test/User/Agent/*`
+- `moog.cabal` if a new test module is added
+
+### Slice 2: Antithesis Launch URL Threading
+
+Thread the Antithesis launch URL from parsed agent configuration into the
+request rendering path instead of using the hard-coded Cardano tenant URL.
+Keep existing command behavior where explicit CLI/env/config supplies the
+value, and fail closed when no launch URL is supplied.
+
+Owned paths for worker brief:
+
+- `src/User/Agent/Options.hs`
+- `src/User/Agent/PushTest.hs`
+- `src/User/Agent/Process.hs` if the process record needs an additional field
+- `test/User/Agent/PushTestSpec.hs`
+- `test/User/Agent/*`
+
+### Slice 3: Deployment Documentation
+
+Document the complete file-backed agent YAML shape and the stable-path
+rotation model. Keep Docker credentials as a mounted Docker config file, not
+raw YAML.
+
+Owned paths for worker brief:
+
+- `docs/ops/deployment.md`
+- `docs/user/secrets-management.md`
+- `docs/ops/agent-role.md` if the environment/config table needs alignment
+- `CD/moog-agent/docker-compose.yaml` only if the canonical example should
+  switch to `/secrets/moog-agent/current/...`
+
+## TDD And Verification
+
+Each behavior slice should follow RED -> GREEN:
+
+- RED: add focused unit coverage that fails on `origin/main`.
+- GREEN: implement the parser/threading change.
+- Gate: run the focused unit test first, then the branch gate.
+
+Expected branch gate for worker briefs:
+
+```bash
+git diff --check
+nix develop --quiet -c cabal build all --enable-tests
+nix develop --quiet -c cabal test unit-tests --test-show-details=direct
+nix develop --quiet -c cabal-fmt -c moog.cabal CI/rewrite-libs/rewrite-libs.cabal
+nix develop --quiet -c fourmolu -m check src app test CI/rewrite-libs
+nix develop --quiet -c hlint -c src app test CI/rewrite-libs
+```
+
+The full repository `just CI` includes integration/E2E flows that require
+operator-provided secrets and wallet fixtures. If those are unavailable during
+this PR, record the limitation in `WIP.md` and the PR body rather than claiming
+full CI equivalence.
+
+## Open Questions For Next Phase
+
+- Should `registry` remain optional with the current default for requester-style
+  ad hoc `push-test`, or should it become required everywhere to satisfy
+  fail-closed tenant behavior?
+- Should `antithesisLaunchUrl` be stored inside `AntithesisAuth` or a sibling
+  deployment/tenant configuration record?
+- Should the canonical compose example in `CD/moog-agent/docker-compose.yaml`
+  move to `/secrets/moog-agent/current/...`, or should only the documentation
+  show that operator rotation pattern?
+
+## Out Of Scope
+
+- Multi-tenant scheduling.
+- Removing existing CLI flags or environment variables.
+- Changing wallet, Docker registry, or Antithesis API formats.
+

--- a/specs/102-agent-file-backed-config/plan.md
+++ b/specs/102-agent-file-backed-config/plan.md
@@ -54,7 +54,7 @@ Per-tenant values that currently have source-level defaults or hard-coded
 values should become explicit configuration. In particular:
 
 - Registry should be configurable through `--registry`, `MOOG_REGISTRY`, and
-  `registry`.
+  `registry`, with no source-level tenant default.
 - Antithesis launch URL should be configurable through `--launch-url`,
   `MOOG_ANTITHESIS_LAUNCH_URL`, and `antithesisLaunchUrl`, then threaded into
   the code path that renders the Antithesis launch request.
@@ -63,6 +63,22 @@ values should become explicit configuration. In particular:
 
 Environment variables and CLI flags must remain supported. Precedence should
 follow existing `opt-env-conf` semantics and must be covered by tests.
+
+## Resolved Decisions Before Implementation
+
+- `registry` is required for `moog-agent` process startup and `agent push-test`.
+  Removing the previous Cardano Foundation source default is intentional so a
+  missing tenant registry fails closed.
+- `antithesisLaunchUrl` is required for every Antithesis push path and is
+  stored with the existing `AntithesisAuth` value. This keeps the launch URL
+  next to the credentials used by `renderPostToAntithesis` while avoiding a
+  second configuration loader.
+- Existing environment variables keep their current names. New environment
+  variables are limited to settings that had no existing environment source:
+  `MOOG_REGISTRY` and `MOOG_ANTITHESIS_LAUNCH_URL`.
+- The canonical deployed agent example should use stable `current` paths under
+  `/secrets/moog-agent/current/...`. Operators can repoint the `current`
+  symlink to `old` or `new` without editing Compose for each rotation.
 
 ## Slice Breakdown
 
@@ -138,18 +154,10 @@ full CI equivalence.
 
 ## Open Questions For Next Phase
 
-- Should `registry` remain optional with the current default for requester-style
-  ad hoc `push-test`, or should it become required everywhere to satisfy
-  fail-closed tenant behavior?
-- Should `antithesisLaunchUrl` be stored inside `AntithesisAuth` or a sibling
-  deployment/tenant configuration record?
-- Should the canonical compose example in `CD/moog-agent/docker-compose.yaml`
-  move to `/secrets/moog-agent/current/...`, or should only the documentation
-  show that operator rotation pattern?
+None. The implementation decisions above are the worker contract.
 
 ## Out Of Scope
 
 - Multi-tenant scheduling.
 - Removing existing CLI flags or environment variables.
 - Changing wallet, Docker registry, or Antithesis API formats.
-

--- a/specs/102-agent-file-backed-config/spec.md
+++ b/specs/102-agent-file-backed-config/spec.md
@@ -1,0 +1,97 @@
+# Feature Specification: moog-agent File-backed Configuration
+
+## Issue
+
+cardano-foundation/moog#102
+
+## P1 User Story
+
+As a `MOOG operator`, I switch a deployed `moog-agent` between old and new
+Antithesis configuration files and observe the agent use the selected
+configuration without editing Docker Compose environment variables.
+
+## Command-Recovery
+
+Yes. This touches the shipped `moog-agent` process startup and configuration
+surface. The delivered proof must exercise the operator-facing command/config
+path, not only internal parser helpers.
+
+## Problem Statement
+
+`moog-agent` already loads a YAML file through `--secrets-file` /
+`MOOG_SECRETS_FILE`, and several sensitive values are already file-backed
+through that path. The deployed agent still requires some Antithesis/runtime
+settings to live in Docker Compose environment variables or source defaults.
+
+That split makes operational rotation awkward. An operator should be able to
+keep Compose pointed at stable mounted paths and switch from an old config set
+to a new config set by changing files or a `current` symlink, without editing
+the Compose file for each rotation.
+
+## Current Findings
+
+- `secrets.yaml` already supports keys such as `githubPAT`, `agentEmail`,
+  `agentEmailPassword`, `antithesisPassword`, `trustedRequesters`,
+  `slackWebhook`, and wallet passphrase/material where applicable.
+- `moog-agent` still needs additional deploy-time settings outside YAML,
+  including Antithesis username, registry, launch URL, MPFS host, token id,
+  wait behavior, poll interval, result lookback minutes, and MPFS timeout.
+- `DOCKER_CONFIG` is a Docker CLI/runtime concern. It can remain an environment
+  variable if Compose points it at a stable mounted directory such as
+  `/run/secrets/docker`.
+- Related issue #92 covers multiple Antithesis tenants. This issue is narrower:
+  one deployed agent instance should be fully configurable from file-backed
+  settings for rotation.
+
+## Functional Requirements
+
+- FR-001: `moog-agent --help` documents config-file keys for all agent
+  Antithesis/runtime settings needed to launch and report tests, including
+  Antithesis username, registry, launch URL, credentials, email settings,
+  requester trust configuration, MPFS host, token id, wait/poll behavior,
+  result lookback minutes, and MPFS timeout.
+- FR-002: `moog-agent --secrets-file /path/to/agent.yaml` accepts the above
+  values from YAML without requiring Compose to encode tenant-specific or
+  rotation-specific values.
+- FR-003: Existing environment variables and CLI flags continue to work.
+- FR-004: Precedence is documented and tested. Explicit CLI/env values must
+  override YAML values according to the existing option parser semantics.
+- FR-005: Deployment documentation includes a complete file-backed agent
+  configuration example.
+- FR-006: Deployment documentation includes a stable-path rotation pattern such
+  as `/secrets/moog-agent/current -> old|new` without editing Compose.
+- FR-007: The implementation fails closed when a required per-tenant setting is
+  absent instead of silently using the wrong tenant.
+
+## Acceptance Criteria
+
+- [ ] `moog-agent --help` includes `config:` entries for the newly file-backed
+      settings.
+- [ ] A parser or command-level test proves `moog-agent --secrets-file` can
+      load the required file-backed settings.
+- [ ] A precedence test proves an explicit CLI/env value overrides a YAML value.
+- [ ] Documentation shows the complete YAML shape for the agent.
+- [ ] Documentation shows the stable Compose mount and `current` symlink
+      rotation model.
+
+## Assumptions
+
+- The existing `opt-env-conf` YAML integration remains the single source of
+  parser behavior; this feature should extend existing parsers rather than add
+  a separate configuration loader.
+- Wallet files and Docker registry config files may remain separate mounted
+  files. The goal is stable file-backed deployment configuration, not merging
+  every secret into one YAML document.
+- The final implementation may choose exact YAML key names during planning, but
+  they should be explicit, documented, and visible in `--help`.
+
+## Non-goals
+
+- Do not implement full multi-tenant scheduling or tenant selection beyond
+  enabling one agent instance to load its complete configuration from files.
+- Do not remove existing environment variables or CLI options.
+- Do not change wallet formats.
+- Do not change Antithesis API semantics.
+- Do not change Docker registry authentication semantics.
+- Do not require operators to store raw Docker credentials inside the YAML file.
+

--- a/specs/102-agent-file-backed-config/tasks.md
+++ b/specs/102-agent-file-backed-config/tasks.md
@@ -23,9 +23,10 @@ nix develop --quiet -c cabal test unit-tests --test-show-details=direct --test-o
 
 Tasks:
 
-- [ ] T102-S1 Add failing unit coverage for `moog-agent` file-backed runtime configuration in `test/User/Agent/*`.
-- [ ] T102-S1 Add a failing precedence test proving an explicit environment value overrides a YAML value in `test/User/Agent/*`.
+- [ ] T102-S1 Add failing unit coverage for `moog-agent` file-backed runtime configuration in `test/User/Agent/*`, using a temporary YAML file and temporary wallet JSON.
+- [ ] T102-S1 Add a failing precedence test proving an explicit environment value such as `MOOG_TOKEN_ID` overrides a YAML value in `test/User/Agent/*`.
 - [ ] T102-S1 Add `conf` keys for token id, MPFS host, wait behavior, MPFS timeout, poll interval, result lookback minutes, registry, Antithesis username, and wallet file path where needed in `src/Core/Options.hs`, `src/Core/Types/MPFS.hs`, `src/Core/Types/Mnemonics/Options.hs`, `src/Oracle/Process.hs`, and `src/User/Agent/Options.hs`.
+- [ ] T102-S1 Remove the source-level registry tenant default and add `MOOG_REGISTRY` as the explicit environment source for registry configuration.
 - [ ] T102-S1 Update `moog.cabal` only if the slice adds a new unit test module.
 - [ ] T102-S1 Run the focused unit test and the branch gate before committing.
 
@@ -44,7 +45,7 @@ Tasks:
 
 - [ ] T102-S2 Add failing unit coverage showing the rendered Antithesis launch request uses the configured launch URL in `test/User/Agent/PushTestSpec.hs` or a focused neighboring test module.
 - [ ] T102-S2 Add `--launch-url`, `MOOG_ANTITHESIS_LAUNCH_URL`, and `antithesisLaunchUrl` support in `src/User/Agent/Options.hs`.
-- [ ] T102-S2 Thread the launch URL into the Antithesis request rendering path in `src/User/Agent/PushTest.hs` and, if required by the chosen data shape, `src/User/Agent/Process.hs`.
+- [ ] T102-S2 Store the launch URL with `AntithesisAuth` and thread it into the Antithesis request rendering path in `src/User/Agent/PushTest.hs` and any call sites that construct or pattern-match `AntithesisAuth`.
 - [ ] T102-S2 Ensure required tenant-specific launch URL configuration fails closed when absent rather than silently using the previous tenant.
 - [ ] T102-S2 Run the focused unit test and the branch gate before committing.
 
@@ -64,7 +65,7 @@ Tasks:
 - [ ] T102-S3 Document the complete agent YAML shape in `docs/user/secrets-management.md`, including newly file-backed runtime keys and existing secret keys.
 - [ ] T102-S3 Document the stable `/secrets/moog-agent/current -> old|new` rotation pattern in `docs/ops/deployment.md`.
 - [ ] T102-S3 Align the agent operations configuration table in `docs/ops/agent-role.md` if it would otherwise contradict the new file-backed configuration path.
-- [ ] T102-S3 Update `CD/moog-agent/docker-compose.yaml` only if the canonical compose example should use `/secrets/moog-agent/current/...`; otherwise keep that change documentation-only.
+- [ ] T102-S3 Update `CD/moog-agent/docker-compose.yaml` so the canonical compose example uses `/secrets/moog-agent/current/...` stable paths.
 - [ ] T102-S3 Run the branch gate before committing.
 
 ## Branch Gate
@@ -104,4 +105,3 @@ Slice 3 may be drafted in parallel only after the exact key names from Slices 1
 and 2 are stable. If documentation touches `CD/moog-agent/docker-compose.yaml`,
 serialize it with implementation review because it changes the deployable
 example.
-

--- a/specs/102-agent-file-backed-config/tasks.md
+++ b/specs/102-agent-file-backed-config/tasks.md
@@ -23,12 +23,12 @@ nix develop --quiet -c cabal test unit-tests --test-show-details=direct --test-o
 
 Tasks:
 
-- [ ] T102-S1 Add failing unit coverage for `moog-agent` file-backed runtime configuration in `test/User/Agent/*`, using a temporary YAML file and temporary wallet JSON.
-- [ ] T102-S1 Add a failing precedence test proving an explicit environment value such as `MOOG_TOKEN_ID` overrides a YAML value in `test/User/Agent/*`.
-- [ ] T102-S1 Add `conf` keys for token id, MPFS host, wait behavior, MPFS timeout, poll interval, result lookback minutes, registry, Antithesis username, and wallet file path where needed in `src/Core/Options.hs`, `src/Core/Types/MPFS.hs`, `src/Core/Types/Mnemonics/Options.hs`, `src/Oracle/Process.hs`, and `src/User/Agent/Options.hs`.
-- [ ] T102-S1 Remove the source-level registry tenant default and add `MOOG_REGISTRY` as the explicit environment source for registry configuration.
-- [ ] T102-S1 Update `moog.cabal` only if the slice adds a new unit test module.
-- [ ] T102-S1 Run the focused unit test and the branch gate before committing.
+- [X] T102-S1 Add failing unit coverage for `moog-agent` file-backed runtime configuration in `test/User/Agent/*`, using a temporary YAML file and temporary wallet JSON.
+- [X] T102-S1 Add a failing precedence test proving an explicit environment value such as `MOOG_TOKEN_ID` overrides a YAML value in `test/User/Agent/*`.
+- [X] T102-S1 Add `conf` keys for token id, MPFS host, wait behavior, MPFS timeout, poll interval, result lookback minutes, registry, Antithesis username, and wallet file path where needed in `src/Core/Options.hs`, `src/Core/Types/MPFS.hs`, `src/Core/Types/Mnemonics/Options.hs`, `src/Oracle/Process.hs`, and `src/User/Agent/Options.hs`.
+- [X] T102-S1 Remove the source-level registry tenant default and add `MOOG_REGISTRY` as the explicit environment source for registry configuration.
+- [X] T102-S1 Update `moog.cabal` only if the slice adds a new unit test module.
+- [X] T102-S1 Run the focused unit test and the branch gate before committing.
 
 ## Slice 2 — Antithesis Launch URL Threading
 

--- a/specs/102-agent-file-backed-config/tasks.md
+++ b/specs/102-agent-file-backed-config/tasks.md
@@ -1,0 +1,107 @@
+# Tasks: moog-agent File-backed Configuration
+
+## Issue
+
+cardano-foundation/moog#102
+
+## Acceptance Target
+
+After all slices land, a deployed `moog-agent` can load its Antithesis/runtime
+configuration from a YAML file selected through stable mounted paths, while
+existing CLI flags and environment variables continue to work.
+
+## Slice 1 — Parser Config Keys And Tests
+
+Goal: extend the existing `opt-env-conf` parser surface so the agent runtime
+settings have documented YAML keys, and prove YAML parsing plus precedence.
+
+Independent proof:
+
+```bash
+nix develop --quiet -c cabal test unit-tests --test-show-details=direct --test-options='--match agent file-backed configuration'
+```
+
+Tasks:
+
+- [ ] T102-S1 Add failing unit coverage for `moog-agent` file-backed runtime configuration in `test/User/Agent/*`.
+- [ ] T102-S1 Add a failing precedence test proving an explicit environment value overrides a YAML value in `test/User/Agent/*`.
+- [ ] T102-S1 Add `conf` keys for token id, MPFS host, wait behavior, MPFS timeout, poll interval, result lookback minutes, registry, Antithesis username, and wallet file path where needed in `src/Core/Options.hs`, `src/Core/Types/MPFS.hs`, `src/Core/Types/Mnemonics/Options.hs`, `src/Oracle/Process.hs`, and `src/User/Agent/Options.hs`.
+- [ ] T102-S1 Update `moog.cabal` only if the slice adds a new unit test module.
+- [ ] T102-S1 Run the focused unit test and the branch gate before committing.
+
+## Slice 2 — Antithesis Launch URL Threading
+
+Goal: remove the hard-coded Antithesis launch URL from the request path and
+make it explicit file/env/CLI-backed configuration.
+
+Independent proof:
+
+```bash
+nix develop --quiet -c cabal test unit-tests --test-show-details=direct --test-options='--match renderPostToAntithesis'
+```
+
+Tasks:
+
+- [ ] T102-S2 Add failing unit coverage showing the rendered Antithesis launch request uses the configured launch URL in `test/User/Agent/PushTestSpec.hs` or a focused neighboring test module.
+- [ ] T102-S2 Add `--launch-url`, `MOOG_ANTITHESIS_LAUNCH_URL`, and `antithesisLaunchUrl` support in `src/User/Agent/Options.hs`.
+- [ ] T102-S2 Thread the launch URL into the Antithesis request rendering path in `src/User/Agent/PushTest.hs` and, if required by the chosen data shape, `src/User/Agent/Process.hs`.
+- [ ] T102-S2 Ensure required tenant-specific launch URL configuration fails closed when absent rather than silently using the previous tenant.
+- [ ] T102-S2 Run the focused unit test and the branch gate before committing.
+
+## Slice 3 — Deployment Documentation
+
+Goal: document the complete operator-facing file-backed configuration and the
+stable-path rotation pattern.
+
+Independent proof:
+
+```bash
+git diff --check
+```
+
+Tasks:
+
+- [ ] T102-S3 Document the complete agent YAML shape in `docs/user/secrets-management.md`, including newly file-backed runtime keys and existing secret keys.
+- [ ] T102-S3 Document the stable `/secrets/moog-agent/current -> old|new` rotation pattern in `docs/ops/deployment.md`.
+- [ ] T102-S3 Align the agent operations configuration table in `docs/ops/agent-role.md` if it would otherwise contradict the new file-backed configuration path.
+- [ ] T102-S3 Update `CD/moog-agent/docker-compose.yaml` only if the canonical compose example should use `/secrets/moog-agent/current/...`; otherwise keep that change documentation-only.
+- [ ] T102-S3 Run the branch gate before committing.
+
+## Branch Gate
+
+Each worker slice must run the focused proof for the slice and then the branch
+gate:
+
+```bash
+git diff --check
+nix develop --quiet -c cabal build all --enable-tests
+nix develop --quiet -c cabal test unit-tests --test-show-details=direct
+nix develop --quiet -c cabal-fmt -c moog.cabal CI/rewrite-libs/rewrite-libs.cabal
+nix develop --quiet -c fourmolu -m check src app test CI/rewrite-libs
+nix develop --quiet -c hlint -c src app test CI/rewrite-libs
+```
+
+If integration/E2E credentials or wallet fixtures are unavailable, record that
+limitation in `WIP.md` and in the PR body. Do not claim `just CI` equivalence
+without running it.
+
+## Dependency Order
+
+1. Slice 1 must land before Slice 2 because launch URL parsing builds on the
+   same parser/config conventions.
+2. Slice 2 must land before Slice 3 so documentation reflects the final
+   behavior rather than a planned API shape.
+3. Slice 3 can be reviewed independently once Slices 1 and 2 define the exact
+   key names and compose behavior.
+
+## Parallelization Notes
+
+Do not run Slices 1 and 2 in parallel: both may touch
+`src/User/Agent/Options.hs`, tests under `test/User/Agent/*`, and possibly
+`moog.cabal`.
+
+Slice 3 may be drafted in parallel only after the exact key names from Slices 1
+and 2 are stable. If documentation touches `CD/moog-agent/docker-compose.yaml`,
+serialize it with implementation review because it changes the deployable
+example.
+

--- a/specs/102-agent-file-backed-config/tasks.md
+++ b/specs/102-agent-file-backed-config/tasks.md
@@ -62,11 +62,11 @@ git diff --check
 
 Tasks:
 
-- [ ] T102-S3 Document the complete agent YAML shape in `docs/user/secrets-management.md`, including newly file-backed runtime keys and existing secret keys.
-- [ ] T102-S3 Document the stable `/secrets/moog-agent/current -> old|new` rotation pattern in `docs/ops/deployment.md`.
-- [ ] T102-S3 Align the agent operations configuration table in `docs/ops/agent-role.md` if it would otherwise contradict the new file-backed configuration path.
-- [ ] T102-S3 Update `CD/moog-agent/docker-compose.yaml` so the canonical compose example uses `/secrets/moog-agent/current/...` stable paths.
-- [ ] T102-S3 Run the branch gate before committing.
+- [X] T102-S3 Document the complete agent YAML shape in `docs/user/secrets-management.md`, including newly file-backed runtime keys and existing secret keys.
+- [X] T102-S3 Document the stable `/secrets/moog-agent/current -> old|new` rotation pattern in `docs/ops/deployment.md`.
+- [X] T102-S3 Align the agent operations configuration table in `docs/ops/agent-role.md` if it would otherwise contradict the new file-backed configuration path.
+- [X] T102-S3 Update `CD/moog-agent/docker-compose.yaml` so the canonical compose example uses `/secrets/moog-agent/current/...` stable paths.
+- [X] T102-S3 Run the branch gate before committing.
 
 ## Branch Gate
 

--- a/specs/102-agent-file-backed-config/tasks.md
+++ b/specs/102-agent-file-backed-config/tasks.md
@@ -43,11 +43,11 @@ nix develop --quiet -c cabal test unit-tests --test-show-details=direct --test-o
 
 Tasks:
 
-- [ ] T102-S2 Add failing unit coverage showing the rendered Antithesis launch request uses the configured launch URL in `test/User/Agent/PushTestSpec.hs` or a focused neighboring test module.
-- [ ] T102-S2 Add `--launch-url`, `MOOG_ANTITHESIS_LAUNCH_URL`, and `antithesisLaunchUrl` support in `src/User/Agent/Options.hs`.
-- [ ] T102-S2 Store the launch URL with `AntithesisAuth` and thread it into the Antithesis request rendering path in `src/User/Agent/PushTest.hs` and any call sites that construct or pattern-match `AntithesisAuth`.
-- [ ] T102-S2 Ensure required tenant-specific launch URL configuration fails closed when absent rather than silently using the previous tenant.
-- [ ] T102-S2 Run the focused unit test and the branch gate before committing.
+- [X] T102-S2 Add failing unit coverage showing the rendered Antithesis launch request uses the configured launch URL in `test/User/Agent/PushTestSpec.hs` or a focused neighboring test module.
+- [X] T102-S2 Add `--launch-url`, `MOOG_ANTITHESIS_LAUNCH_URL`, and `antithesisLaunchUrl` support in `src/User/Agent/Options.hs`.
+- [X] T102-S2 Store the launch URL with `AntithesisAuth` and thread it into the Antithesis request rendering path in `src/User/Agent/PushTest.hs` and any call sites that construct or pattern-match `AntithesisAuth`.
+- [X] T102-S2 Ensure required tenant-specific launch URL configuration fails closed when absent rather than silently using the previous tenant.
+- [X] T102-S2 Run the focused unit test and the branch gate before committing.
 
 ## Slice 3 — Deployment Documentation
 

--- a/src/Core/Options.hs
+++ b/src/Core/Options.hs
@@ -46,6 +46,7 @@ import OptEnvConf
     ( Parser
     , auto
     , checkEither
+    , conf
     , env
     , help
     , long
@@ -244,6 +245,7 @@ tokenIdOption =
     TokenId
         <$> setting
             [ env "MOOG_TOKEN_ID"
+            , conf "tokenId"
             , metavar "TOKEN_ID"
             , help "The token ID of the antithesis token"
             , reader str

--- a/src/Core/Types/MPFS.hs
+++ b/src/Core/Types/MPFS.hs
@@ -57,7 +57,6 @@ newMPFSClient = do
                     \to be included in a block (omit to skip waiting)"
                 , reader auto
                 ]
-    let wait = maybe NoWait Wait mWaitCycles
     timeoutSeconds <-
         setting
             [ metavar "SECONDS"
@@ -67,6 +66,7 @@ newMPFSClient = do
             , reader auto
             , value 120
             ]
+    let wait = maybe NoWait Wait mWaitCycles
     pure (host, wait, timeoutSeconds)
 
 timeout :: Int -> ManagerSettings -> ManagerSettings

--- a/src/Core/Types/MPFS.hs
+++ b/src/Core/Types/MPFS.hs
@@ -41,23 +41,29 @@ newMPFSClient = do
     host <-
         setting
             [ env "MOOG_MPFS_HOST"
+            , conf "mpfsHost"
             , metavar "HOST"
             , help "The host of the MPFS server"
             , reader str
             ]
-    wait <-
-        setting
-            [ env "MOOG_WAIT"
-            , metavar "WAIT"
-            , help "Whether to wait for the transaction to be included in a block"
-            , reader $ Wait <$> auto
-            , value NoWait
-            ]
+    mWaitCycles <-
+        optional
+            $ setting
+                [ env "MOOG_WAIT"
+                , conf "wait"
+                , metavar "WAIT"
+                , help
+                    "Number of polling cycles to wait for a transaction \
+                    \to be included in a block (omit to skip waiting)"
+                , reader auto
+                ]
+    let wait = maybe NoWait Wait mWaitCycles
     timeoutSeconds <-
         setting
             [ metavar "SECONDS"
             , help "Timeout in seconds for MPFS requests"
             , env "MOOG_MPFS_TIMEOUT_SECONDS"
+            , conf "mpfsTimeoutSeconds"
             , reader auto
             , value 120
             ]

--- a/src/Core/Types/MPFS.hs
+++ b/src/Core/Types/MPFS.hs
@@ -37,18 +37,18 @@ data MPFSClient = MPFSClient
     }
 
 newMPFSClient :: Parser (String, IfToWait, Int)
-newMPFSClient = do
-    host <-
-        setting
+newMPFSClient =
+    (\host mWaitCycles timeoutSeconds ->
+        (host, maybe NoWait Wait mWaitCycles, timeoutSeconds))
+        <$> setting
             [ env "MOOG_MPFS_HOST"
             , conf "mpfsHost"
             , metavar "HOST"
             , help "The host of the MPFS server"
             , reader str
             ]
-    mWaitCycles <-
-        optional
-            $ setting
+        <*> optional
+            ( setting
                 [ env "MOOG_WAIT"
                 , conf "wait"
                 , metavar "WAIT"
@@ -57,8 +57,8 @@ newMPFSClient = do
                     \to be included in a block (omit to skip waiting)"
                 , reader auto
                 ]
-    timeoutSeconds <-
-        setting
+            )
+        <*> setting
             [ metavar "SECONDS"
             , help "Timeout in seconds for MPFS requests"
             , env "MOOG_MPFS_TIMEOUT_SECONDS"
@@ -66,8 +66,6 @@ newMPFSClient = do
             , reader auto
             , value 120
             ]
-    let wait = maybe NoWait Wait mWaitCycles
-    pure (host, wait, timeoutSeconds)
 
 timeout :: Int -> ManagerSettings -> ManagerSettings
 timeout tOut r =

--- a/src/Core/Types/Mnemonics/Options.hs
+++ b/src/Core/Types/Mnemonics/Options.hs
@@ -66,6 +66,7 @@ walletFileOption :: Parser FilePath
 walletFileOption =
     setting
         [ env "MOOG_WALLET_FILE"
+        , conf "walletFile"
         , metavar "FILEPATH"
         , help "The file path to the wallet secret mnemonics"
         , long "wallet"

--- a/src/Oracle/Process.hs
+++ b/src/Oracle/Process.hs
@@ -110,6 +110,7 @@ pollIntervalOption =
         , metavar "SECONDS"
         , help "Interval in seconds between polling for new requests"
         , env "POLL_INTERVAL_SECONDS"
+        , conf "pollIntervalSeconds"
         , reader auto
         , option
         , value 30

--- a/src/User/Agent/Options.hs
+++ b/src/User/Agent/Options.hs
@@ -134,6 +134,7 @@ minutesOption =
             , help
                 "Number of minutes in the past to check for test results (default: 1440)"
             , metavar "MINUTES"
+            , conf "minutes"
             , reader auto
             , value 1440
             , option
@@ -194,6 +195,7 @@ registryOption =
             , metavar "REGISTRY_URL"
             , long "registry"
             , env "MOOG_REGISTRY"
+            , conf "registry"
             , reader str
             , option
             ]
@@ -216,6 +218,7 @@ antithesisUserOption :: Parser String
 antithesisUserOption =
     setting
         [ env "MOOG_ANTITHESIS_USER"
+        , conf "antithesisUser"
         , metavar "ANTITHESIS_USER"
         , help "The username of the Antithesis account"
         , reader str

--- a/src/User/Agent/PublishResults/Email.hs
+++ b/src/User/Agent/PublishResults/Email.hs
@@ -65,7 +65,6 @@ import Data.Time.Clock.POSIX
     ( posixSecondsToUTCTime
     , utcTimeToPOSIXSeconds
     )
-import Data.Typeable (Typeable)
 import Lib.JSON.Canonical.Extra (object, (.=))
 import Network.HaskellNet.IMAP
     ( SearchQuery
@@ -123,7 +122,7 @@ data EmailException where
     SelectFailed :: IOError -> EmailException
     SearchFailed :: IOError -> EmailException
     FetchFailed :: IOError -> EmailException
-    deriving (Show, Typeable, Eq)
+    deriving (Show, Eq)
 
 instance Exception EmailException
 

--- a/test/User/Agent/ProcessOptionsSpec.hs
+++ b/test/User/Agent/ProcessOptionsSpec.hs
@@ -52,8 +52,7 @@ agentEnvVars =
     ]
 
 withScrubbedEnv :: IO a -> IO a
-withScrubbedEnv =
-    bracket_ (saveAndUnset agentEnvVars) restoreAll . const
+withScrubbedEnv = bracket_ (saveAndUnset agentEnvVars) restoreAll
   where
     saveAndUnset xs = mapM_ unsetEnv xs >> pure ()
     restoreAll = pure ()

--- a/test/User/Agent/ProcessOptionsSpec.hs
+++ b/test/User/Agent/ProcessOptionsSpec.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module User.Agent.ProcessOptionsSpec
+    ( spec
+    )
+where
+
+import Control.Exception (bracket_)
+import Core.Types.Basic (TokenId (..))
+import System.Environment
+    ( lookupEnv
+    , setEnv
+    , unsetEnv
+    , withArgs
+    )
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec (Spec, describe, it, shouldBe)
+import User.Agent.Process
+    ( ProcessOptions (..)
+    , parseArgs
+    )
+import User.Agent.PublishResults.Email (Minutes (..))
+import User.Agent.PushTest
+    ( AntithesisAuth (..)
+    , LaunchUrl (..)
+    , Registry (..)
+    )
+
+-- | Names of every environment variable that the agent parser reads.
+-- The list is used to scrub the environment for hermetic tests so that
+-- a caller's shell cannot bleed values into the parser under test.
+agentEnvVars :: [String]
+agentEnvVars =
+    [ "MOOG_SECRETS_FILE"
+    , "MOOG_INTERACTIVE_SECRETS"
+    , "MOOG_GITHUB_PAT"
+    , "MOOG_WALLET_FILE"
+    , "MOOG_TOKEN_ID"
+    , "MOOG_MPFS_HOST"
+    , "MOOG_WAIT"
+    , "MOOG_MPFS_TIMEOUT_SECONDS"
+    , "POLL_INTERVAL_SECONDS"
+    , "MOOG_AGENT_EMAIL"
+    , "MOOG_AGENT_EMAIL_PASSWORD"
+    , "MOOG_ANTITHESIS_USER"
+    , "MOOG_ANTITHESIS_PASSWORD"
+    , "MOOG_ANTITHESIS_LAUNCH_URL"
+    , "MOOG_REGISTRY"
+    , "MOOG_SLACK_WEBHOOK"
+    , "MOOG_WALLET_PASSPHRASE"
+    ]
+
+withScrubbedEnv :: IO a -> IO a
+withScrubbedEnv =
+    bracket_ (saveAndUnset agentEnvVars) restoreAll . const
+  where
+    saveAndUnset xs = mapM_ unsetEnv xs >> pure ()
+    restoreAll = pure ()
+
+-- | Temporarily set an env var inside an IO action, restoring whatever
+-- value (or absence) the variable had before.
+withEnv :: String -> String -> IO a -> IO a
+withEnv name v action = do
+    mPrev <- lookupEnv name
+    bracket_ (setEnv name v) (restore mPrev) action
+  where
+    restore Nothing = unsetEnv name
+    restore (Just old) = setEnv name old
+
+walletJsonContent :: String
+walletJsonContent =
+    "{\"mnemonics\":\"coin april solid purity wish slight \
+    \acquire kitchen dragon faculty clutch picnic\"}"
+
+agentYamlContent :: FilePath -> String
+agentYamlContent walletPath =
+    unlines
+        [ "githubPAT: test-github-token"
+        , "walletFile: " ++ walletPath
+        , "tokenId: yaml-token"
+        , "mpfsHost: http://127.0.0.1:38081"
+        , "wait: 9"
+        , "mpfsTimeoutSeconds: 9"
+        , "pollIntervalSeconds: 7"
+        , "minutes: 11"
+        , "registry: registry.example.invalid/moog"
+        , "antithesisUser: ant-user"
+        , "antithesisPassword: ant-pass"
+        , "antithesisLaunchUrl: https://example.invalid/api/v1/launch/cardano"
+        , "agentEmail: agent@example.invalid"
+        , "agentEmailPassword: email-pass"
+        , "trustedRequesters:"
+        , "  - alice"
+        ]
+
+writeFixtures :: FilePath -> IO (FilePath, FilePath)
+writeFixtures tmp = do
+    let walletPath = tmp </> "agent-wallet.json"
+        yamlPath = tmp </> "agent.yaml"
+    writeFile walletPath walletJsonContent
+    writeFile yamlPath (agentYamlContent walletPath)
+    pure (walletPath, yamlPath)
+
+withParsedAgent
+    :: [String]
+    -- ^ extra command-line arguments
+    -> (ProcessOptions -> IO ())
+    -> IO ()
+withParsedAgent extraArgs k =
+    withScrubbedEnv $ withSystemTempDirectory "moog-agent-conf" $ \tmp -> do
+        (_walletPath, yamlPath) <- writeFixtures tmp
+        let args =
+                [ "--secrets-file"
+                , yamlPath
+                , "--trust-all-requesters"
+                ]
+                    ++ extraArgs
+        opts <- withArgs args parseArgs
+        k opts
+
+spec :: Spec
+spec = describe "agent file-backed configuration" $ do
+    it "loads runtime settings from a YAML secrets file" $ do
+        withParsedAgent [] $ \opts -> do
+            poTokenId opts `shouldBe` TokenId "yaml-token"
+            poPollIntervalSeconds opts `shouldBe` 7
+            poMinutes opts `shouldBe` Minutes 11
+            poRegistry opts `shouldBe` Registry "registry.example.invalid/moog"
+            poAntithesisAuth opts
+                `shouldBe` AntithesisAuth
+                    { username = "ant-user"
+                    , password = "ant-pass"
+                    , launchUrl =
+                        LaunchUrl
+                            "https://example.invalid/api/v1/launch/cardano"
+                    }
+    it "lets MOOG_TOKEN_ID override the YAML tokenId value" $ do
+        withScrubbedEnv $ withEnv "MOOG_TOKEN_ID" "env-token" $ do
+            withSystemTempDirectory "moog-agent-conf-prec" $ \tmp -> do
+                (_walletPath, yamlPath) <- writeFixtures tmp
+                let args =
+                        [ "--secrets-file"
+                        , yamlPath
+                        , "--trust-all-requesters"
+                        ]
+                opts <- withArgs args parseArgs
+                poTokenId opts `shouldBe` TokenId "env-token"

--- a/test/User/Agent/ProcessOptionsSpec.hs
+++ b/test/User/Agent/ProcessOptionsSpec.hs
@@ -5,17 +5,32 @@ module User.Agent.ProcessOptionsSpec
     )
 where
 
-import Control.Exception (bracket_)
+import Control.Exception (bracket, bracket_, try)
 import Core.Types.Basic (TokenId (..))
+import Data.List (isPrefixOf)
+import GHC.IO.Handle (hDuplicate, hDuplicateTo)
 import System.Environment
     ( lookupEnv
     , setEnv
     , unsetEnv
     , withArgs
     )
+import System.Exit (ExitCode (..))
 import System.FilePath ((</>))
+import System.IO
+    ( IOMode (..)
+    , hClose
+    , stderr
+    , withFile
+    )
 import System.IO.Temp (withSystemTempDirectory)
-import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    )
 import User.Agent.Process
     ( ProcessOptions (..)
     , parseArgs
@@ -57,6 +72,17 @@ withScrubbedEnv = bracket_ (saveAndUnset agentEnvVars) restoreAll
     saveAndUnset xs = mapM_ unsetEnv xs >> pure ()
     restoreAll = pure ()
 
+-- | Redirect stderr to /dev/null for the duration of the action. Used to
+-- suppress the OptEnvConf error renderer when a test deliberately triggers
+-- a parse failure.
+silenceStderr :: IO a -> IO a
+silenceStderr action =
+    withFile "/dev/null" WriteMode $ \devNull ->
+        bracket
+            (hDuplicate stderr)
+            (\saved -> hDuplicateTo saved stderr >> hClose saved)
+            (\_ -> hDuplicateTo devNull stderr >> action)
+
 -- | Temporarily set an env var inside an IO action, restoring whatever
 -- value (or absence) the variable had before.
 withEnv :: String -> String -> IO a -> IO a
@@ -92,6 +118,15 @@ agentYamlContent walletPath =
         , "trustedRequesters:"
         , "  - alice"
         ]
+
+-- | Variant of 'agentYamlContent' with the @antithesisLaunchUrl@ key removed,
+-- so the parser sees no source for the tenant launch URL.
+agentYamlContentWithoutLaunchUrl :: FilePath -> String
+agentYamlContentWithoutLaunchUrl walletPath =
+    unlines
+        . filter (not . isPrefixOf "antithesisLaunchUrl")
+        . lines
+        $ agentYamlContent walletPath
 
 writeFixtures :: FilePath -> IO (FilePath, FilePath)
 writeFixtures tmp = do
@@ -145,3 +180,30 @@ spec = describe "agent file-backed configuration" $ do
                         ]
                 opts <- withArgs args parseArgs
                 poTokenId opts `shouldBe` TokenId "env-token"
+    it "fails closed when no launch URL is supplied" $ do
+        withScrubbedEnv
+            $ withSystemTempDirectory "moog-agent-conf-no-url"
+            $ \tmp -> do
+                let walletPath = tmp </> "agent-wallet.json"
+                    yamlPath = tmp </> "agent.yaml"
+                writeFile walletPath walletJsonContent
+                writeFile
+                    yamlPath
+                    (agentYamlContentWithoutLaunchUrl walletPath)
+                let args =
+                        [ "--secrets-file"
+                        , yamlPath
+                        , "--trust-all-requesters"
+                        ]
+                result <-
+                    try $ silenceStderr $ withArgs args parseArgs
+                case result of
+                    Left (ExitFailure _) -> pure ()
+                    Left ExitSuccess ->
+                        expectationFailure
+                            "parser returned ExitSuccess; expected\
+                            \ ExitFailure for missing launch URL"
+                    Right _ ->
+                        expectationFailure
+                            "parser succeeded; expected ExitFailure\
+                            \ when antithesisLaunchUrl is unset"


### PR DESCRIPTION
## Summary

Closes #102. Wires the existing `opt-env-conf` parser surface so a deployed `moog-agent` can load its complete Antithesis/runtime configuration from a single YAML file, with the stable `/secrets/moog-agent/current -> old|new` rotation pattern documented. Rotation no longer requires editing `docker-compose.yaml`.

## What changed

### Slice 1 — Parser config keys (`feat: add file-backed agent runtime config`)

Adds `conf "<key>"` entries to the existing `setting`/`secretsParser` declarations so the agent reads the following from `secrets.yaml` alongside the existing CLI/env sources:

- `tokenId`, `mpfsHost`, `wait`, `mpfsTimeoutSeconds`, `walletFile`, `pollIntervalSeconds`, `minutes`, `registry`, `antithesisUser`.

The MPFS `wait` parser is restructured to read `Maybe Int` and map to `IfToWait` (operator-facing semantics unchanged: `MOOG_WAIT=240` still yields `Wait 240`).

`test/User/Agent/ProcessOptionsSpec.hs` drives `parseArgs` through a temp YAML + wallet JSON and asserts (a) every key is honoured from the file and (b) `MOOG_TOKEN_ID` overrides the YAML value.

### Slice 2 — Launch URL fails-closed assertion (`test(agent): assert launch URL parser fails closed when unset`)

The launch URL field on `AntithesisAuth` and its parser were delivered by [`1d76344a`](https://github.com/cardano-foundation/moog/commit/1d76344a) (PR #93). This slice adds the matching `ProcessOptionsSpec` case that drives `parseArgs` with **no** CLI / env / YAML source for `antithesisLaunchUrl` and asserts the parser exits with `ExitFailure`, locking in the no-default fail-closed behaviour against a future regression.

### Slice 3 — Deployment documentation (`docs(agent): document file-backed configuration and rotation pattern`)

- `docs/user/secrets-management.md`: complete YAML key table (runtime + secrets), precedence (CLI > env > YAML), wallet resolution.
- `docs/ops/deployment.md`: `/secrets/moog-agent/current` symlink layout and the rotation procedure (populate inactive side → repoint → `docker compose up -d --force-recreate moog-agent`). Calls out that plain `docker restart` does NOT re-read compose secrets — a real operational footgun.
- `docs/ops/agent-role.md`: env-var ↔ YAML key cross-reference.
- `CD/moog-agent/docker-compose.yaml`: canonical example mounts the `current/` paths; tenant-specific values move to YAML.

### Baseline fixes carried (chore commits, separate from the slices)

- `chore(nix): replace removed pkgs.gitAndTools.git with pkgs.git` — unblocks `nix develop` on current nixpkgs.
- `fix(email): drop redundant Typeable from EmailException` — GHC 9.12 raises `-Wderiving-typeable` and `-Werror` kills the build.
- `fix(mpfs): rewrite newMPFSClient with explicit Applicative` — ApplicativeDo couldn't desugar the do-block with `optional`; replaced with explicit `<$>` / `<*>`.
- `fix(test): drop spurious '. const' in withScrubbedEnv` — type error in slice 1's test setup.

## Verification

- Local: `nix build .#unit-tests` + `result/bin/unit-tests` → 132 examples, 0 failures (the new fails-closed test is `#132`).
- CI: unit-tests workflow green on the rebased SHA (other workflows still in flight at the time of writing; CSE failure of `gate.sh` locally is the documented cabal-fmt-0.1.12 vs base-4.21.1.0 baseline blocker, which CI does not exercise the same way).

## Out of scope

- Per spec, this PR does not implement multi-tenant scheduling, remove existing CLI/env options, change wallet formats, or change Antithesis API semantics.

Refs #102.