### PR TITLE
Lib.GitHub.Auth.DeviceFlow OAuth device flow client

### DIFF
--- a/app/Moog/GitHub/DeviceFlowSmoke.hs
+++ b/app/Moog/GitHub/DeviceFlowSmoke.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Moog.GitHub.DeviceFlowSmoke
+    ( renderTokenEvidence
+    , main
+    )
+where
+
+import Data.ByteString qualified as BS
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
+import Lib.GitHub.Auth.DeviceFlow
+    ( ClientId (..)
+    , DeviceCodeResponse (..)
+    , DeviceFlowError
+    , OAuthToken (..)
+    , runDeviceFlow
+    )
+import System.Environment (getArgs)
+import System.Exit (die)
+
+renderTokenEvidence :: OAuthToken -> Text
+renderTokenEvidence (OAuthToken token) =
+    T.decodeUtf8 (BS.take 4 token)
+        <> " token="
+        <> T.pack (show $ BS.length token)
+
+main :: IO ()
+main = do
+    clientId <- parseClientId =<< getArgs
+    result <-
+        runDeviceFlow clientId [] $ \DeviceCodeResponse{..} -> do
+            putStrLn $ "Verification URI: " <> T.unpack dcVerificationUri
+            putStrLn $ "User code: " <> T.unpack dcUserCode
+    case result of
+        Left err ->
+            die $ "GitHub device flow failed: " <> showDeviceFlowError err
+        Right token ->
+            putStrLn $ "Token evidence: " <> T.unpack (renderTokenEvidence token)
+
+parseClientId :: [String] -> IO ClientId
+parseClientId ["--client-id", clientId]
+    | not (null clientId) = pure $ ClientId $ T.pack clientId
+parseClientId _ =
+    die "Usage: moog-github-device-flow-smoke --client-id <id>"
+
+showDeviceFlowError :: DeviceFlowError -> String
+showDeviceFlowError = show

--- a/app/moog-github-device-flow-smoke.hs
+++ b/app/moog-github-device-flow-smoke.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import Moog.GitHub.DeviceFlowSmoke qualified as DeviceFlowSmoke
+
+main :: IO ()
+main = DeviceFlowSmoke.main

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+nix build --quiet .#unit-tests --no-link

--- a/gate.sh
+++ b/gate.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 git diff --check
-nix build --quiet .#unit-tests --no-link
+nix run .#unit-tests

--- a/moog.cabal
+++ b/moog.cabal
@@ -403,6 +403,7 @@ test-suite e2e-tests
 test-suite unit-tests
   -- Import common warning flags.
   import:             warnings
+  ghc-options:        -threaded
 
   -- Base language which the package is written in.
   default-language:   Haskell2010

--- a/moog.cabal
+++ b/moog.cabal
@@ -347,6 +347,29 @@ executable moog-mpfs-v2-canary
   -- Base language which the package is written in.
   default-language: Haskell2010
 
+executable moog-github-device-flow-smoke
+  -- Import common warning flags.
+  import:           warnings
+
+  -- .hs or .lhs file containing the Main module.
+  main-is:          moog-github-device-flow-smoke.hs
+
+  -- Modules included in this executable, other than Main.
+  other-modules:    Moog.GitHub.DeviceFlowSmoke
+
+  -- Other library packages from which modules are imported.
+  build-depends:
+    , base
+    , bytestring
+    , moog
+    , text
+
+  -- Directories containing source files.
+  hs-source-dirs:   app
+
+  -- Base language which the package is written in.
+  default-language: Haskell2010
+
 test-suite e2e-tests
   -- Import common warning flags.
   import:           warnings
@@ -394,6 +417,7 @@ test-suite unit-tests
     Lib.EdToCurveSpec
     Lib.GitHub.Auth.DeviceFlow
     Lib.GitHub.Auth.DeviceFlow.Internal
+    Lib.GitHub.Auth.DeviceFlowSmokeSpec
     Lib.GitHub.Auth.DeviceFlowSpec
     Lib.JSON.Canonical.AesonSpec
     Lib.JSON.Canonical.ExtraSpec
@@ -430,6 +454,7 @@ test-suite unit-tests
   hs-source-dirs:
     test
     src
+    app
 
   -- The entrypoint to the test suite.
   main-is:            Main.hs

--- a/moog.cabal
+++ b/moog.cabal
@@ -85,7 +85,9 @@ common warnings
 library
   -- Import common warning flags.
   import:           warnings
-  other-modules:    Paths_moog
+  other-modules:
+    Lib.GitHub.Auth.DeviceFlow.Internal
+    Paths_moog
 
   -- Modules exported by the library.
   exposed-modules:
@@ -116,6 +118,7 @@ library
     Lib.CryptoBox
     Lib.EdToCurve
     Lib.GitHub
+    Lib.GitHub.Auth.DeviceFlow
     Lib.JSON.Canonical.Aeson
     Lib.JSON.Canonical.Extra
     Lib.Options.Secrets
@@ -389,6 +392,9 @@ test-suite unit-tests
     Docker.FaultExclusionSpec
     Lib.CryptoBoxSpec
     Lib.EdToCurveSpec
+    Lib.GitHub.Auth.DeviceFlow
+    Lib.GitHub.Auth.DeviceFlow.Internal
+    Lib.GitHub.Auth.DeviceFlowSpec
     Lib.JSON.Canonical.AesonSpec
     Lib.JSON.Canonical.ExtraSpec
     Lib.SSH.KeySpec
@@ -421,7 +427,9 @@ test-suite unit-tests
   type:               exitcode-stdio-1.0
 
   -- Directories containing source files.
-  hs-source-dirs:     test
+  hs-source-dirs:
+    test
+    src
 
   -- The entrypoint to the test suite.
   main-is:            Main.hs
@@ -430,24 +438,66 @@ test-suite unit-tests
   build-depends:
     , aeson
     , base
+    , base16-bytestring
+    , base64-bytestring
     , bech32
+    , binary
     , bytestring
     , canonical-json
+    , cardano-addresses
+    , cardano-crypto
+    , cardano-crypto-class
+    , cardano-ledger-api
+    , cardano-ledger-binary
+    , cardano-ledger-core
+    , cardano-ledger-mary
+    , cardano-mpfs-api
+    , cardano-mpfs-cage
+    , cardano-mpfs-client
+    , cardano-slotting
+    , cardano-tx-tools
     , case-insensitive
+    , containers
     , crypton
+    , crypton-box
     , directory
+    , exceptions
     , filepath
+    , github
+    , haskeline
+    , HaskellNet
+    , HaskellNet-SSL
+    , html-parse
     , hspec
+    , http-client
+    , http-client-tls
+    , http-types
     , lens
     , memory
+    , mmark
     , moog
     , moog:test-lib
+    , monad-control
+    , old-time
+    , opt-env-conf
+    , path
+    , plutus-tx
+    , process
+    , purebred-email
     , QuickCheck
+    , random
     , scientific
+    , servant
+    , servant-client
+    , streaming
     , string-qq
     , temporary
     , text
     , time
+    , transformers
+    , vector
+    , wai
+    , warp
     , yaml
 
   build-tool-depends: hspec-discover:hspec-discover

--- a/nix/moog-project.nix
+++ b/nix/moog-project.nix
@@ -79,6 +79,8 @@ in {
   packages.moog-agent = project.hsPkgs.moog.components.exes.moog-agent;
   packages.moog-mpfs-v2-canary =
     project.hsPkgs.moog.components.exes.moog-mpfs-v2-canary;
+  packages.moog-github-device-flow-smoke =
+    project.hsPkgs.moog.components.exes.moog-github-device-flow-smoke;
   packages.bech32 = project.hsPkgs.bech32.components.exes.bech32;
   packages.cardano-address =
     project.hsPkgs.cardano-addresses.components.exes.cardano-address;

--- a/specs/111-github-device-flow/plan.md
+++ b/specs/111-github-device-flow/plan.md
@@ -1,0 +1,84 @@
+# Plan — moog#111
+
+## Tech stack
+
+- Haskell, Cabal, GHC pinned by the existing project.
+- Existing `http-client`, `http-client-tls`, `http-types`, `aeson`, `bytestring`, `text`, and `transformers` dependencies for the client.
+- Unit tests in the existing `unit-tests` test-suite with hspec.
+- New test-only dependencies for the embedded mock server: `wai`, `warp`, and `unordered-containers` or equivalent request-form parsing support if the implementation needs it.
+
+The dependency-manifest edits are behavior-changing and must be made by the driver/navigator pair, not the orchestrator.
+
+## Module layout
+
+```text
+src/Lib/GitHub/Auth/DeviceFlow.hs                 # NEW public API.
+src/Lib/GitHub/Auth/DeviceFlow/Internal.hs        # NEW testable internals: endpoints/manager/delay injection.
+test/Lib/GitHub/Auth/DeviceFlowSpec.hs            # NEW embedded WAI mock-server tests.
+app/moog-github-device-flow-smoke.hs              # NEW live-boundary smoke harness.
+```
+
+`Lib.GitHub.Auth.DeviceFlow` exports only the issue-defined API. The internal module exists so the unit tests can point the state machine at the WAI mock server without changing the public `runDeviceFlow` signature. Sibling tickets must import the public module, not the internal one.
+
+## State machine
+
+The implementation should model the GitHub wire shape directly:
+
+- Device-code request: `POST /login/device/code`, form-encoded `client_id` and space-joined `scope`, with `Accept: application/json`.
+- Access-token request: `POST /login/oauth/access_token`, form-encoded `client_id`, `device_code`, and `grant_type=urn:ietf:params:oauth:grant-type:device_code`, with `Accept: application/json`.
+- Success response: JSON object containing `access_token`.
+- Pending response: JSON object containing `error = "authorization_pending"`.
+- Slow-down response: JSON object containing `error = "slow_down"`.
+- Terminal errors: `expired_token`, `access_denied`.
+
+The internal entry point should accept endpoint URLs and a delay function so tests run fast and deterministically.
+
+## Slices
+
+### Slice 0 — Orchestration bootstrap
+
+Owned by the ticket-orchestrator. Add `gate.sh`, spec, plan, and tasks; open the draft PR. No production or test behavior changes.
+
+### Slice 1 — Public API + mock-server unit coverage
+
+Add the device-flow module, internal test hook, cabal module/dependency declarations, and the hspec mock-server suite. This is the type-pinning slice. After the orchestrator accepts and pushes this commit, append the required `NOTE RELEASE: oauth-token-type-pinned ...` line to `/tmp/epic-109/moog-111/STATUS.md`.
+
+RED: add mock-server tests covering pending success, slow-down success, expired, denied, malformed JSON, callback fields, and parameter client id. Tests fail because the module does not exist.
+
+GREEN: implement the state machine with injectable internals and the public `runDeviceFlow` pointed at github.com.
+
+Bisect-safe because the new module is additive and has complete focused tests.
+
+### Slice 2 — Live-boundary smoke harness
+
+Add a tiny Cabal executable that accepts `--client-id`, calls the public `runDeviceFlow`, prints the verification URI and user code, and on success prints only a token prefix of 4 characters plus total token length. It must not read the client id from an environment variable.
+
+RED: add an executable-level smoke check or unit-level output-safety test proving the renderer never prints the full token.
+
+GREEN: implement the harness and cabal executable stanza.
+
+Bisect-safe because the executable is additive and does not alter library behavior.
+
+### Slice 3 — Real OAuth App smoke proof
+
+Use the OAuth App client id from #110 to run the live smoke manually through `cabal run moog-github-device-flow-smoke -- --client-id <id>`. Record the transcript artifact in `WIP.md` and the PR body, redacting the token except for first 4 characters and total length.
+
+If the client id is not available when this slice begins, raise a parent Q-file and log `BLOCKED Q-NNN-...` in STATUS.md.
+
+## Risks + mitigations
+
+- **Testing a fixed github.com endpoint.** The public API intentionally has no endpoint parameter, so tests use an internal injectable entry point. Public consumers still see only the issue-defined function.
+- **Long sleeps in unit tests.** The internal delay hook must be injectable; unit tests record requested delays without sleeping.
+- **Token leakage.** The smoke harness must construct an explicit redacted string and never log `unOAuthToken` directly.
+- **OAuth App dependency.** The live smoke depends on #110. Planning and implementation can proceed before the real client id exists; only Slice 3 blocks on it.
+
+## Gate
+
+`./gate.sh` runs:
+
+```bash
+git diff --check
+nix build --quiet .#unit-tests --no-link
+```
+
+The live-boundary smoke is not run automatically by `gate.sh` because it needs an operator-approved OAuth App client id and browser approval. It is a named pre-ready proof in Slice 3.

--- a/specs/111-github-device-flow/spec.md
+++ b/specs/111-github-device-flow/spec.md
@@ -1,0 +1,75 @@
+# Spec — moog#111 GitHub OAuth Device Flow client
+
+## P1 user story
+
+As a moog operator who needs to call the future Antithesis proxy from a laptop or CI runner, I can run a pure Haskell GitHub OAuth Device Flow client with a caller-supplied OAuth App `client_id`, see the GitHub verification URL and user code, approve the request in the browser, and receive an `OAuthToken` value without any moog-specific state or environment-variable dependency.
+
+## Why
+
+The parent epic (#109) needs a GitHub-team-gated Antithesis HTTP proxy. The CLI side must obtain a GitHub user token before later tickets can identify the user (#112), cache the token and expose commands (#114), or authenticate requests through the proxy (#113).
+
+This ticket is the type-defining foundation for that stack. `OAuthToken` and the related newtypes must be stable enough for sibling tickets to import after the first implementation slice lands.
+
+## Authoritative API
+
+```haskell
+module Lib.GitHub.Auth.DeviceFlow
+    ( ClientId (..)
+    , Scope (..)
+    , OAuthToken (..)
+    , DeviceCodeResponse (..)
+    , DeviceFlowError (..)
+    , runDeviceFlow
+    ) where
+
+newtype ClientId = ClientId Text
+newtype Scope = Scope Text
+newtype OAuthToken = OAuthToken {unOAuthToken :: ByteString}
+
+data DeviceCodeResponse = DeviceCodeResponse
+    { dcVerificationUri :: Text
+    , dcUserCode :: Text
+    , dcExpiresIn :: Int
+    , dcInterval :: Int
+    }
+
+data DeviceFlowError
+    = ExpiredToken
+    | AccessDenied
+    | UnexpectedStatus Int Text
+    | NetworkError Text
+
+runDeviceFlow
+    :: MonadIO m
+    => ClientId
+    -> [Scope]
+    -> (DeviceCodeResponse -> m ())
+    -> m (Either DeviceFlowError OAuthToken)
+```
+
+## Functional requirements
+
+- **F1** Add `Lib.GitHub.Auth.DeviceFlow` under `src/Lib/GitHub/Auth/DeviceFlow.hs` with exactly the exported public API above.
+- **F2** `runDeviceFlow` sends `POST /login/device/code` as form data containing `client_id` and the requested scopes, parses `device_code`, `user_code`, `verification_uri`, `expires_in`, and `interval`, then invokes the caller callback once with the parsed `DeviceCodeResponse`.
+- **F3** `runDeviceFlow` polls `POST /login/oauth/access_token` as form data containing `client_id`, `device_code`, and `grant_type=urn:ietf:params:oauth:grant-type:device_code`.
+- **F4** Polling waits the server-provided interval between attempts, continues on `authorization_pending`, increases the interval by 5 seconds on `slow_down`, returns `Left ExpiredToken` on `expired_token`, returns `Left AccessDenied` on `access_denied`, and returns `Right (OAuthToken access_token)` on success.
+- **F5** Non-2xx HTTP statuses, unrecognized OAuth error strings, and malformed JSON are reported as `Left (UnexpectedStatus status body)` where an HTTP status exists, or `Left (NetworkError text)` when the request cannot be completed or decoded into the expected shape.
+- **F6** The library never reads a client id from the environment. `ClientId` is always an explicit parameter.
+- **F7** The unit suite uses an embedded WAI mock server and does not call github.com.
+- **F8** The live-boundary smoke uses the actual exported API against github.com, prints the `user_code`, waits for browser approval, and prints only the resulting token prefix length evidence: first 4 characters plus total length, never the full token.
+
+## Success criteria
+
+- **S1** Unit tests cover `authorization_pending -> success`, `slow_down -> success`, `expired_token`, `access_denied`, and malformed JSON against an embedded WAI mock server.
+- **S2** Unit tests prove the callback receives `verification_uri`, `user_code`, `expires_in`, and `interval` from the mock device-code response.
+- **S3** Unit tests prove `client_id` is sent from the `ClientId` parameter, not read from an environment variable.
+- **S4** The public API is pinned and announced to the parent epic after the first implementation slice passes its focused unit gate.
+- **S5** A tiny Cabal-runnable smoke harness exists for the real OAuth App from #110 and never logs a full token.
+- **S6** `gate.sh` passes at every accepted slice boundary.
+
+## Out of scope
+
+- Caching the token to disk.
+- Calling GitHub APIs with the token.
+- CLI UX for invoking the flow.
+- Proxy authentication or team membership checks.

--- a/specs/111-github-device-flow/tasks.md
+++ b/specs/111-github-device-flow/tasks.md
@@ -1,0 +1,49 @@
+# Tasks — moog#111
+
+## Slice 0 — Orchestration bootstrap
+
+- [X] T111-S0.1 Add `gate.sh` with the ticket gate commands.
+- [X] T111-S0.2 Add `specs/111-github-device-flow/spec.md`.
+- [X] T111-S0.3 Add `specs/111-github-device-flow/plan.md`.
+- [X] T111-S0.4 Add `specs/111-github-device-flow/tasks.md`.
+- [X] T111-S0.5 Commit with subject `chore(#111): bootstrap device-flow ticket gate`.
+- [X] T111-S0.6 Open a draft PR linked to #111.
+
+## Slice 1 — Public API + mock-server unit coverage
+
+- [ ] T111-S1.1 Add `Lib.GitHub.Auth.DeviceFlow` to the library exposed modules and add a testable internal module as needed.
+- [ ] T111-S1.2 Add the cabal dependencies needed for JSON HTTP client behavior and embedded WAI mock-server tests.
+- [ ] T111-S1.3 RED: add `test/Lib/GitHub/Auth/DeviceFlowSpec.hs` covering `authorization_pending -> success`, `slow_down -> success`, `expired_token`, `access_denied`, malformed JSON, callback fields, and parameter-sourced `client_id`.
+- [ ] T111-S1.4 GREEN: implement the device-code request, callback invocation, polling loop, interval slow-down behavior, terminal errors, success token parsing, and network/decode error mapping.
+- [ ] T111-S1.5 Run `./gate.sh` green.
+- [ ] T111-S1.6 Commit with subject `feat(auth): add GitHub OAuth device flow client` and trailer `Tasks: T111-S1`.
+
+## Slice 2 — Live-boundary smoke harness
+
+- [ ] T111-S2.1 Add the cabal executable stanza for `moog-github-device-flow-smoke`.
+- [ ] T111-S2.2 RED: add a focused test proving smoke output redacts the token to first 4 characters plus total length and never includes the full token.
+- [ ] T111-S2.3 GREEN: implement `app/moog-github-device-flow-smoke.hs` using the exported `runDeviceFlow` API and a required `--client-id` argument.
+- [ ] T111-S2.4 Run `./gate.sh` green.
+- [ ] T111-S2.5 Commit with subject `feat(auth): add GitHub device-flow live smoke` and trailer `Tasks: T111-S2`.
+
+## Slice 3 — Real OAuth App smoke proof
+
+- [ ] T111-S3.1 Obtain the #110 OAuth App client id from the parent epic via Q/A file if it is not already available.
+- [ ] T111-S3.2 Run `cabal run moog-github-device-flow-smoke -- --client-id <id>` against github.com.
+- [ ] T111-S3.3 Record the redacted transcript artifact in `WIP.md` and the PR body; verify it contains only token first 4 characters and length.
+- [ ] T111-S3.4 Run `./gate.sh` green after recording PR metadata.
+- [ ] T111-S3.5 Commit any final PR metadata updates with subject `docs(#111): record device-flow live smoke proof`.
+
+## Finalization (orchestrator)
+
+- [ ] T111-F1 Audit the PR body against delivered behavior and test evidence.
+- [ ] T111-F2 Run finalization audit for this branch and `specs/111-github-device-flow/tasks.md`.
+- [ ] T111-F3 Drop `gate.sh` in `chore(#111): drop gate.sh (ready for review)`.
+- [ ] T111-F4 Mark the draft PR ready for review.
+- [ ] T111-F5 Wait for review and merge. Do not self-merge.
+
+## Post-merge cleanup (orchestrator)
+
+- [ ] T111-C1 After merge, remove `/code/moog-issue-111`.
+- [ ] T111-C2 Delete local and remote branch `feat/111-deviceflow`.
+- [ ] T111-C3 Run `git worktree prune`.

--- a/specs/111-github-device-flow/tasks.md
+++ b/specs/111-github-device-flow/tasks.md
@@ -42,6 +42,14 @@
 - [X] T111-R1.4 Run `./gate.sh` green.
 - [X] T111-R1.5 Commit with subject `fix(auth): make device-flow mock tests pass in CI` and trailer `Tasks: T111-R1`.
 
+## Repair Slice R2 — Runnable smoke executable
+
+- [X] T111-R2.1 RED: prove `nix run .#moog-github-device-flow-smoke -- --client-id <id>` currently fails because the smoke executable is not exposed as a flake package/app.
+- [X] T111-R2.2 GREEN: expose the existing `moog-github-device-flow-smoke` executable through the flake package outputs without changing the production library API.
+- [X] T111-R2.3 Prove `nix run .#moog-github-device-flow-smoke -- --client-id <id>` starts the live device flow and emits a GitHub verification URI/user code.
+- [X] T111-R2.4 Run `./gate.sh` green.
+- [X] T111-R2.5 Commit with subject `fix(auth): expose device-flow smoke executable` and trailer `Tasks: T111-R2`.
+
 ## Finalization (orchestrator)
 
 - [ ] T111-F1 Audit the PR body against delivered behavior and test evidence.

--- a/specs/111-github-device-flow/tasks.md
+++ b/specs/111-github-device-flow/tasks.md
@@ -34,6 +34,14 @@
 - [ ] T111-S3.4 Run `./gate.sh` green after recording PR metadata.
 - [ ] T111-S3.5 Commit any final PR metadata updates with subject `docs(#111): record device-flow live smoke proof`.
 
+## Repair Slice R1 — CI unit-test runner parity
+
+- [X] T111-R1.1 RED: make `./gate.sh` run the unit-test executable like CI (`nix run .#unit-tests`) and reproduce the six `Lib.GitHub.Auth.DeviceFlow` failures locally.
+- [X] T111-R1.2 Diagnose why the WAI/Warp mock-server tests fail under the CI-style runner while the build-only gate passed.
+- [X] T111-R1.3 GREEN: fix the test harness or test-suite runtime settings so the DeviceFlow mock-server tests pass under `nix run .#unit-tests -- --match Lib.GitHub.Auth.DeviceFlow`.
+- [X] T111-R1.4 Run `./gate.sh` green.
+- [X] T111-R1.5 Commit with subject `fix(auth): make device-flow mock tests pass in CI` and trailer `Tasks: T111-R1`.
+
 ## Finalization (orchestrator)
 
 - [ ] T111-F1 Audit the PR body against delivered behavior and test evidence.

--- a/specs/111-github-device-flow/tasks.md
+++ b/specs/111-github-device-flow/tasks.md
@@ -28,11 +28,11 @@
 
 ## Slice 3 — Real OAuth App smoke proof
 
-- [ ] T111-S3.1 Obtain the #110 OAuth App client id from the parent epic via Q/A file if it is not already available.
-- [ ] T111-S3.2 Run `cabal run moog-github-device-flow-smoke -- --client-id <id>` against github.com.
-- [ ] T111-S3.3 Record the redacted transcript artifact in `WIP.md` and the PR body; verify it contains only token first 4 characters and length.
-- [ ] T111-S3.4 Run `./gate.sh` green after recording PR metadata.
-- [ ] T111-S3.5 Commit any final PR metadata updates with subject `docs(#111): record device-flow live smoke proof`.
+- [X] T111-S3.1 Obtain the #110 OAuth App client id from the parent epic via Q/A file if it is not already available.
+- [X] T111-S3.2 Run `nix run .#moog-github-device-flow-smoke -- --client-id <id>` against github.com.
+- [X] T111-S3.3 Record the redacted transcript artifact in `WIP.md` and the PR body; verify it contains only token first 4 characters and length.
+- [X] T111-S3.4 Run `./gate.sh` green after recording PR metadata.
+- [X] T111-S3.5 Commit any final PR metadata updates with subject `docs(#111): record device-flow live smoke proof`.
 
 ## Repair Slice R1 — CI unit-test runner parity
 

--- a/specs/111-github-device-flow/tasks.md
+++ b/specs/111-github-device-flow/tasks.md
@@ -20,11 +20,11 @@
 
 ## Slice 2 — Live-boundary smoke harness
 
-- [ ] T111-S2.1 Add the cabal executable stanza for `moog-github-device-flow-smoke`.
-- [ ] T111-S2.2 RED: add a focused test proving smoke output redacts the token to first 4 characters plus total length and never includes the full token.
-- [ ] T111-S2.3 GREEN: implement `app/moog-github-device-flow-smoke.hs` using the exported `runDeviceFlow` API and a required `--client-id` argument.
-- [ ] T111-S2.4 Run `./gate.sh` green.
-- [ ] T111-S2.5 Commit with subject `feat(auth): add GitHub device-flow live smoke` and trailer `Tasks: T111-S2`.
+- [X] T111-S2.1 Add the cabal executable stanza for `moog-github-device-flow-smoke`.
+- [X] T111-S2.2 RED: add a focused test proving smoke output redacts the token to first 4 characters plus total length and never includes the full token.
+- [X] T111-S2.3 GREEN: implement `app/moog-github-device-flow-smoke.hs` using the exported `runDeviceFlow` API and a required `--client-id` argument.
+- [X] T111-S2.4 Run `./gate.sh` green.
+- [X] T111-S2.5 Commit with subject `feat(auth): add GitHub device-flow live smoke` and trailer `Tasks: T111-S2`.
 
 ## Slice 3 — Real OAuth App smoke proof
 

--- a/specs/111-github-device-flow/tasks.md
+++ b/specs/111-github-device-flow/tasks.md
@@ -11,12 +11,12 @@
 
 ## Slice 1 — Public API + mock-server unit coverage
 
-- [ ] T111-S1.1 Add `Lib.GitHub.Auth.DeviceFlow` to the library exposed modules and add a testable internal module as needed.
-- [ ] T111-S1.2 Add the cabal dependencies needed for JSON HTTP client behavior and embedded WAI mock-server tests.
-- [ ] T111-S1.3 RED: add `test/Lib/GitHub/Auth/DeviceFlowSpec.hs` covering `authorization_pending -> success`, `slow_down -> success`, `expired_token`, `access_denied`, malformed JSON, callback fields, and parameter-sourced `client_id`.
-- [ ] T111-S1.4 GREEN: implement the device-code request, callback invocation, polling loop, interval slow-down behavior, terminal errors, success token parsing, and network/decode error mapping.
-- [ ] T111-S1.5 Run `./gate.sh` green.
-- [ ] T111-S1.6 Commit with subject `feat(auth): add GitHub OAuth device flow client` and trailer `Tasks: T111-S1`.
+- [X] T111-S1.1 Add `Lib.GitHub.Auth.DeviceFlow` to the library exposed modules and add a testable internal module as needed.
+- [X] T111-S1.2 Add the cabal dependencies needed for JSON HTTP client behavior and embedded WAI mock-server tests.
+- [X] T111-S1.3 RED: add `test/Lib/GitHub/Auth/DeviceFlowSpec.hs` covering `authorization_pending -> success`, `slow_down -> success`, `expired_token`, `access_denied`, malformed JSON, callback fields, and parameter-sourced `client_id`.
+- [X] T111-S1.4 GREEN: implement the device-code request, callback invocation, polling loop, interval slow-down behavior, terminal errors, success token parsing, and network/decode error mapping.
+- [X] T111-S1.5 Run `./gate.sh` green.
+- [X] T111-S1.6 Commit with subject `feat(auth): add GitHub OAuth device flow client` and trailer `Tasks: T111-S1`.
 
 ## Slice 2 — Live-boundary smoke harness
 

--- a/src/Lib/GitHub/Auth/DeviceFlow.hs
+++ b/src/Lib/GitHub/Auth/DeviceFlow.hs
@@ -1,0 +1,31 @@
+module Lib.GitHub.Auth.DeviceFlow
+    ( ClientId (..)
+    , Scope (..)
+    , OAuthToken (..)
+    , DeviceCodeResponse (..)
+    , DeviceFlowError (..)
+    , runDeviceFlow
+    )
+where
+
+import Control.Concurrent (threadDelay)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Lib.GitHub.Auth.DeviceFlow.Internal
+    ( ClientId (..)
+    , DeviceCodeResponse (..)
+    , DeviceFlowError (..)
+    , OAuthToken (..)
+    , Scope (..)
+    , githubDeviceFlowEndpoints
+    , runDeviceFlowWith
+    )
+
+runDeviceFlow
+    :: MonadIO m
+    => ClientId
+    -> [Scope]
+    -> (DeviceCodeResponse -> m ())
+    -> m (Either DeviceFlowError OAuthToken)
+runDeviceFlow =
+    runDeviceFlowWith githubDeviceFlowEndpoints $ \seconds ->
+        liftIO $ threadDelay $ seconds * 1000000

--- a/src/Lib/GitHub/Auth/DeviceFlow/Internal.hs
+++ b/src/Lib/GitHub/Auth/DeviceFlow/Internal.hs
@@ -1,0 +1,246 @@
+module Lib.GitHub.Auth.DeviceFlow.Internal
+    ( ClientId (..)
+    , Scope (..)
+    , OAuthToken (..)
+    , DeviceCodeResponse (..)
+    , DeviceFlowError (..)
+    , DeviceFlowEndpoints (..)
+    , githubDeviceFlowEndpoints
+    , runDeviceFlowWith
+    )
+where
+
+import Control.Applicative ((<|>))
+import Control.Exception (try)
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.Aeson
+    ( FromJSON (parseJSON)
+    , eitherDecode
+    , withObject
+    , (.:)
+    )
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
+import Network.HTTP.Client
+    ( HttpException
+    , Manager
+    , Request (method, requestHeaders)
+    , Response (responseBody, responseStatus)
+    , httpLbs
+    , newManager
+    , parseRequest
+    , urlEncodedBody
+    )
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Network.HTTP.Types.Status (statusCode)
+
+newtype ClientId = ClientId Text
+    deriving stock (Eq, Show)
+
+newtype Scope = Scope Text
+    deriving stock (Eq, Show)
+
+newtype OAuthToken = OAuthToken {unOAuthToken :: ByteString}
+    deriving stock (Eq, Show)
+
+data DeviceCodeResponse = DeviceCodeResponse
+    { dcVerificationUri :: Text
+    , dcUserCode :: Text
+    , dcExpiresIn :: Int
+    , dcInterval :: Int
+    }
+    deriving stock (Eq, Show)
+
+data DeviceFlowError
+    = ExpiredToken
+    | AccessDenied
+    | UnexpectedStatus Int Text
+    | NetworkError Text
+    deriving stock (Eq, Show)
+
+data DeviceFlowEndpoints = DeviceFlowEndpoints
+    { deviceCodeEndpoint :: String
+    , accessTokenEndpoint :: String
+    }
+    deriving stock (Eq, Show)
+
+githubDeviceFlowEndpoints :: DeviceFlowEndpoints
+githubDeviceFlowEndpoints =
+    DeviceFlowEndpoints
+        { deviceCodeEndpoint = "https://github.com/login/device/code"
+        , accessTokenEndpoint = "https://github.com/login/oauth/access_token"
+        }
+
+runDeviceFlowWith
+    :: MonadIO m
+    => DeviceFlowEndpoints
+    -> (Int -> m ())
+    -> ClientId
+    -> [Scope]
+    -> (DeviceCodeResponse -> m ())
+    -> m (Either DeviceFlowError OAuthToken)
+runDeviceFlowWith endpoints delay clientId scopes callback = do
+    manager <- liftIO $ newManager tlsManagerSettings
+    deviceCodeResult <-
+        liftIO
+            $ requestDeviceCode
+                manager
+                (deviceCodeEndpoint endpoints)
+                clientId
+                scopes
+    case deviceCodeResult of
+        Left err -> pure $ Left err
+        Right deviceCode -> do
+            let response = toDeviceCodeResponse deviceCode
+            callback response
+            pollForToken
+                manager
+                (accessTokenEndpoint endpoints)
+                delay
+                clientId
+                (deviceCodeValue deviceCode)
+                (dcInterval response)
+
+requestDeviceCode
+    :: Manager
+    -> String
+    -> ClientId
+    -> [Scope]
+    -> IO (Either DeviceFlowError DeviceCodeWire)
+requestDeviceCode manager endpoint clientId scopes =
+    postJson
+        manager
+        endpoint
+        [ ("client_id", encodeText $ unClientId clientId)
+        , ("scope", encodeText $ renderScopes scopes)
+        ]
+
+pollForToken
+    :: MonadIO m
+    => Manager
+    -> String
+    -> (Int -> m ())
+    -> ClientId
+    -> Text
+    -> Int
+    -> m (Either DeviceFlowError OAuthToken)
+pollForToken manager endpoint delay clientId deviceCode interval = do
+    pollResult <-
+        liftIO
+            $ postJson
+                manager
+                endpoint
+                [ ("client_id", encodeText $ unClientId clientId)
+                , ("device_code", encodeText deviceCode)
+                ,
+                    ( "grant_type"
+                    , "urn:ietf:params:oauth:grant-type:device_code"
+                    )
+                ]
+    case pollResult of
+        Left err -> pure $ Left err
+        Right (PollAccessToken token) ->
+            pure $ Right $ OAuthToken $ encodeText token
+        Right (PollError "authorization_pending") -> do
+            delay interval
+            pollForToken manager endpoint delay clientId deviceCode interval
+        Right (PollError "slow_down") -> do
+            let nextInterval = interval + 5
+            delay nextInterval
+            pollForToken manager endpoint delay clientId deviceCode nextInterval
+        Right (PollError "expired_token") ->
+            pure $ Left ExpiredToken
+        Right (PollError "access_denied") ->
+            pure $ Left AccessDenied
+        Right (PollError err) ->
+            pure $ Left $ NetworkError $ "GitHub device-flow error: " <> err
+
+postJson
+    :: FromJSON a
+    => Manager
+    -> String
+    -> [(ByteString, ByteString)]
+    -> IO (Either DeviceFlowError a)
+postJson manager endpoint form = do
+    requestResult <- try @HttpException $ do
+        baseRequest <- parseRequest endpoint
+        let request =
+                urlEncodedBody form
+                    baseRequest
+                        { method = "POST"
+                        , requestHeaders =
+                            ("Accept", "application/json")
+                                : requestHeaders baseRequest
+                        }
+        httpLbs request manager
+    pure $ case requestResult of
+        Left err -> Left $ NetworkError $ T.pack $ show err
+        Right response ->
+            let body = responseBody response
+                code = statusCode $ responseStatus response
+             in if code == 200
+                    then decodeBody body
+                    else Left $ UnexpectedStatus code $ decodeBodyText body
+
+decodeBody :: FromJSON a => LBS.ByteString -> Either DeviceFlowError a
+decodeBody body =
+    case eitherDecode body of
+        Left err -> Left $ NetworkError $ T.pack err
+        Right value -> Right value
+
+decodeBodyText :: LBS.ByteString -> Text
+decodeBodyText = T.decodeUtf8With lenientDecode . LBS.toStrict
+  where
+    lenientDecode _ _ = Just '\xfffd'
+
+encodeText :: Text -> ByteString
+encodeText = T.encodeUtf8
+
+renderScopes :: [Scope] -> Text
+renderScopes scopes =
+    T.intercalate " " [scope | Scope scope <- scopes]
+
+unClientId :: ClientId -> Text
+unClientId (ClientId clientId) = clientId
+
+data DeviceCodeWire = DeviceCodeWire
+    { deviceCodeValue :: Text
+    , userCodeValue :: Text
+    , verificationUriValue :: Text
+    , expiresInValue :: Int
+    , intervalValue :: Int
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON DeviceCodeWire where
+    parseJSON =
+        withObject "DeviceCodeResponse" $ \objectValue ->
+            DeviceCodeWire
+                <$> objectValue .: "device_code"
+                <*> objectValue .: "user_code"
+                <*> objectValue .: "verification_uri"
+                <*> objectValue .: "expires_in"
+                <*> objectValue .: "interval"
+
+toDeviceCodeResponse :: DeviceCodeWire -> DeviceCodeResponse
+toDeviceCodeResponse DeviceCodeWire{..} =
+    DeviceCodeResponse
+        { dcVerificationUri = verificationUriValue
+        , dcUserCode = userCodeValue
+        , dcExpiresIn = expiresInValue
+        , dcInterval = intervalValue
+        }
+
+data PollResponse
+    = PollAccessToken Text
+    | PollError Text
+    deriving stock (Eq, Show)
+
+instance FromJSON PollResponse where
+    parseJSON =
+        withObject "DeviceFlowPollResponse" $ \objectValue ->
+            (PollAccessToken <$> objectValue .: "access_token")
+                <|> (PollError <$> objectValue .: "error")

--- a/test/Lib/GitHub/Auth/DeviceFlowSmokeSpec.hs
+++ b/test/Lib/GitHub/Auth/DeviceFlowSmokeSpec.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Lib.GitHub.Auth.DeviceFlowSmokeSpec
+    ( spec
+    )
+where
+
+import Data.Text qualified as T
+import Lib.GitHub.Auth.DeviceFlow (OAuthToken (..))
+import Moog.GitHub.DeviceFlowSmoke (renderTokenEvidence)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+
+spec :: Spec
+spec =
+    describe "renderTokenEvidence" $ do
+        it "prints the token prefix and length without printing the full token" $ do
+            let token = "ghu_abcdefghijklmnopqrstuvwxyz"
+                evidence = renderTokenEvidence $ OAuthToken token
+
+            evidence `shouldSatisfy` T.isInfixOf "ghu_"
+            evidence `shouldSatisfy` T.isInfixOf "30"
+            evidence `shouldSatisfy` not . T.isInfixOf "ghu_abcdefghijklmnopqrstuvwxyz"
+            T.length evidence `shouldBe` 13

--- a/test/Lib/GitHub/Auth/DeviceFlowSpec.hs
+++ b/test/Lib/GitHub/Auth/DeviceFlowSpec.hs
@@ -1,0 +1,279 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Lib.GitHub.Auth.DeviceFlowSpec
+    ( spec
+    )
+where
+
+import Control.Concurrent.MVar
+    ( MVar
+    , modifyMVar
+    , modifyMVar_
+    , newMVar
+    , readMVar
+    )
+import Control.Monad (forM_)
+import Data.Aeson (Value, encode, object, (.=))
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as LBS
+import Data.List (find)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Lib.GitHub.Auth.DeviceFlow
+    ( ClientId (..)
+    , DeviceCodeResponse (..)
+    , DeviceFlowError (..)
+    , OAuthToken (..)
+    , Scope (..)
+    )
+import Lib.GitHub.Auth.DeviceFlow.Internal
+    ( DeviceFlowEndpoints (..)
+    , runDeviceFlowWith
+    )
+import Network.HTTP.Types
+    ( Query
+    , Status
+    , hContentType
+    , methodPost
+    , parseQuery
+    , status200
+    , status404
+    )
+import Network.Wai
+    ( Application
+    , Request (rawPathInfo, requestMethod)
+    , Response
+    , responseLBS
+    , strictRequestBody
+    )
+import Network.Wai.Handler.Warp (testWithApplication)
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    , shouldSatisfy
+    )
+
+data RecordedRequest = RecordedRequest
+    { recordedPath :: ByteString
+    , recordedBody :: LBS.ByteString
+    }
+    deriving stock (Eq, Show)
+
+spec :: Spec
+spec = do
+    describe "runDeviceFlowWith" $ do
+        it "keeps polling after authorization_pending and returns the access token" $ do
+            outcome <-
+                withMockGitHub
+                    [ jsonResponse $ object ["error" .= ("authorization_pending" :: Text)]
+                    , jsonResponse $ object ["access_token" .= ("token-one" :: Text)]
+                    ]
+                    $ \endpoints requests -> do
+                        delays <- newMVar []
+                        result <-
+                            runDeviceFlowWith
+                                endpoints
+                                (recordDelay delays)
+                                (ClientId "client-one")
+                                [Scope "repo"]
+                                (const $ pure ())
+                        (,,)
+                            <$> pure result
+                            <*> readMVar delays
+                            <*> readMVar requests
+
+            let (result, delays, requests) = outcome
+            result `shouldBe` Right (OAuthToken "token-one")
+            delays `shouldBe` [1]
+            requestPaths requests
+                `shouldBe` ["/login/device/code", "/login/oauth/access_token", "/login/oauth/access_token"]
+
+        it "increases the next polling delay by five seconds after slow_down" $ do
+            outcome <-
+                withMockGitHub
+                    [ jsonResponse $ object ["error" .= ("slow_down" :: Text)]
+                    , jsonResponse $ object ["access_token" .= ("token-two" :: Text)]
+                    ]
+                    $ \endpoints _requests -> do
+                        delays <- newMVar []
+                        result <-
+                            runDeviceFlowWith
+                                endpoints
+                                (recordDelay delays)
+                                (ClientId "client-two")
+                                [Scope "repo"]
+                                (const $ pure ())
+                        (result,) <$> readMVar delays
+
+            outcome `shouldBe` (Right (OAuthToken "token-two"), [6])
+
+        it "returns ExpiredToken for expired_token polling responses" $ do
+            result <-
+                withMockGitHub
+                    [jsonResponse $ object ["error" .= ("expired_token" :: Text)]]
+                    $ \endpoints _requests ->
+                        runDeviceFlowWith
+                            endpoints
+                            (const $ pure ())
+                            (ClientId "client-three")
+                            [Scope "repo"]
+                            (const $ pure ())
+
+            result `shouldBe` Left ExpiredToken
+
+        it "returns AccessDenied for access_denied polling responses" $ do
+            result <-
+                withMockGitHub
+                    [jsonResponse $ object ["error" .= ("access_denied" :: Text)]]
+                    $ \endpoints _requests ->
+                        runDeviceFlowWith
+                            endpoints
+                            (const $ pure ())
+                            (ClientId "client-four")
+                            [Scope "repo"]
+                            (const $ pure ())
+
+            result `shouldBe` Left AccessDenied
+
+        it "maps malformed JSON responses to NetworkError" $ do
+            result <-
+                withMockGitHub ["not-json"] $ \endpoints _requests ->
+                    runDeviceFlowWith
+                        endpoints
+                        (const $ pure ())
+                        (ClientId "client-five")
+                        [Scope "repo"]
+                        (const $ pure ())
+
+            result `shouldSatisfy` \case
+                Left (NetworkError message) -> not (null $ show message)
+                _ -> False
+
+        it "passes the complete device-code payload to the callback" $ do
+            callbackPayload <-
+                withMockGitHub
+                    [jsonResponse $ object ["access_token" .= ("token-three" :: Text)]]
+                    $ \endpoints _requests -> do
+                        payloads <- newMVar []
+                        _ <-
+                            runDeviceFlowWith
+                                endpoints
+                                (const $ pure ())
+                                (ClientId "client-six")
+                                [Scope "repo"]
+                                (\payload -> modifyMVar_ payloads $ \xs -> pure (xs <> [payload]))
+                        readMVar payloads
+
+            callbackPayload
+                `shouldBe` [ DeviceCodeResponse
+                                { dcVerificationUri = "https://github.com/login/device"
+                                , dcUserCode = "ABCD-EFGH"
+                                , dcExpiresIn = 900
+                                , dcInterval = 1
+                                }
+                           ]
+
+        it "uses the explicit ClientId parameter in every request body" $ do
+            requests <-
+                withMockGitHub
+                    [jsonResponse $ object ["access_token" .= ("token-four" :: Text)]]
+                    $ \endpoints requestLog -> do
+                        _ <-
+                            runDeviceFlowWith
+                                endpoints
+                                (const $ pure ())
+                                (ClientId "explicit-client")
+                                [Scope "repo", Scope "read:user"]
+                                (const $ pure ())
+                        readMVar requestLog
+
+            forM_ requests $ \request ->
+                formBody request `lookupParam` "client_id" `shouldBe` Just "explicit-client"
+            let deviceRequest =
+                    fromMaybe (error "missing device-code request")
+                        $ find ((== "/login/device/code") . recordedPath) requests
+            formBody deviceRequest `lookupParam` "scope" `shouldBe` Just "repo read:user"
+
+withMockGitHub
+    :: [LBS.ByteString]
+    -> (DeviceFlowEndpoints -> MVar [RecordedRequest] -> IO a)
+    -> IO a
+withMockGitHub tokenResponses action = do
+    requests <- newMVar []
+    responses <- newMVar tokenResponses
+    testWithApplication (pure $ application requests responses) $ \port ->
+        action
+            DeviceFlowEndpoints
+                { deviceCodeEndpoint =
+                    "http://127.0.0.1:" <> show port <> "/login/device/code"
+                , accessTokenEndpoint =
+                    "http://127.0.0.1:" <> show port <> "/login/oauth/access_token"
+                }
+            requests
+
+application :: MVar [RecordedRequest] -> MVar [LBS.ByteString] -> Application
+application requests responses request respond = do
+    body <- strictRequestBody request
+    modifyMVar_ requests $ \xs ->
+        pure
+            $ xs
+                <> [ RecordedRequest
+                        { recordedPath = rawPathInfo request
+                        , recordedBody = body
+                        }
+                   ]
+    if requestMethod request == methodPost
+        then respondForPath body
+        else respond $ responseLBS status404 [] ""
+  where
+    respondForPath _body = case rawPathInfo request of
+        "/login/device/code" ->
+            respond $ json status200 deviceCodeResponse
+        "/login/oauth/access_token" -> do
+            response <- popResponse responses
+            respond $ responseLBS status200 [(hContentType, "application/json")] response
+        _ ->
+            respond $ responseLBS status404 [] ""
+
+deviceCodeResponse :: Value
+deviceCodeResponse =
+    object
+        [ "device_code" .= ("device-code-from-server" :: Text)
+        , "user_code" .= ("ABCD-EFGH" :: Text)
+        , "verification_uri" .= ("https://github.com/login/device" :: Text)
+        , "expires_in" .= (900 :: Int)
+        , "interval" .= (1 :: Int)
+        ]
+
+json :: Status -> Value -> Response
+json status value =
+    responseLBS status [(hContentType, "application/json")] (encode value)
+
+jsonResponse :: Value -> LBS.ByteString
+jsonResponse = encode
+
+popResponse :: MVar [LBS.ByteString] -> IO LBS.ByteString
+popResponse responses =
+    modifyMVar responses $ \case
+        [] -> pure ([], jsonResponse $ object ["error" .= ("unexpected_poll" :: Text)])
+        response : rest -> pure (rest, response)
+
+recordDelay :: MVar [Int] -> Int -> IO ()
+recordDelay delays delay =
+    modifyMVar_ delays $ \xs -> pure (xs <> [delay])
+
+requestPaths :: [RecordedRequest] -> [ByteString]
+requestPaths = fmap recordedPath
+
+formBody :: RecordedRequest -> Query
+formBody = parseQuery . LBS.toStrict . recordedBody
+
+lookupParam :: Query -> ByteString -> Maybe ByteString
+lookupParam query key = joinMaybe $ lookup key query
+
+joinMaybe :: Maybe (Maybe a) -> Maybe a
+joinMaybe = \case
+    Just (Just value) -> Just value
+    _ -> Nothing


### PR DESCRIPTION
Closes #111.

## Summary

- Adds `Lib.GitHub.Auth.DeviceFlow`, a pure-Haskell GitHub OAuth Device Flow client with explicit `ClientId`, `Scope`, `OAuthToken`, `DeviceCodeResponse`, and `DeviceFlowError` types.
- Covers the device-flow state machine with embedded WAI mock-server unit tests: pending-to-success, slow-down, expiry, denial, malformed JSON, callback payload, and parameter-sourced client id.
- Adds `moog-github-device-flow-smoke` for live OAuth App proof and exposes it as `nix run .#moog-github-device-flow-smoke`.

## Delivered slices

- Slice 1: public API plus mock-server unit coverage.
- Slice 2: live-boundary smoke harness with redacted token evidence.
- Repair R1: CI parity fix for the unit-test runner (`./gate.sh` now runs `nix run .#unit-tests`; test suite links `-threaded`).
- Repair R2: flake package exposure for the smoke executable.
- Slice 3: live github.com OAuth smoke using OAuth App client id from #110.

## Live smoke evidence

- Command: `script -q -f -c 'nix run .#moog-github-device-flow-smoke -- --client-id <client-id>' /tmp/epic-109/moog-111/slice-3-real-oauth-smoke-driver/smoke.log`
- Verification URI: `https://github.com/login/device`
- Successful user code: `0708-504B`
- Redacted token evidence: `Token evidence: gho_ token=40`
- Full token logged: no

## Test plan

- [x] `./gate.sh` (runs `git diff --check` and `nix run .#unit-tests`; 157 examples, 0 failures)
- [x] DeviceFlow mock-server unit tests under CI-style runner
- [x] Live OAuth App smoke transcript with redacted token prefix + length only
- [x] PR CI at `3c10e343`: unit tests, docs, tarballs, docker images, MPFS canary rerun, and no-nix build green
