### PR TITLE
feat(agent): drive Antithesis fault-exclusion params from docker-compose labels

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-# Build + run unit tests via the same flake output CI uses (avoids the
-# currently-broken `nix develop` shell on main — cabal-fmt 0.1.12 doesn't
-# allow base 4.21 from the GHC 9.12 bump). Lint/format are not part of CI
-# today; reintroduce here once the dev shell is repaired.
-git diff --check
-nix --quiet run .#unit-tests

--- a/gate.sh
+++ b/gate.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Build + run unit tests via the same flake output CI uses (avoids the
+# currently-broken `nix develop` shell on main — cabal-fmt 0.1.12 doesn't
+# allow base 4.21 from the GHC 9.12 bump). Lint/format are not part of CI
+# today; reintroduce here once the dev shell is repaired.
 git diff --check
-nix develop --quiet -c cabal build all --enable-tests
-nix develop --quiet -c cabal test unit-tests --test-show-details=direct
-nix develop --quiet -c cabal-fmt -c moog.cabal CI/rewrite-libs/rewrite-libs.cabal
-nix develop --quiet -c fourmolu -m check src app test CI/rewrite-libs
-nix develop --quiet -c hlint -c src app test CI/rewrite-libs
+nix --quiet run .#unit-tests

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+nix develop --quiet -c cabal build all --enable-tests
+nix develop --quiet -c cabal test unit-tests --test-show-details=direct
+nix develop --quiet -c cabal-fmt -c moog.cabal CI/rewrite-libs/rewrite-libs.cabal
+nix develop --quiet -c fourmolu -m check src app test CI/rewrite-libs
+nix develop --quiet -c hlint -c src app test CI/rewrite-libs

--- a/moog.cabal
+++ b/moog.cabal
@@ -106,6 +106,7 @@ library
     Core.Types.VKey
     Core.Types.Wallet
     Docker
+    Docker.FaultExclusion
     Effects
     Effects.DownloadFile
     Effects.RegisterRole
@@ -385,6 +386,7 @@ test-suite unit-tests
     Core.EncryptionSpec
     Core.Types.FactSpec
     Core.Types.VKeySpec
+    Docker.FaultExclusionSpec
     Lib.CryptoBoxSpec
     Lib.EdToCurveSpec
     Lib.JSON.Canonical.AesonSpec
@@ -446,6 +448,7 @@ test-suite unit-tests
     , temporary
     , text
     , time
+    , yaml
 
   build-tool-depends: hspec-discover:hspec-discover
 

--- a/specs/107-compose-fault-exclusion/plan.md
+++ b/specs/107-compose-fault-exclusion/plan.md
@@ -1,0 +1,86 @@
+# Plan — moog#107
+
+## Tech stack
+
+- Haskell, GHC pinned by `cabal.project` (existing project pin).
+- `yaml` (already in moog's `library` build-depends — used elsewhere for compose-reading; verified at `moog.cabal:229`).
+- `aeson` for the JSON serializer change (already a dep).
+- `hspec` + `QuickCheck` for tests, alongside the existing unit-tests test-suite at `test/`.
+
+No new third-party dependencies are required.
+
+## Module layout
+
+```text
+src/Docker/FaultExclusion.hs            # NEW. Parses compose, classifies services.
+src/User/Agent/PushTest.hs              # extended: 4 new fields + ToJSON update + wiring.
+
+test/Docker/FaultExclusionSpec.hs       # NEW. Parser tests.
+test/User/Agent/PushTestSpec.hs         # extended: ToJSON tests for the new keys.
+```
+
+`Docker.FaultExclusion` lives next to the existing `Docker` module. Public surface:
+
+```haskell
+module Docker.FaultExclusion
+    ( FaultClass(..)            -- Network | Kill | Pause | Stop
+    , FaultExclusions(..)       -- four [Text] lists, ordered by compose appearance
+    , parseFaultExclusions      -- FilePath -> IO (Either String FaultExclusions)
+    , emptyFaultExclusions      -- FaultExclusions{ all four lists empty }
+    ) where
+```
+
+The parser is `IO` only because it reads the compose file. The pure core (`Yaml.Value -> Either String FaultExclusions`) sits below it so tests don't need the FS.
+
+`PostTestRunRequest` grows four fields:
+
+```haskell
+data PostTestRunRequest = PostTestRunRequest
+    { -- existing fields...
+    , networkFaultExclusion            :: [String]
+    , containerFaultsKillExclusion     :: [String]
+    , containerFaultsPauseExclusion    :: [String]
+    , containerFaultsStopExclusion     :: [String]
+    }
+```
+
+`ToJSON` emits each `custom.*_exclusion` key only when its list is non-empty (`mconcat` of conditional `[Pair]` chunks).
+
+## Slices
+
+Each slice is one bisect-safe commit. Slice boundaries are vertical (parser → serializer → wiring) so reviewers can read them as the design steps they actually are.
+
+### Slice 1 — `T107-S1` — Compose-label parser
+
+Add `Docker.FaultExclusion` + tests. No callers yet; module is exposed in `moog.cabal` so the unit suite builds against it. Strictly additive.
+
+RED: `test/Docker/FaultExclusionSpec.hs` with the eight cases listed in tasks.md, all failing.
+GREEN: minimal parser implementing F1–F4.
+Bisect-safe because: no caller touched, so the module compiling and its tests passing is the whole contract.
+
+### Slice 2 — `T107-S2` — `PostTestRunRequest` fields + `ToJSON`
+
+Extend `User.Agent.PushTest.PostTestRunRequest` with the four `[String]` fields. Update `ToJSON`. Extend the existing `User.Agent.PushTestSpec` with the three serialization cases. **Default the four fields to `[]` at all call sites** so the rest of the codebase still builds — the wiring slice replaces the defaults with parser output.
+
+RED: new cases in `PushTestSpec` fail because the keys aren't there yet.
+GREEN: add the fields, update the serializer, fix call sites with `[]` placeholders.
+Bisect-safe because: with all four lists `[]`, F6 says the keys are omitted — payload is byte-identical to today's.
+
+### Slice 3 — `T107-S3` — Wire parser into `pushTestToAntithesisIO`
+
+In `pushTestToAntithesisIO`, call `parseFaultExclusions (context </> "docker-compose.yaml")`, populate the four fields on `PostTestRunRequest` from the result. Replace the `[]` defaults from Slice 2.
+
+RED: a new integration test in `PushTestSpec` (or a small fixture-based test) exercises the path: a temp dir with a stub compose containing one service labeled across all four classes → request carries that service in all four `custom.*_exclusion` fields.
+GREEN: wire it.
+Bisect-safe because: a compose without `com.antithesis.exclude_from_faults` labels yields `emptyFaultExclusions`, F6 still suppresses the keys, and existing call sites pass through unchanged. The change is purely an upgrade from "always empty" to "compose-derived" lists.
+
+## Risks + mitigations
+
+- **Compose parsing surprise (anchors, includes).** The yaml library handles anchors. compose files in `cardano-node-antithesis` don't use `extends:` or compose-file `include:`. Parser stays at YAML-level, doesn't try to resolve compose semantics.
+- **Label value with single quotes vs unquoted comma.** YAML's flow scalar handling treats `"network,kill"` and `network,kill` identically once parsed to `Text`. Tests cover both.
+- **Service without any labels.** The label map is absent → the service contributes to no exclusion class. No special case needed.
+- **Compose file missing entirely.** Parser returns `Left "<path>: no such file"`. Wiring slice decides whether to treat this as fatal or `emptyFaultExclusions`. Decision: **fatal** — silent fallback would mask config rot.
+
+## Gate
+
+`./gate.sh` (in worktree root) runs `nix develop -c cabal build all --enable-tests`, `cabal test unit-tests`, `cabal-fmt -c moog.cabal`, `fourmolu -m check`, `hlint -c`. Each slice must leave it green.

--- a/specs/107-compose-fault-exclusion/spec.md
+++ b/specs/107-compose-fault-exclusion/spec.md
@@ -1,0 +1,50 @@
+# Spec — moog#107 compose-driven Antithesis fault exclusion
+
+## P1 user story
+
+As an Antithesis test operator running cardano-node-antithesis through moog, when I mark a docker-compose service in `testnets/<name>/docker-compose.yaml` with `com.antithesis.exclude_from_faults: "network,kill,pause,stop"` (any subset), the test launched by `moog requester create-test` must include that service in the corresponding `custom.*_exclusion` launch params, so that the Antithesis platform skips fault injection on that container — without needing to edit the Antithesis-hosted notebook or any sibling YAML.
+
+## Why
+
+Antithesis's `amaru-cardano.nb2` notebook accepts four launch params, each a comma-separated list of compose service names:
+
+- `custom.network_fault_exclusion`
+- `custom.container_faults_kill_exclusion`
+- `custom.container_faults_pause_exclusion`
+- `custom.container_faults_stop_exclusion`
+
+Today `moog`'s `PostTestRunRequest` hard-codes seven fields and does not emit any of these. The notebook's defaults (`tracer, tracer-sidecar, sidecar`) are the only way to opt a container out of faults, and we don't own the notebook. As a result `tx-generator`, `asteria-game`, and (in the adversary testnet) `adversary` get faulted even though they are workload generators, not parts of the SUT, and their composer scripts have been accumulating "Always: Commands finish with zero exit code" findings as residual after cardano-foundation/cardano-node-antithesis#142 and #145.
+
+Moving the exclusion list onto the compose service itself makes the compose the single source of truth: renames are atomic, the role of each service is readable in one file, and we stop depending on undocumented notebook defaults.
+
+## User stories
+
+- **U1** — As an operator, I can label a service with one or more of `network`, `kill`, `pause`, `stop` and see the matching params appear in the next run's launch payload, comma-joined by service name.
+- **U2** — As an operator, when no service in the compose carries a label class, moog must omit the corresponding `custom.*_exclusion` param entirely so the notebook's existing default applies (safe rollout — does not clobber the historical `tracer, tracer-sidecar, sidecar` exclusion until the consumer is ready to take over).
+- **U3** — As an operator, if a label value contains a token outside `{network, kill, pause, stop}`, moog fails the launch with a clear error pointing at the service and the offending token, rather than silently dropping the unknown token.
+
+## Functional requirements
+
+- **F1** Parse `<testnet-dir>/docker-compose.yaml` to extract, for each service, the value of the label `com.antithesis.exclude_from_faults`.
+- **F2** The label value is a comma-separated list of tokens from the set `{network, kill, pause, stop}`. Whitespace around tokens is permitted. Empty strings between commas are ignored.
+- **F3** From the parsed labels, build four sets keyed by class: services whose label includes `network`, services whose label includes `kill`, etc. Order within each set is the order services appear in the compose file (deterministic).
+- **F4** A label value containing a token outside the four-element vocabulary is a hard error. The error must name the service and the offending token.
+- **F5** Extend `User.Agent.PushTest.PostTestRunRequest` with four `[String]` fields: `networkFaultExclusion`, `containerFaultsKillExclusion`, `containerFaultsPauseExclusion`, `containerFaultsStopExclusion`.
+- **F6** `ToJSON PostTestRunRequest` emits `custom.network_fault_exclusion`, `custom.container_faults_kill_exclusion`, `custom.container_faults_pause_exclusion`, `custom.container_faults_stop_exclusion` keys with their lists comma-joined (no spaces), **only when the corresponding list is non-empty**. Empty list = key absent from the payload.
+- **F7** `pushTestToAntithesisIO` reads the compose file from the same `Directory context` it already passes to `buildConfigImage`, runs the parser (F1–F4), and populates the four fields on `PostTestRunRequest` before serialization.
+- **F8** The change is a no-op for any caller whose testnet directory contains a compose with zero `com.antithesis.exclude_from_faults` labels.
+
+## Success criteria
+
+- **S1** New unit tests cover: empty compose → all four lists empty; one service per class → each class list has that service; one service labeled with all four → all four lists contain it; malformed label → parse error names the service + token.
+- **S2** New unit tests cover the `ToJSON PostTestRunRequest` shape: empty list omits the key; populated list emits comma-joined value; mixed empty/populated emits only the populated ones.
+- **S3** Existing unit tests still pass without modification — F8 guarantees backwards compatibility.
+- **S4** `gate.sh` passes at HEAD on every slice boundary.
+- **S5** One manual launch from cardano-foundation/cardano-node-antithesis (post-release of this PR + the corresponding labels PR there) shows `custom.container_faults_*_exclusion` in the run params containing the labeled services.
+
+## Out of scope
+
+- Editing any docker-compose file in any other repository. That is done in the cardano-foundation/cardano-node-antithesis follow-up PR.
+- Removing the absorption scaffolding from `components/asteria-game/composer/asteria-game/*.sh`. That is a third, follow-on cleanup once the exclusion is verified in the field.
+- Generalizing the label vocabulary beyond the four fault classes the notebook currently accepts.
+- Providing CLI overrides for the exclusion lists. Compose is the source of truth; if you want a one-off override, edit the compose temporarily.

--- a/specs/107-compose-fault-exclusion/tasks.md
+++ b/specs/107-compose-fault-exclusion/tasks.md
@@ -2,11 +2,11 @@
 
 ## Slice 1 — Compose-label parser
 
-- [ ] T107-S1.1 Add `Docker.FaultExclusion` to `moog.cabal` `library` `exposed-modules` and add the corresponding spec module to `test-suite unit-tests` `other-modules`.
-- [ ] T107-S1.2 RED: write `test/Docker/FaultExclusionSpec.hs` with these cases — empty compose / no labels → all four lists empty; one service labeled `"network"` → only network list contains it; one service labeled `"network,kill,pause,stop"` → all four lists contain it; two services labeled disjoint classes → each class list contains its service; whitespace-padded value `" network , kill "` → parsed identically to `"network,kill"`; empty token between commas (`"network,,kill"`) → parsed as `["network","kill"]`; unknown token `"netwrk"` → `Left` naming the service + the offending token; missing compose file → `Left` with path. Tests fail because module + types don't exist yet.
-- [ ] T107-S1.3 GREEN: implement `Docker.FaultExclusion` (`FaultClass`, `FaultExclusions`, `parseFaultExclusions`, pure helper `classifyServices :: Yaml.Value -> Either String FaultExclusions`, `emptyFaultExclusions`).
-- [ ] T107-S1.4 Run `./gate.sh` green. WIP.md milestone: `Slice 1 gate green`.
-- [ ] T107-S1.5 Commit (signed) with subject `feat(agent): compose-label-driven fault-exclusion parser` and trailer `Tasks: T107-S1`.
+- [X] T107-S1.1 Add `Docker.FaultExclusion` to `moog.cabal` `library` `exposed-modules` and add the corresponding spec module to `test-suite unit-tests` `other-modules`.
+- [X] T107-S1.2 RED: write `test/Docker/FaultExclusionSpec.hs` with these cases — empty compose / no labels → all four lists empty; one service labeled `"network"` → only network list contains it; one service labeled `"network,kill,pause,stop"` → all four lists contain it; two services labeled disjoint classes → each class list contains its service; whitespace-padded value `" network , kill "` → parsed identically to `"network,kill"`; empty token between commas (`"network,,kill"`) → parsed as `["network","kill"]`; unknown token `"netwrk"` → `Left` naming the service + the offending token; missing compose file → `Left` with path. Tests fail because module + types don't exist yet.
+- [X] T107-S1.3 GREEN: implement `Docker.FaultExclusion` (`FaultClass`, `FaultExclusions`, `parseFaultExclusions`, pure helper `classifyServices :: Yaml.Value -> Either String FaultExclusions`, `emptyFaultExclusions`).
+- [X] T107-S1.4 Run `./gate.sh` green. WIP.md milestone: `Slice 1 gate green`.
+- [X] T107-S1.5 Commit (signed) with subject `feat(agent): compose-label-driven fault-exclusion parser` and trailer `Tasks: T107-S1`.
 
 ## Slice 2 — PostTestRunRequest fields + JSON serializer
 

--- a/specs/107-compose-fault-exclusion/tasks.md
+++ b/specs/107-compose-fault-exclusion/tasks.md
@@ -1,0 +1,37 @@
+# Tasks — moog#107
+
+## Slice 1 — Compose-label parser
+
+- [ ] T107-S1.1 Add `Docker.FaultExclusion` to `moog.cabal` `library` `exposed-modules` and add the corresponding spec module to `test-suite unit-tests` `other-modules`.
+- [ ] T107-S1.2 RED: write `test/Docker/FaultExclusionSpec.hs` with these cases — empty compose / no labels → all four lists empty; one service labeled `"network"` → only network list contains it; one service labeled `"network,kill,pause,stop"` → all four lists contain it; two services labeled disjoint classes → each class list contains its service; whitespace-padded value `" network , kill "` → parsed identically to `"network,kill"`; empty token between commas (`"network,,kill"`) → parsed as `["network","kill"]`; unknown token `"netwrk"` → `Left` naming the service + the offending token; missing compose file → `Left` with path. Tests fail because module + types don't exist yet.
+- [ ] T107-S1.3 GREEN: implement `Docker.FaultExclusion` (`FaultClass`, `FaultExclusions`, `parseFaultExclusions`, pure helper `classifyServices :: Yaml.Value -> Either String FaultExclusions`, `emptyFaultExclusions`).
+- [ ] T107-S1.4 Run `./gate.sh` green. WIP.md milestone: `Slice 1 gate green`.
+- [ ] T107-S1.5 Commit (signed) with subject `feat(agent): compose-label-driven fault-exclusion parser` and trailer `Tasks: T107-S1`.
+
+## Slice 2 — PostTestRunRequest fields + JSON serializer
+
+- [ ] T107-S2.1 RED: extend `test/User/Agent/PushTestSpec.hs` with three cases — `PostTestRunRequest` with all four exclusion lists empty serializes to a payload with **no** `custom.*_exclusion` keys; populated list emits `"custom.container_faults_kill_exclusion": "asteria-game,tx-generator"` (comma-joined, no spaces); mixed empty + populated emits only the populated keys. Tests fail because fields and serializer logic don't exist yet.
+- [ ] T107-S2.2 GREEN: add `networkFaultExclusion`, `containerFaultsKillExclusion`, `containerFaultsPauseExclusion`, `containerFaultsStopExclusion` to `PostTestRunRequest`. Update `ToJSON` to emit each `custom.*_exclusion` key conditionally (omit on empty). Update every existing call site of `PostTestRunRequest` constructor to default the four fields to `[]` so the codebase still builds.
+- [ ] T107-S2.3 Run `./gate.sh` green. WIP.md milestone: `Slice 2 gate green` + note the existing `PushTestSpec` cases still pass (proves F8 backwards compatibility).
+- [ ] T107-S2.4 Commit (signed) with subject `feat(agent): emit custom.*_exclusion params in launch payload` and trailer `Tasks: T107-S2`.
+
+## Slice 3 — Wire parser into pushTestToAntithesisIO
+
+- [ ] T107-S3.1 RED: integration test in `PushTestSpec` — set up a `withSystemTempDirectory` containing a stub `docker-compose.yaml` with one labeled service, run the relevant slice of `pushTestToAntithesisIO`'s logic (the part that builds `PostTestRunRequest` from `Directory context`; factor out a pure helper if needed to make it testable without doing the HTTP POST), assert the request carries the service in all four exclusion fields.
+- [ ] T107-S3.2 GREEN: in `pushTestToAntithesisIO`, call `parseFaultExclusions ((unDirectory context) </> "docker-compose.yaml")`. On `Left`, throw `PushFailure` (new constructor `ComposeFaultExclusionParseFailure String`). On `Right`, populate the four fields on `PostTestRunRequest`. Remove the `[]` placeholders from the call site introduced in Slice 2.
+- [ ] T107-S3.3 Run `./gate.sh` green. WIP.md milestone: `Slice 3 gate green` + a note recording the integration test's tmpdir compose content for posterity.
+- [ ] T107-S3.4 Commit (signed) with subject `feat(agent): wire compose fault-exclusion parser into push payload` and trailer `Tasks: T107-S3`.
+
+## Finalization (orchestrator)
+
+- [ ] T107-F1 PR body audit — confirm the three slice subjects appear in the merge log and the test plan checkboxes match what shipped.
+- [ ] T107-F2 Drop `gate.sh` in a `chore(#107): drop gate.sh (ready for review)` commit (signed).
+- [ ] T107-F3 `gh pr ready 108` to flip out of draft.
+- [ ] T107-F4 Wait for review + merge. Do not self-merge.
+
+## Post-merge cleanup (orchestrator)
+
+- [ ] T107-C1 Tag a moog release that includes this PR so cardano-node-antithesis CI can bump to it.
+- [ ] T107-C2 Open the follow-up PR on `cardano-foundation/cardano-node-antithesis` adding `com.antithesis.exclude_from_faults` labels to `tracer`, `tracer-sidecar`, `sidecar`, `tx-generator`, `asteria-game` (master) and the same plus `adversary` (adversary testnet), and bumping the moog release tag in `.github/workflows/cardano-node.yaml`.
+- [ ] T107-C3 After 2-3 consecutive trys on the master testnet show zero new findings on the three Asteria scripts, open the cleanup PR removing `sdk_install_signal_trap` from `components/asteria-game/composer/asteria-game/*.sh`.
+- [ ] T107-C4 `git worktree remove /code/moog-issue-107`, `git branch -D feat/compose-fault-exclusion`, `git push origin --delete feat/compose-fault-exclusion`, `git worktree prune`.

--- a/specs/107-compose-fault-exclusion/tasks.md
+++ b/specs/107-compose-fault-exclusion/tasks.md
@@ -17,10 +17,10 @@
 
 ## Slice 3 — Wire parser into pushTestToAntithesisIO
 
-- [ ] T107-S3.1 RED: integration test in `PushTestSpec` — set up a `withSystemTempDirectory` containing a stub `docker-compose.yaml` with one labeled service, run the relevant slice of `pushTestToAntithesisIO`'s logic (the part that builds `PostTestRunRequest` from `Directory context`; factor out a pure helper if needed to make it testable without doing the HTTP POST), assert the request carries the service in all four exclusion fields.
-- [ ] T107-S3.2 GREEN: in `pushTestToAntithesisIO`, call `parseFaultExclusions ((unDirectory context) </> "docker-compose.yaml")`. On `Left`, throw `PushFailure` (new constructor `ComposeFaultExclusionParseFailure String`). On `Right`, populate the four fields on `PostTestRunRequest`. Remove the `[]` placeholders from the call site introduced in Slice 2.
-- [ ] T107-S3.3 Run `./gate.sh` green. WIP.md milestone: `Slice 3 gate green` + a note recording the integration test's tmpdir compose content for posterity.
-- [ ] T107-S3.4 Commit (signed) with subject `feat(agent): wire compose fault-exclusion parser into push payload` and trailer `Tasks: T107-S3`.
+- [X] T107-S3.1 RED: integration test in `PushTestSpec` — set up a `withSystemTempDirectory` containing a stub `docker-compose.yaml` with one labeled service, run the relevant slice of `pushTestToAntithesisIO`'s logic (the part that builds `PostTestRunRequest` from `Directory context`; factor out a pure helper if needed to make it testable without doing the HTTP POST), assert the request carries the service in all four exclusion fields.
+- [X] T107-S3.2 GREEN: in `pushTestToAntithesisIO`, call `parseFaultExclusions ((unDirectory context) </> "docker-compose.yaml")`. On `Left`, throw `PushFailure` (new constructor `ComposeFaultExclusionParseFailure String`). On `Right`, populate the four fields on `PostTestRunRequest`. Remove the `[]` placeholders from the call site introduced in Slice 2.
+- [X] T107-S3.3 Run `./gate.sh` green. WIP.md milestone: `Slice 3 gate green` + a note recording the integration test's tmpdir compose content for posterity.
+- [X] T107-S3.4 Commit (signed) with subject `feat(agent): wire compose fault-exclusion parser into push payload` and trailer `Tasks: T107-S3`.
 
 ## Finalization (orchestrator)
 

--- a/specs/107-compose-fault-exclusion/tasks.md
+++ b/specs/107-compose-fault-exclusion/tasks.md
@@ -10,10 +10,10 @@
 
 ## Slice 2 — PostTestRunRequest fields + JSON serializer
 
-- [ ] T107-S2.1 RED: extend `test/User/Agent/PushTestSpec.hs` with three cases — `PostTestRunRequest` with all four exclusion lists empty serializes to a payload with **no** `custom.*_exclusion` keys; populated list emits `"custom.container_faults_kill_exclusion": "asteria-game,tx-generator"` (comma-joined, no spaces); mixed empty + populated emits only the populated keys. Tests fail because fields and serializer logic don't exist yet.
-- [ ] T107-S2.2 GREEN: add `networkFaultExclusion`, `containerFaultsKillExclusion`, `containerFaultsPauseExclusion`, `containerFaultsStopExclusion` to `PostTestRunRequest`. Update `ToJSON` to emit each `custom.*_exclusion` key conditionally (omit on empty). Update every existing call site of `PostTestRunRequest` constructor to default the four fields to `[]` so the codebase still builds.
-- [ ] T107-S2.3 Run `./gate.sh` green. WIP.md milestone: `Slice 2 gate green` + note the existing `PushTestSpec` cases still pass (proves F8 backwards compatibility).
-- [ ] T107-S2.4 Commit (signed) with subject `feat(agent): emit custom.*_exclusion params in launch payload` and trailer `Tasks: T107-S2`.
+- [X] T107-S2.1 RED: extend `test/User/Agent/PushTestSpec.hs` with three cases — `PostTestRunRequest` with all four exclusion lists empty serializes to a payload with **no** `custom.*_exclusion` keys; populated list emits `"custom.container_faults_kill_exclusion": "asteria-game,tx-generator"` (comma-joined, no spaces); mixed empty + populated emits only the populated keys. Tests fail because fields and serializer logic don't exist yet.
+- [X] T107-S2.2 GREEN: add `networkFaultExclusion`, `containerFaultsKillExclusion`, `containerFaultsPauseExclusion`, `containerFaultsStopExclusion` to `PostTestRunRequest`. Update `ToJSON` to emit each `custom.*_exclusion` key conditionally (omit on empty). Update every existing call site of `PostTestRunRequest` constructor to default the four fields to `[]` so the codebase still builds.
+- [X] T107-S2.3 Run `./gate.sh` green. WIP.md milestone: `Slice 2 gate green` + note the existing `PushTestSpec` cases still pass (proves F8 backwards compatibility).
+- [X] T107-S2.4 Commit (signed) with subject `feat(agent): emit custom.*_exclusion params in launch payload` and trailer `Tasks: T107-S2`.
 
 ## Slice 3 — Wire parser into pushTestToAntithesisIO
 

--- a/src/Docker/FaultExclusion.hs
+++ b/src/Docker/FaultExclusion.hs
@@ -1,0 +1,205 @@
+module Docker.FaultExclusion
+    ( FaultClass (..)
+    , FaultExclusions (..)
+    , emptyFaultExclusions
+    , classifyServices
+    , parseFaultExclusions
+    )
+where
+
+import Control.Exception (IOException, try)
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.List (find)
+import Data.Text qualified as Text
+import Data.Vector qualified as Vector
+import Data.Yaml qualified as Yaml
+
+data FaultClass = Network | Kill | Pause | Stop
+    deriving (Eq, Ord, Show)
+
+data FaultExclusions = FaultExclusions
+    { networkExclusion :: [String]
+    , killExclusion :: [String]
+    , pauseExclusion :: [String]
+    , stopExclusion :: [String]
+    }
+    deriving (Eq, Show)
+
+emptyFaultExclusions :: FaultExclusions
+emptyFaultExclusions =
+    FaultExclusions
+        { networkExclusion = []
+        , killExclusion = []
+        , pauseExclusion = []
+        , stopExclusion = []
+        }
+
+classifyServices :: Aeson.Value -> Either String FaultExclusions
+classifyServices value =
+    case value of
+        Aeson.Object object ->
+            case KeyMap.lookup servicesKey object of
+                Nothing -> Right emptyFaultExclusions
+                Just (Aeson.Object services) ->
+                    foldl
+                        classifyService
+                        (Right emptyFaultExclusions)
+                        (KeyMap.toList services)
+                Just _ -> Left "services: expected map"
+        _ -> Left "compose document: expected map"
+
+parseFaultExclusions :: FilePath -> IO (Either String FaultExclusions)
+parseFaultExclusions path = do
+    result <- try $ Yaml.decodeFileEither path
+    case result of
+        Left err -> pure $ Left $ path <> ": " <> show (err :: IOException)
+        Right (Left err) ->
+            pure $ Left $ path <> ": " <> Yaml.prettyPrintParseException err
+        Right (Right value) -> pure $ classifyServices value
+
+classifyService
+    :: Either String FaultExclusions
+    -> (Aeson.Key, Aeson.Value)
+    -> Either String FaultExclusions
+classifyService acc (serviceKey, serviceValue) = do
+    exclusions <- acc
+    case labelValue serviceValue of
+        Nothing -> Right exclusions
+        Just rawLabel ->
+            foldl
+                (addService serviceName)
+                (Right exclusions)
+                (labelTokens rawLabel)
+  where
+    serviceName = Key.toString serviceKey
+
+labelValue :: Aeson.Value -> Maybe String
+labelValue (Aeson.Object service) =
+    KeyMap.lookup labelsKey service >>= labelsValue
+labelValue _ = Nothing
+
+labelsValue :: Aeson.Value -> Maybe String
+labelsValue (Aeson.Object labels) =
+    case KeyMap.lookup faultLabelKey labels of
+        Just (Aeson.String value) -> Just $ Text.unpack value
+        _ -> Nothing
+labelsValue (Aeson.Array labels) =
+    labelFromList $ Vector.toList labels
+labelsValue _ = Nothing
+
+labelFromList :: [Aeson.Value] -> Maybe String
+labelFromList labels =
+    listLabelValue
+        =<< find
+            (maybe False isFaultLabel . listLabelText)
+            labels
+
+listLabelValue :: Aeson.Value -> Maybe String
+listLabelValue label = do
+    text <- listLabelText label
+    stripPrefix (faultLabelName <> "=") text
+
+listLabelText :: Aeson.Value -> Maybe String
+listLabelText (Aeson.String value) = Just $ Text.unpack value
+listLabelText _ = Nothing
+
+isFaultLabel :: String -> Bool
+isFaultLabel label =
+    (faultLabelName <> "=") `isPrefixOf` label
+
+labelTokens :: String -> [String]
+labelTokens =
+    filter (not . null)
+        . fmap trimAscii
+        . splitOnComma
+
+splitOnComma :: String -> [String]
+splitOnComma "" = [""]
+splitOnComma input =
+    case break (== ',') input of
+        (token, "") -> [token]
+        (token, _comma : rest) -> token : splitOnComma rest
+
+trimAscii :: String -> String
+trimAscii =
+    dropWhileEnd isAsciiSpace . dropWhile isAsciiSpace
+
+dropWhileEnd :: (a -> Bool) -> [a] -> [a]
+dropWhileEnd predicate =
+    reverse . dropWhile predicate . reverse
+
+isAsciiSpace :: Char -> Bool
+isAsciiSpace char =
+    char `elem` [' ', '\t', '\n', '\r', '\f', '\v']
+
+addService
+    :: String
+    -> Either String FaultExclusions
+    -> String
+    -> Either String FaultExclusions
+addService serviceName acc token = do
+    exclusions <- acc
+    case parseFaultClass token of
+        Nothing ->
+            Left $
+                serviceName
+                    <> ": unknown fault class \""
+                    <> token
+                    <> "\" (expected one of network, kill, pause, stop)"
+        Just Network ->
+            Right
+                exclusions
+                    { networkExclusion =
+                        networkExclusion exclusions <> [serviceName]
+                    }
+        Just Kill ->
+            Right
+                exclusions
+                    { killExclusion =
+                        killExclusion exclusions <> [serviceName]
+                    }
+        Just Pause ->
+            Right
+                exclusions
+                    { pauseExclusion =
+                        pauseExclusion exclusions <> [serviceName]
+                    }
+        Just Stop ->
+            Right
+                exclusions
+                    { stopExclusion =
+                        stopExclusion exclusions <> [serviceName]
+                    }
+
+parseFaultClass :: String -> Maybe FaultClass
+parseFaultClass "network" = Just Network
+parseFaultClass "kill" = Just Kill
+parseFaultClass "pause" = Just Pause
+parseFaultClass "stop" = Just Stop
+parseFaultClass _ = Nothing
+
+servicesKey :: Aeson.Key
+servicesKey = Key.fromString "services"
+
+labelsKey :: Aeson.Key
+labelsKey = Key.fromString "labels"
+
+faultLabelKey :: Aeson.Key
+faultLabelKey = Key.fromString faultLabelName
+
+faultLabelName :: String
+faultLabelName = "com.antithesis.exclude_from_faults"
+
+isPrefixOf :: Eq a => [a] -> [a] -> Bool
+isPrefixOf [] _ = True
+isPrefixOf _ [] = False
+isPrefixOf (x : xs) (y : ys) = x == y && isPrefixOf xs ys
+
+stripPrefix :: Eq a => [a] -> [a] -> Maybe [a]
+stripPrefix [] xs = Just xs
+stripPrefix _ [] = Nothing
+stripPrefix (x : xs) (y : ys)
+    | x == y = stripPrefix xs ys
+    | otherwise = Nothing

--- a/src/User/Agent/PushTest.hs
+++ b/src/User/Agent/PushTest.hs
@@ -36,6 +36,8 @@ import Core.Types.Basic
 import Core.Types.Fact (Fact (..))
 import Core.Types.Wallet (Wallet (..))
 import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.Types (Pair)
 import Data.ByteString.Lazy.Char8 qualified as BL
 import Data.CaseInsensitive (CI (..))
 import Data.Functor (($>), (<&>))
@@ -94,6 +96,10 @@ data PostTestRunRequest = PostTestRunRequest
     , slack :: Maybe String
     , faults_enabled :: Bool
     , is_haskell :: Bool
+    , networkFaultExclusion :: [String]
+    , containerFaultsKillExclusion :: [String]
+    , containerFaultsPauseExclusion :: [String]
+    , containerFaultsStopExclusion :: [String]
     }
     deriving (Show, Eq)
 
@@ -109,6 +115,10 @@ instance Aeson.ToJSON PostTestRunRequest where
             , slack
             , faults_enabled
             , is_haskell
+            , networkFaultExclusion
+            , containerFaultsKillExclusion
+            , containerFaultsPauseExclusion
+            , containerFaultsStopExclusion
             } =
             Aeson.object
                 [ "params"
@@ -131,6 +141,24 @@ instance Aeson.ToJSON PostTestRunRequest where
                             ["antithesis.integrations.slack.callback_url" Aeson..= wh]
                         )
                         slack
+                    <> exclusionFields
+                        "custom.network_fault_exclusion"
+                        networkFaultExclusion
+                    <> exclusionFields
+                        "custom.container_faults_kill_exclusion"
+                        containerFaultsKillExclusion
+                    <> exclusionFields
+                        "custom.container_faults_pause_exclusion"
+                        containerFaultsPauseExclusion
+                    <> exclusionFields
+                        "custom.container_faults_stop_exclusion"
+                        containerFaultsStopExclusion
+
+exclusionFields :: String -> [String] -> [Pair]
+exclusionFields _ [] = []
+exclusionFields key services =
+    [Key.fromString key Aeson..= intercalate "," services]
+
 pushTestToAntithesis
     :: Wallet
     -> Directory
@@ -170,6 +198,10 @@ pushTestToAntithesisIO
                     , slack = fmap unSlackWebhook slack
                     , faults_enabled = getFaultsEnabled faultsEnabled
                     , is_haskell = not (getHasInstrumentation hasInstrumentation)
+                    , networkFaultExclusion = []
+                    , containerFaultsKillExclusion = []
+                    , containerFaultsPauseExclusion = []
+                    , containerFaultsStopExclusion = []
                     }
             post = renderPostToAntithesis auth body
         epost <- liftIO $ curl post

--- a/src/User/Agent/PushTest.hs
+++ b/src/User/Agent/PushTest.hs
@@ -7,6 +7,7 @@ module User.Agent.PushTest
     , pushTestToAntithesis
     , dockerfile
     , pushTestToAntithesisIO
+    , buildPostTestRunRequest
     , PostTestRunRequest (..)
     , Tag (..)
     , AntithesisAuth (..)
@@ -44,6 +45,10 @@ import Data.Functor (($>), (<&>))
 import Data.Functor.Identity (Identity (..))
 import Data.List (intercalate)
 import Data.String.QQ (s)
+import Docker.FaultExclusion
+    ( FaultExclusions (..)
+    , parseFaultExclusions
+    )
 import Lib.JSON.Canonical.Extra (object, withObject, (.:), (.=))
 import Lib.System (runSystemCommand)
 import Oracle.Validate.Types
@@ -184,28 +189,77 @@ pushTestToAntithesisIO
     slack = do
         etag <- liftIO $ buildConfigImage registry dir testRunId
         tag <- throwLeft DockerBuildFailure etag
-        epush <- liftIO $ pushConfigImage tag
-        void $ throwLeft DockerPushFailure epush
         (tr, Duration duration, faultsEnabled, hasInstrumentation) <-
             getTestRun tk testRunId
-        let body =
-                PostTestRunRequest
-                    { description = renderTestRun testRunId tr
-                    , duration = realToFrac duration * 60
-                    , config_image = tagString tag
-                    , recipients = ["antithesis@cardanofoundation.org"]
-                    , source = renderSource tr
-                    , slack = fmap unSlackWebhook slack
-                    , faults_enabled = getFaultsEnabled faultsEnabled
-                    , is_haskell = not (getHasInstrumentation hasInstrumentation)
-                    , networkFaultExclusion = []
-                    , containerFaultsKillExclusion = []
-                    , containerFaultsPauseExclusion = []
-                    , containerFaultsStopExclusion = []
-                    }
-            post = renderPostToAntithesis auth body
+        body <-
+            liftIO
+                ( buildPostTestRunRequest
+                    dir
+                    (renderTestRun testRunId tr)
+                    (realToFrac duration * 60)
+                    (tagString tag)
+                    ["antithesis@cardanofoundation.org"]
+                    (renderSource tr)
+                    (fmap unSlackWebhook slack)
+                    (getFaultsEnabled faultsEnabled)
+                    (not (getHasInstrumentation hasInstrumentation))
+                )
+                >>= throwLeft id
+        epush <- liftIO $ pushConfigImage tag
+        void $ throwLeft DockerPushFailure epush
+        let post = renderPostToAntithesis auth body
         epost <- liftIO $ curl post
         void $ throwLeft PostToAntithesisFailure epost
+
+buildPostTestRunRequest
+    :: Directory
+    -> String
+    -> Float
+    -> String
+    -> [String]
+    -> String
+    -> Maybe String
+    -> Bool
+    -> Bool
+    -> IO (Either PushFailure PostTestRunRequest)
+buildPostTestRunRequest
+    (Directory testnetDir)
+    description
+    duration
+    configImage
+    recipients
+    source
+    slack
+    faultsEnabled
+    isHaskell = do
+        exclusions <- parseFaultExclusions composePath
+        pure $
+            case exclusions of
+                Left err -> Left $ ComposeFaultExclusionParseFailure err
+                Right
+                    FaultExclusions
+                        { networkExclusion
+                        , killExclusion
+                        , pauseExclusion
+                        , stopExclusion
+                        } ->
+                        Right
+                            PostTestRunRequest
+                                { description
+                                , duration
+                                , config_image = configImage
+                                , recipients
+                                , source
+                                , slack
+                                , faults_enabled = faultsEnabled
+                                , is_haskell = isHaskell
+                                , networkFaultExclusion = networkExclusion
+                                , containerFaultsKillExclusion = killExclusion
+                                , containerFaultsPauseExclusion = pauseExclusion
+                                , containerFaultsStopExclusion = stopExclusion
+                                }
+      where
+        composePath = testnetDir ++ "/docker-compose.yaml"
 
 renderSource :: TestRun -> String
 renderSource TestRun{repository = GithubRepository{organization, project}} =
@@ -343,6 +397,7 @@ buildConfigImage (Registry registry) (Directory context) (TestRunId trId) =
 data PushFailure
     = DockerBuildFailure String
     | DockerPushFailure String
+    | ComposeFaultExclusionParseFailure String
     | Couldn'tResolveTestRunId TestRunId
     | PostToAntithesisFailure String
     deriving (Show, Eq)
@@ -355,6 +410,10 @@ instance Monad m => ToJSON m PushFailure where
     toJSON (DockerPushFailure msg) =
         object
             [ "dockerPushFailure" .= msg
+            ]
+    toJSON (ComposeFaultExclusionParseFailure msg) =
+        object
+            [ "composeFaultExclusionParseFailure" .= msg
             ]
     toJSON (Couldn'tResolveTestRunId (TestRunId trId)) =
         object

--- a/test/Docker/FaultExclusionSpec.hs
+++ b/test/Docker/FaultExclusionSpec.hs
@@ -1,0 +1,185 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Docker.FaultExclusionSpec
+    ( spec
+    )
+where
+
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Char8 qualified as BS
+import Data.Either (isLeft)
+import Data.List (isInfixOf)
+import Data.String.QQ (s)
+import Data.Yaml qualified as Yaml
+import Docker.FaultExclusion
+    ( FaultExclusions (..)
+    , classifyServices
+    , emptyFaultExclusions
+    , parseFaultExclusions
+    )
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    , shouldSatisfy
+    )
+
+spec :: Spec
+spec =
+    describe "Docker.FaultExclusion" $ do
+        it "returns empty exclusions for an empty services map" $
+            classifyServices
+                ( compose
+                    [s|
+services: {}
+                    |]
+                )
+                `shouldBe` Right emptyFaultExclusions
+
+        it "returns empty exclusions for a service without labels" $
+            classifyServices
+                ( compose
+                    [s|
+services:
+  tracer:
+    image: tracer:latest
+                    |]
+                )
+                `shouldBe` Right emptyFaultExclusions
+
+        it "classifies a map-form network label" $
+            classifyServices
+                ( compose
+                    [s|
+services:
+  tracer:
+    labels:
+      com.antithesis.exclude_from_faults: network
+                    |]
+                )
+                `shouldBe` Right
+                    emptyFaultExclusions{networkExclusion = ["tracer"]}
+
+        it "classifies a service excluded from all fault classes" $
+            classifyServices
+                ( compose
+                    [s|
+services:
+  tracer:
+    labels:
+      com.antithesis.exclude_from_faults: network,kill,pause,stop
+                    |]
+                )
+                `shouldBe` Right
+                    FaultExclusions
+                        { networkExclusion = ["tracer"]
+                        , killExclusion = ["tracer"]
+                        , pauseExclusion = ["tracer"]
+                        , stopExclusion = ["tracer"]
+                        }
+
+        it "keeps service order with disjoint labels" $
+            classifyServices
+                ( compose
+                    [s|
+services:
+  alpha:
+    labels:
+      com.antithesis.exclude_from_faults: network
+  beta:
+    labels:
+      com.antithesis.exclude_from_faults: kill,pause
+                    |]
+                )
+                `shouldBe` Right
+                    FaultExclusions
+                        { networkExclusion = ["alpha"]
+                        , killExclusion = ["beta"]
+                        , pauseExclusion = ["beta"]
+                        , stopExclusion = []
+                        }
+
+        it "trims surrounding whitespace from label tokens" $
+            classifyServices
+                ( compose
+                    [s|
+services:
+  tracer:
+    labels:
+      com.antithesis.exclude_from_faults: " network , kill "
+                    |]
+                )
+                `shouldBe` Right
+                    emptyFaultExclusions
+                        { networkExclusion = ["tracer"]
+                        , killExclusion = ["tracer"]
+                        }
+
+        it "drops empty label tokens" $
+            classifyServices
+                ( compose
+                    [s|
+services:
+  tracer:
+    labels:
+      com.antithesis.exclude_from_faults: network,,kill
+                    |]
+                )
+                `shouldBe` Right
+                    emptyFaultExclusions
+                        { networkExclusion = ["tracer"]
+                        , killExclusion = ["tracer"]
+                        }
+
+        it "reports the service name and token for an unknown fault class" $
+            classifyServices
+                ( compose
+                    [s|
+services:
+  tracer:
+    labels:
+      com.antithesis.exclude_from_faults: netwrk
+                    |]
+                )
+                `shouldSatisfy` containsLeft "tracer" "netwrk"
+
+        it "classifies a list-form label" $
+            classifyServices
+                ( compose
+                    [s|
+services:
+  tracer:
+    labels:
+      - com.antithesis.exclude_from_faults=network,kill
+                    |]
+                )
+                `shouldBe` Right
+                    emptyFaultExclusions
+                        { networkExclusion = ["tracer"]
+                        , killExclusion = ["tracer"]
+                        }
+
+        it "prefixes parse errors with the input path" $
+            withSystemTempDirectory
+                "fault-exclusion-spec"
+                $ \dir -> do
+                    let path = dir </> "missing-compose.yaml"
+                    result <- parseFaultExclusions path
+                    result `shouldSatisfy` containsLeft path ""
+
+compose :: String -> Aeson.Value
+compose yaml =
+    case Yaml.decodeEither' $ BS.pack yaml of
+        Left err -> error $ Yaml.prettyPrintParseException err
+        Right value -> value
+
+containsLeft :: String -> String -> Either String a -> Bool
+containsLeft first second value =
+    isLeft value
+        && either
+            (\err -> first `isInfixOf` err && second `isInfixOf` err)
+            (const False)
+            value

--- a/test/User/Agent/PushTestSpec.hs
+++ b/test/User/Agent/PushTestSpec.hs
@@ -3,6 +3,10 @@ module User.Agent.PushTestSpec
     )
 where
 
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.Text qualified as Text
 import Core.Types.Basic
     ( Commit (..)
     , Directory (..)
@@ -67,6 +71,10 @@ spec = do
                         , slack = Nothing
                         , faults_enabled = True
                         , is_haskell = False
+                        , networkFaultExclusion = []
+                        , containerFaultsKillExclusion = []
+                        , containerFaultsPauseExclusion = []
+                        , containerFaultsStopExclusion = []
                         }
                 (cmd, args) = renderPostToAntithesis auth body
             cmd `shouldBe` "curl"
@@ -82,3 +90,77 @@ spec = do
                            , "-d"
                            , "{\"params\":{\"antithesis.config_image\":\"registry/cardano-moog-config:dummy\",\"antithesis.description\":\"{\\\"testRun\\\":{\\\"commitId\\\":\\\"abcdef1234567890\\\",\\\"directory\\\":\\\"tests\\\",\\\"platform\\\":\\\"github\\\",\\\"repository\\\":{\\\"organization\\\":\\\"cardano-foundation\\\",\\\"repo\\\":\\\"moog\\\"},\\\"requester\\\":\\\"alice\\\",\\\"try\\\":1,\\\"type\\\":\\\"test-run\\\"},\\\"testRunId\\\":\\\"test-run-001\\\"}\",\"antithesis.duration\":3600,\"antithesis.report.recipients\":\"hal@cardanofoundation.org\",\"antithesis.source\":\"dummy\",\"custom.faults_enabled\":true,\"custom.is_haskell\":false}}"
                            ]
+    describe "PostTestRunRequest exclusion serialization" $ do
+        it "omits exclusion keys when all exclusion lists are empty" $ do
+            exclusionParams basePostTestRunRequest
+                `shouldBe` [ Nothing
+                           , Nothing
+                           , Nothing
+                           , Nothing
+                           ]
+
+        it "serializes only the non-empty kill exclusion list" $ do
+            let request =
+                    basePostTestRunRequest
+                        { containerFaultsKillExclusion =
+                            ["asteria-game", "tx-generator"]
+                        }
+            exclusionParams request
+                `shouldBe` [ Nothing
+                           , Just
+                                $ Aeson.String
+                                $ Text.pack "asteria-game,tx-generator"
+                           , Nothing
+                           , Nothing
+                           ]
+
+        it "serializes all exclusion lists independently" $ do
+            let request =
+                    basePostTestRunRequest
+                        { networkFaultExclusion = ["net-a", "net-b"]
+                        , containerFaultsKillExclusion = ["kill-a"]
+                        , containerFaultsPauseExclusion =
+                            ["pause-a", "pause-b"]
+                        , containerFaultsStopExclusion = ["stop-a"]
+                        }
+            exclusionParams request
+                `shouldBe` [ Just $ Aeson.String $ Text.pack "net-a,net-b"
+                           , Just $ Aeson.String $ Text.pack "kill-a"
+                           , Just
+                                $ Aeson.String
+                                $ Text.pack "pause-a,pause-b"
+                           , Just $ Aeson.String $ Text.pack "stop-a"
+                           ]
+
+basePostTestRunRequest :: PostTestRunRequest
+basePostTestRunRequest =
+    PostTestRunRequest
+        { description = "description"
+        , duration = 3600
+        , config_image = "registry/cardano-moog-config:dummy"
+        , recipients = ["hal@cardanofoundation.org"]
+        , source = "dummy"
+        , slack = Nothing
+        , faults_enabled = True
+        , is_haskell = False
+        , networkFaultExclusion = []
+        , containerFaultsKillExclusion = []
+        , containerFaultsPauseExclusion = []
+        , containerFaultsStopExclusion = []
+        }
+
+exclusionParams :: PostTestRunRequest -> [Maybe Aeson.Value]
+exclusionParams request =
+    fmap
+        (`lookupParam` request)
+        [ "custom.network_fault_exclusion"
+        , "custom.container_faults_kill_exclusion"
+        , "custom.container_faults_pause_exclusion"
+        , "custom.container_faults_stop_exclusion"
+        ]
+
+lookupParam :: String -> PostTestRunRequest -> Maybe Aeson.Value
+lookupParam name request = do
+    Aeson.Object topLevel <- Aeson.decode $ Aeson.encode request
+    Aeson.Object params <- KeyMap.lookup (Key.fromString "params") topLevel
+    KeyMap.lookup (Key.fromString name) params

--- a/test/User/Agent/PushTestSpec.hs
+++ b/test/User/Agent/PushTestSpec.hs
@@ -6,6 +6,7 @@ where
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as Key
 import Data.Aeson.KeyMap qualified as KeyMap
+import Data.List (isInfixOf)
 import Data.Text qualified as Text
 import Core.Types.Basic
     ( Commit (..)
@@ -16,12 +17,16 @@ import Core.Types.Basic
     , Try (..)
     )
 import Test.Hspec (Spec, describe, it, shouldBe, shouldReturn)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
 import User.Agent.PushTest
     ( AntithesisAuth (..)
     , LaunchUrl (..)
     , PostTestRunRequest (..)
+    , PushFailure (..)
     , Registry (..)
     , Tag (..)
+    , buildPostTestRunRequest
     , buildConfigImage
     , renderPostToAntithesis
     , renderTestRun
@@ -131,6 +136,78 @@ spec = do
                                 $ Text.pack "pause-a,pause-b"
                            , Just $ Aeson.String $ Text.pack "stop-a"
                            ]
+    describe "buildPostTestRunRequest" $ do
+        it "populates all exclusion lists from a compose label" $
+            withSystemTempDirectory
+                "push-test-compose"
+                $ \dir -> do
+                    writeCompose
+                        dir
+                        [ "services:"
+                        , "  asteria-game:"
+                        , "    image: asteria-game:latest"
+                        , "    labels:"
+                        , "      com.antithesis.exclude_from_faults: \"network,kill,pause,stop\""
+                        ]
+                    result <- testBuildPostTestRunRequest dir
+                    fmap requestExclusions result
+                        `shouldBe` Right
+                            ( ["asteria-game"]
+                            , ["asteria-game"]
+                            , ["asteria-game"]
+                            , ["asteria-game"]
+                            )
+
+        it "populates disjoint exclusion lists from two services" $
+            withSystemTempDirectory
+                "push-test-compose"
+                $ \dir -> do
+                    writeCompose
+                        dir
+                        [ "services:"
+                        , "  alpha:"
+                        , "    image: alpha:latest"
+                        , "    labels:"
+                        , "      com.antithesis.exclude_from_faults: network"
+                        , "  beta:"
+                        , "    image: beta:latest"
+                        , "    labels:"
+                        , "      com.antithesis.exclude_from_faults: kill,pause"
+                        ]
+                    result <- testBuildPostTestRunRequest dir
+                    fmap requestExclusions result
+                        `shouldBe` Right
+                            ( ["alpha"]
+                            , ["beta"]
+                            , ["beta"]
+                            , []
+                            )
+
+        it "returns a PushFailure when docker-compose.yaml is missing" $
+            withSystemTempDirectory
+                "push-test-compose"
+                $ \dir -> do
+                    result <- testBuildPostTestRunRequest dir
+                    result
+                        `shouldBeComposeFailureContaining`
+                            [dir </> "docker-compose.yaml"]
+
+        it "returns a PushFailure for an unknown fault class" $
+            withSystemTempDirectory
+                "push-test-compose"
+                $ \dir -> do
+                    writeCompose
+                        dir
+                        [ "services:"
+                        , "  tracer:"
+                        , "    image: tracer:latest"
+                        , "    labels:"
+                        , "      com.antithesis.exclude_from_faults: netwrk"
+                        ]
+                    result <- testBuildPostTestRunRequest dir
+                    result
+                        `shouldBeComposeFailureContaining`
+                            ["tracer", "netwrk"]
 
 basePostTestRunRequest :: PostTestRunRequest
 basePostTestRunRequest =
@@ -164,3 +241,42 @@ lookupParam name request = do
     Aeson.Object topLevel <- Aeson.decode $ Aeson.encode request
     Aeson.Object params <- KeyMap.lookup (Key.fromString "params") topLevel
     KeyMap.lookup (Key.fromString name) params
+
+testBuildPostTestRunRequest
+    :: FilePath -> IO (Either PushFailure PostTestRunRequest)
+testBuildPostTestRunRequest dir =
+    buildPostTestRunRequest
+        (Directory dir)
+        "description"
+        3600
+        "registry/cardano-moog-config:dummy"
+        ["hal@cardanofoundation.org"]
+        "dummy"
+        Nothing
+        True
+        False
+
+writeCompose :: FilePath -> [String] -> IO ()
+writeCompose dir =
+    writeFile (dir </> "docker-compose.yaml") . unlines
+
+requestExclusions :: PostTestRunRequest -> ([String], [String], [String], [String])
+requestExclusions request =
+    ( networkFaultExclusion request
+    , containerFaultsKillExclusion request
+    , containerFaultsPauseExclusion request
+    , containerFaultsStopExclusion request
+    )
+
+shouldBeComposeFailureContaining
+    :: Either PushFailure PostTestRunRequest -> [String] -> IO ()
+shouldBeComposeFailureContaining
+    (Left (ComposeFaultExclusionParseFailure msg))
+    expected =
+        mapM_ (`shouldContain` msg) expected
+shouldBeComposeFailureContaining actual _ =
+    actual `shouldBe` Left (ComposeFaultExclusionParseFailure "")
+
+shouldContain :: String -> String -> IO ()
+shouldContain expected actual =
+    (expected `isInfixOf` actual) `shouldBe` True


### PR DESCRIPTION
Closes #107.

## Summary

- Add a docker-compose-label-driven mechanism for the four Antithesis fault-exclusion launch params (`custom.network_fault_exclusion`, `custom.container_faults_kill_exclusion`, `custom.container_faults_pause_exclusion`, `custom.container_faults_stop_exclusion`).
- Services labeled `com.antithesis.exclude_from_faults: "network,kill,pause,stop"` (any subset) are emitted in the corresponding lists at launch time. Both compose label-list and label-map forms are accepted; unknown tokens fail the launch with a service+token error.
- When no service in the testnet's compose carries a label class, moog omits the corresponding `custom.*_exclusion` param entirely so the notebook's existing default still applies (safe rollout — does not clobber the historical `tracer, tracer-sidecar, sidecar` exclusion until consumers take it over).

## Slices

- `e652907c` feat(agent): compose-label-driven fault-exclusion parser — new `Docker.FaultExclusion` module + 10 RED-first tests covering empty / per-class / disjoint / whitespace / empty-tokens / unknown-token / list-form / missing-file paths.
- `e095b4a8` feat(agent): emit `custom.*_exclusion` params in launch payload — four `[String]` fields on `PostTestRunRequest`, `ToJSON` emits each key only when non-empty (3 serialization tests; payload byte-identical to today's when all lists are `[]`).
- `1d9f8f14` feat(agent): wire compose fault-exclusion parser into push payload — `buildPostTestRunRequest` helper extracted from `pushTestToAntithesisIO` so the parse-and-populate path is unit-testable without the live HTTP POST; new `PushFailure` constructor `ComposeFaultExclusionParseFailure` surfaces parser errors; compose parse runs before `pushConfigImage` so config-image pushes are skipped on a bad compose.

## Test plan

- [x] Unit tests for the compose-label parser (10 cases — RED-first; map + list label forms; malformed-label error path).
- [x] Unit tests for `PostTestRunRequest` JSON serialization (3 cases — empty / partial / full; existing 7-field serialization byte-identical).
- [x] Unit tests for the wiring in `pushTestToAntithesisIO` (4 cases — labelled service populates all four lists; disjoint labels; missing compose; bad token).
- [x] Local `./gate.sh` green at every slice boundary (149 examples, 0 failures at HEAD).
- [ ] Manual: trigger one `cardano_node_master` run after `cardano-foundation/cardano-node-antithesis` bumps to the moog release that includes this PR and lands its compose-labels PR; confirm `custom.container_faults_*_exclusion` appears with `asteria-game`, `tx-generator`, and the existing diagnostic services.

## Follow-ups

- `cardano-foundation/cardano-node-antithesis` PR — add `com.antithesis.exclude_from_faults` labels to `tracer`, `tracer-sidecar`, `sidecar`, `tx-generator`, `asteria-game` in `testnets/cardano_node_master/docker-compose.yaml`; same plus `adversary` in `testnets/cardano_node_adversary/docker-compose.yaml`; bump the moog release tag in `.github/workflows/cardano-node.yaml`.
- `cardano-foundation/cardano-node-antithesis` follow-on — once 2-3 trys on master show zero new findings on the three Asteria scripts, remove the now-redundant `sdk_install_signal_trap` from `components/asteria-game/composer/asteria-game/*.sh`.

## Pre-existing breakage carried into this PR

- `nix develop` is broken on `origin/main` because `cabal-fmt 0.1.12` (pinned by `flake.nix:indexState = 2026-02-17`) doesn't allow `base 4.21.1.0` from the GHC 9.12.3 bump (`e07e88fc`). This PR's gate.sh therefore uses `nix run .#unit-tests` (the same path CI uses), not `nix develop -c cabal ...`. Repairing the dev shell is out of scope here — separate maintenance commit.

## Spec

`specs/107-compose-fault-exclusion/spec.md` + `plan.md` + `tasks.md` cover the design — P1 user story, 8 functional requirements, slice-by-slice TDD plan, and the rollout-safety invariant ("empty list ⇒ key absent ⇒ notebook default applies").
