### PR TITLE
chore(ci): make Build-without-nix dispatch-only

### DIFF
--- a/.github/workflows/build-no-nix.yaml
+++ b/.github/workflows/build-no-nix.yaml
@@ -3,14 +3,9 @@ name: Build without nix
 on:
   workflow_dispatch:
 
-  pull_request:
-    branches:
-      - main
-
 jobs:
   build:
     name: Build moog without nix
-    if: github.event_name != 'pull_request' || (github.head_ref != 'feat/boot-facts-pivot' && github.head_ref != 'feat/end-facts-canary')
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository


### PR DESCRIPTION
## Summary

Removes the `pull_request` trigger from the `Build without nix` workflow. Keeps `workflow_dispatch` so it can still be run on demand from the Actions tab.

## Motivation

The job historically takes 30-40 minutes on the GitHub runner and has not (in the recent history I checked) caught a regression that the nix-based `Unit tests` + `Build tarballs` jobs already catch faster. Today on PR #118 it sat in_progress for ~35 minutes after every other check had finished, blocking that PR's review. The workflow had been disabled mid-day via the GitHub API; this PR captures the decision in the workflow file so the state survives a re-enable.

After this merges I'll re-enable the workflow ID so manual dispatch works.

## Test plan

- [ ] CI for this PR does not include "Build moog without nix" (the trigger is removed).
- [ ] After merge: `gh workflow run "Build without nix" --ref main -R cardano-foundation/moog` runs the job on-demand.