### PR TITLE
Lib.GitHub.Auth.Identify + TeamCheck modules

### DIFF
--- a/app/Moog/GitHub/AuthSmoke.hs
+++ b/app/Moog/GitHub/AuthSmoke.hs
@@ -55,9 +55,10 @@ tokenEnvVar :: String
 tokenEnvVar = "MOOG_GITHUB_OAUTH_TOKEN"
 
 -- | Parse the smoke arguments. @--expected-login@ is required; @--org@
--- and @--team@ default to @pragma@ and @antithesis@.
+-- and @--team@ default to @pragma-org@ and @antithesis-access@.
 parseSmokeArgs :: [String] -> Either Text SmokeConfig
-parseSmokeArgs = go Nothing (Org "pragma") (TeamSlug "antithesis")
+parseSmokeArgs =
+    go Nothing (Org "pragma-org") (TeamSlug "antithesis-access")
   where
     go mLogin o t args = case args of
         [] -> case mLogin of

--- a/app/Moog/GitHub/AuthSmoke.hs
+++ b/app/Moog/GitHub/AuthSmoke.hs
@@ -1,0 +1,160 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Operator smoke for the live GitHub auth boundary.
+--
+-- This module exposes pure helpers (argument parsing, token-evidence
+-- redaction, and outcome rendering) so they can be unit-tested without
+-- touching github.com, alongside 'main', which performs the live
+-- @whoami@ and team-membership calls.
+--
+-- The expected operator invocation is:
+--
+-- > MOOG_GITHUB_OAUTH_TOKEN=<token> \
+-- >   nix run .#moog-github-auth-smoke -- --expected-login <login>
+module Moog.GitHub.AuthSmoke
+    ( SmokeConfig (..)
+    , parseSmokeArgs
+    , tokenFromEnv
+    , renderTokenEvidence
+    , renderLoginCheck
+    , renderMembershipCheck
+    , main
+    )
+where
+
+import Data.ByteString qualified as BS
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
+import Lib.GitHub.Auth.DeviceFlow (OAuthToken (..))
+import Lib.GitHub.Auth.Identify
+    ( GitHubError (..)
+    , Login (..)
+    , whoami
+    )
+import Lib.GitHub.Auth.TeamCheck
+    ( MembershipResult (..)
+    , Org (..)
+    , TeamSlug (..)
+    , checkTeamMembership
+    )
+import System.Environment (getArgs, lookupEnv)
+import System.Exit (die)
+
+-- | Resolved smoke configuration: the login the token must resolve to,
+-- and the org/team whose membership is checked.
+data SmokeConfig = SmokeConfig
+    { expectedLogin :: Login
+    , org :: Org
+    , team :: TeamSlug
+    }
+    deriving stock (Eq, Show)
+
+-- | Name of the environment variable carrying the OAuth token.
+tokenEnvVar :: String
+tokenEnvVar = "MOOG_GITHUB_OAUTH_TOKEN"
+
+-- | Parse the smoke arguments. @--expected-login@ is required; @--org@
+-- and @--team@ default to @pragma@ and @antithesis@.
+parseSmokeArgs :: [String] -> Either Text SmokeConfig
+parseSmokeArgs = go Nothing (Org "pragma") (TeamSlug "antithesis")
+  where
+    go mLogin o t args = case args of
+        [] -> case mLogin of
+            Just l ->
+                Right SmokeConfig{expectedLogin = l, org = o, team = t}
+            Nothing -> Left usage
+        ("--expected-login" : v : rest) ->
+            go (Just (Login (T.pack v))) o t rest
+        ("--org" : v : rest) ->
+            go mLogin (Org (T.pack v)) t rest
+        ("--team" : v : rest) ->
+            go mLogin o (TeamSlug (T.pack v)) rest
+        (other : _) ->
+            Left $
+                "unrecognised or incomplete argument: "
+                    <> T.pack other
+                    <> "\n"
+                    <> usage
+    usage =
+        "usage: moog-github-auth-smoke --expected-login <login>"
+            <> " [--org <org>] [--team <team>]"
+
+-- | Read the OAuth token from the environment value, failing closed
+-- when it is unset or empty. The token bytes never appear in the error.
+tokenFromEnv :: Maybe String -> Either Text OAuthToken
+tokenFromEnv mValue = case mValue of
+    Just value
+        | not (null value) ->
+            Right (OAuthToken (T.encodeUtf8 (T.pack value)))
+    _ -> Left $ T.pack tokenEnvVar <> " is not set"
+
+-- | Render redacted evidence of the token: its 4-byte prefix and byte
+-- length only, never the full secret.
+renderTokenEvidence :: OAuthToken -> Text
+renderTokenEvidence (OAuthToken token) =
+    T.decodeUtf8 (BS.take 4 token)
+        <> " len="
+        <> T.pack (show (BS.length token))
+
+-- | Render the @whoami@ outcome against the expected login. 'Right'
+-- carries a confirmation message; 'Left' carries a failure message for
+-- a transport/HTTP error or a login mismatch.
+renderLoginCheck
+    :: Login
+    -> Either GitHubError Login
+    -> Either Text Text
+renderLoginCheck expected result = case result of
+    Left (GitHubError code _) ->
+        Left $ "whoami failed with status " <> T.pack (show code)
+    Right actual
+        | actual == expected ->
+            Right $ "identity confirmed: " <> unLogin actual
+        | otherwise ->
+            Left $
+                "expected login "
+                    <> unLogin expected
+                    <> " but token resolves to "
+                    <> unLogin actual
+
+-- | Render the membership outcome. Only 'Active' membership succeeds;
+-- every other result is a failure message.
+renderMembershipCheck :: MembershipResult -> Either Text Text
+renderMembershipCheck result = case result of
+    Active -> Right "active team membership confirmed"
+    Pending -> Left "membership is pending, not active"
+    NotMember -> Left "login is not a member of the team"
+    TokenInvalid -> Left "token was rejected by GitHub"
+    SSORequired ssoUrl ->
+        Left $ "SAML SSO authorisation required: " <> ssoUrl
+    OtherError code raw ->
+        Left $
+            "unexpected membership response: status "
+                <> T.pack (show code)
+                <> " "
+                <> raw
+
+-- | Run the live auth smoke: confirm the token resolves to the expected
+-- login, then confirm active membership of the configured team. Exits
+-- non-zero (via 'die') on any failure, printing only redacted evidence.
+main :: IO ()
+main = do
+    config <-
+        either (die . T.unpack) pure . parseSmokeArgs =<< getArgs
+    token <-
+        either (die . T.unpack) pure . tokenFromEnv
+            =<< lookupEnv tokenEnvVar
+    putStrLn $ "Token evidence: " <> T.unpack (renderTokenEvidence token)
+    loginResult <- whoami token
+    case renderLoginCheck (expectedLogin config) loginResult of
+        Left err -> die $ T.unpack err
+        Right msg -> putStrLn $ T.unpack msg
+    membership <-
+        checkTeamMembership
+            token
+            (org config)
+            (team config)
+            (expectedLogin config)
+    case renderMembershipCheck membership of
+        Left err -> die $ T.unpack err
+        Right msg -> putStrLn $ T.unpack msg

--- a/app/moog-github-auth-smoke.hs
+++ b/app/moog-github-auth-smoke.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import Moog.GitHub.AuthSmoke qualified as AuthSmoke
+
+main :: IO ()
+main = AuthSmoke.main

--- a/moog.cabal
+++ b/moog.cabal
@@ -87,6 +87,7 @@ library
   import:           warnings
   other-modules:
     Lib.GitHub.Auth.DeviceFlow.Internal
+    Lib.GitHub.Auth.TeamCheck.Internal
     Paths_moog
 
   -- Modules exported by the library.
@@ -119,6 +120,8 @@ library
     Lib.EdToCurve
     Lib.GitHub
     Lib.GitHub.Auth.DeviceFlow
+    Lib.GitHub.Auth.Identify
+    Lib.GitHub.Auth.TeamCheck
     Lib.JSON.Canonical.Aeson
     Lib.JSON.Canonical.Extra
     Lib.Options.Secrets
@@ -420,6 +423,10 @@ test-suite unit-tests
     Lib.GitHub.Auth.DeviceFlow.Internal
     Lib.GitHub.Auth.DeviceFlowSmokeSpec
     Lib.GitHub.Auth.DeviceFlowSpec
+    Lib.GitHub.Auth.Identify
+    Lib.GitHub.Auth.TeamCheck
+    Lib.GitHub.Auth.TeamCheck.Internal
+    Lib.GitHub.Auth.TeamCheckSpec
     Lib.JSON.Canonical.AesonSpec
     Lib.JSON.Canonical.ExtraSpec
     Lib.SSH.KeySpec

--- a/moog.cabal
+++ b/moog.cabal
@@ -87,6 +87,7 @@ library
   import:           warnings
   other-modules:
     Lib.GitHub.Auth.DeviceFlow.Internal
+    Lib.GitHub.Auth.Identify.Internal
     Lib.GitHub.Auth.TeamCheck.Internal
     Paths_moog
 
@@ -424,6 +425,8 @@ test-suite unit-tests
     Lib.GitHub.Auth.DeviceFlowSmokeSpec
     Lib.GitHub.Auth.DeviceFlowSpec
     Lib.GitHub.Auth.Identify
+    Lib.GitHub.Auth.Identify.Internal
+    Lib.GitHub.Auth.IdentifySpec
     Lib.GitHub.Auth.TeamCheck
     Lib.GitHub.Auth.TeamCheck.Internal
     Lib.GitHub.Auth.TeamCheckSpec

--- a/moog.cabal
+++ b/moog.cabal
@@ -374,6 +374,29 @@ executable moog-github-device-flow-smoke
   -- Base language which the package is written in.
   default-language: Haskell2010
 
+executable moog-github-auth-smoke
+  -- Import common warning flags.
+  import:           warnings
+
+  -- .hs or .lhs file containing the Main module.
+  main-is:          moog-github-auth-smoke.hs
+
+  -- Modules included in this executable, other than Main.
+  other-modules:    Moog.GitHub.AuthSmoke
+
+  -- Other library packages from which modules are imported.
+  build-depends:
+    , base
+    , bytestring
+    , moog
+    , text
+
+  -- Directories containing source files.
+  hs-source-dirs:   app
+
+  -- Base language which the package is written in.
+  default-language: Haskell2010
+
 test-suite e2e-tests
   -- Import common warning flags.
   import:           warnings
@@ -420,6 +443,7 @@ test-suite unit-tests
     Docker.FaultExclusionSpec
     Lib.CryptoBoxSpec
     Lib.EdToCurveSpec
+    Lib.GitHub.Auth.AuthSmokeSpec
     Lib.GitHub.Auth.DeviceFlow
     Lib.GitHub.Auth.DeviceFlow.Internal
     Lib.GitHub.Auth.DeviceFlowSmokeSpec

--- a/nix/moog-project.nix
+++ b/nix/moog-project.nix
@@ -81,6 +81,8 @@ in {
     project.hsPkgs.moog.components.exes.moog-mpfs-v2-canary;
   packages.moog-github-device-flow-smoke =
     project.hsPkgs.moog.components.exes.moog-github-device-flow-smoke;
+  packages.moog-github-auth-smoke =
+    project.hsPkgs.moog.components.exes.moog-github-auth-smoke;
   packages.bech32 = project.hsPkgs.bech32.components.exes.bech32;
   packages.cardano-address =
     project.hsPkgs.cardano-addresses.components.exes.cardano-address;

--- a/specs/112-github-auth-identify-teamcheck/plan.md
+++ b/specs/112-github-auth-identify-teamcheck/plan.md
@@ -21,6 +21,7 @@ test/Lib/GitHub/Auth/IdentifySpec.hs             # NEW fixture tests for /user.
 app/Moog/GitHub/AuthSmoke.hs                     # NEW live-boundary smoke helper.
 app/moog-github-auth-smoke.hs                    # NEW executable entry point.
 test/Lib/GitHub/Auth/AuthSmokeSpec.hs            # NEW token-output redaction tests.
+nix/moog-project.nix                             # Expose smoke executable for nix run.
 ```
 
 Public consumers should import only `Lib.GitHub.Auth.TeamCheck`, `Lib.GitHub.Auth.Identify`, and `Lib.GitHub.Auth.DeviceFlow`.
@@ -75,6 +76,8 @@ Add a Cabal-runnable smoke executable that accepts a token and expected login, c
 RED: add unit-level output-safety or argument-parsing tests for the smoke helper.
 
 GREEN: implement the smoke helper and executable stanza.
+
+Expose the executable through the flake package set so the operator can run `nix run .#moog-github-auth-smoke`.
 
 After the slice lands locally, raise a parent Q-file asking the operator to run the live smoke with the real OAuth App/token. Do not block earlier implementation slices on this operator-run proof.
 

--- a/specs/112-github-auth-identify-teamcheck/plan.md
+++ b/specs/112-github-auth-identify-teamcheck/plan.md
@@ -1,0 +1,97 @@
+# Plan - moog#112
+
+## Tech stack
+
+- Haskell, Cabal, and the existing project warning profile.
+- Existing `github`, `http-client`, `http-client-tls`, `http-types`, `aeson`, `bytestring`, and `text` dependencies.
+- Unit tests in the existing `unit-tests` hspec suite, reusing the embedded WAI/Warp mock-server pattern from #111.
+- `OAuthToken` imported from `Lib.GitHub.Auth.DeviceFlow`.
+
+Dependency-manifest edits are behavior-changing and belong to the driver/navigator pair for the implementation slice that needs them.
+
+## Module layout
+
+```text
+src/Lib/GitHub/Auth/TeamCheck.hs                 # NEW public membership API.
+src/Lib/GitHub/Auth/TeamCheck/Internal.hs        # NEW testable endpoints and response mapping.
+test/Lib/GitHub/Auth/TeamCheckSpec.hs            # NEW fixture tests for MembershipResult.
+src/Lib/GitHub/Auth/Identify.hs                  # NEW public whoami API.
+src/Lib/GitHub/Auth/Identify/Internal.hs         # NEW testable endpoint/client hook.
+test/Lib/GitHub/Auth/IdentifySpec.hs             # NEW fixture tests for /user.
+app/Moog/GitHub/AuthSmoke.hs                     # NEW live-boundary smoke helper.
+app/moog-github-auth-smoke.hs                    # NEW executable entry point.
+test/Lib/GitHub/Auth/AuthSmokeSpec.hs            # NEW token-output redaction tests.
+```
+
+Public consumers should import only `Lib.GitHub.Auth.TeamCheck`, `Lib.GitHub.Auth.Identify`, and `Lib.GitHub.Auth.DeviceFlow`.
+
+## Response mapping
+
+`checkTeamMembership` must produce exactly these outcomes:
+
+- `200` with JSON `state = "active"`: `Active`.
+- `200` with JSON `state = "pending"`: `Pending`.
+- `404`: `NotMember`.
+- `401`: `TokenInvalid`.
+- `403` with an `X-GitHub-SSO` header containing an `https://github.com/orgs/<org>/sso?...` URL: `SSORequired url`.
+- Any other status, malformed successful response, unknown state, or GitHub error without a more specific mapping: `OtherError status body`.
+
+The SSO parser should preserve the authorization URL exactly as GitHub sent it, excluding only header metadata such as `required; url=`.
+
+## Slices
+
+### Slice 0 - Orchestration bootstrap
+
+Owned by the ticket-orchestrator. Add spec, plan, and tasks; use the inherited repository `gate.sh`; open the draft PR. No production or test behavior changes.
+
+### Slice 1 - Team membership API and fixture matrix
+
+Add `Lib.GitHub.Auth.TeamCheck`, a testable internal module, cabal module declarations, and fixture tests for every `MembershipResult` constructor. This is the type-pinning slice for #113.
+
+RED: add mock-server tests that fail because the module/API does not exist.
+
+GREEN: implement the endpoint request, token auth, response decoding, status mapping, and SSO header URL extraction.
+
+Bisect-safe because the new module is additive and covered by focused fixture tests.
+
+After this slice is accepted and pushed, append `NOTE RELEASE: membership-result-type-pinned at <commit-or-PR-url>` to `/tmp/epic-109/moog-112/STATUS.md`.
+
+### Slice 2 - GitHub identity API
+
+Add `Lib.GitHub.Auth.Identify`, a testable internal module, cabal module declarations, and fixture tests for `GET /user`.
+
+RED: add tests proving a fixture user response returns the expected `GH.Login` and a non-success response returns `Left GitHubError`.
+
+GREEN: implement `whoami` using the shared OAuth token conversion and GitHub user response parsing.
+
+Bisect-safe because `whoami` is additive and does not change team-check behavior.
+
+### Slice 3 - Live-boundary auth smoke
+
+Add a Cabal-runnable smoke executable that accepts a token and expected login, calls `whoami`, then calls `checkTeamMembership (Org "pragma") (TeamSlug "antithesis") <login>`, and reports success only for matching login plus `Active` membership. Output must not include the full token.
+
+RED: add unit-level output-safety or argument-parsing tests for the smoke helper.
+
+GREEN: implement the smoke helper and executable stanza.
+
+After the slice lands locally, raise a parent Q-file asking the operator to run the live smoke with the real OAuth App/token. Do not block earlier implementation slices on this operator-run proof.
+
+## Gate
+
+This branch inherits `gate.sh` from `origin/main`; it currently runs:
+
+```bash
+git diff --check
+nix run .#unit-tests
+```
+
+The focused commands for slices use `nix develop --quiet -c just unit "<match>"` while developing, followed by `./gate.sh` before commit and again during orchestrator acceptance.
+
+The live-boundary smoke is not part of `gate.sh` because it needs an operator-held token and real GitHub SSO/team state.
+
+## Risks and mitigations
+
+- **GitHub API surface uncertainty.** Keep internal helpers injectable so fixture tests prove wire behavior without depending on github.com.
+- **SSO header parsing.** Test the exact `X-GitHub-SSO` shape with a URL-bearing fixture.
+- **Token leakage.** Smoke tests must prove only redacted token evidence is rendered.
+- **Cross-ticket type drift.** Treat `MembershipResult` as pinned after Slice 1. Any later constructor/signature change requires a parent Q-file before continuing.

--- a/specs/112-github-auth-identify-teamcheck/plan.md
+++ b/specs/112-github-auth-identify-teamcheck/plan.md
@@ -25,6 +25,8 @@ test/Lib/GitHub/Auth/AuthSmokeSpec.hs            # NEW token-output redaction te
 
 Public consumers should import only `Lib.GitHub.Auth.TeamCheck`, `Lib.GitHub.Auth.Identify`, and `Lib.GitHub.Auth.DeviceFlow`.
 
+Q-002 decision: because `github-0.30.0.2` does not expose the issue-body shorthand `GH.Login`, #112 owns `newtype Login = Login Text` in `Lib.GitHub.Auth.Identify`. `Lib.GitHub.Auth.TeamCheck` re-exports it, and `checkTeamMembership` takes `Login`.
+
 ## Response mapping
 
 `checkTeamMembership` must produce exactly these outcomes:
@@ -58,9 +60,9 @@ After this slice is accepted and pushed, append `NOTE RELEASE: membership-result
 
 ### Slice 2 - GitHub identity API
 
-Add `Lib.GitHub.Auth.Identify`, a testable internal module, cabal module declarations, and fixture tests for `GET /user`.
+Add `Lib.GitHub.Auth.Identify`, a testable internal module, cabal module declarations, and fixture tests for `GET /user`. Preserve the `Login` newtype introduced by Slice 1.
 
-RED: add tests proving a fixture user response returns the expected `GH.Login` and a non-success response returns `Left GitHubError`.
+RED: add tests proving a fixture user response returns the expected `Login` and a non-success response returns `Left GitHubError`.
 
 GREEN: implement `whoami` using the shared OAuth token conversion and GitHub user response parsing.
 

--- a/specs/112-github-auth-identify-teamcheck/spec.md
+++ b/specs/112-github-auth-identify-teamcheck/spec.md
@@ -1,0 +1,71 @@
+# Spec - moog#112 GitHub identity and team membership checks
+
+## P1 user story
+
+As the Antithesis proxy boundary, moog can take an `OAuthToken` from the device-flow client, identify the GitHub user who owns it, and answer whether that login is an active member of the `pragma/antithesis` team, including a concrete SSO authorization URL when GitHub requires organization SSO.
+
+## Why
+
+The parent epic (#109) gates Antithesis requests by GitHub team membership. Ticket #111 already pinned `OAuthToken`; this ticket pins the identity and membership API consumed by the proxy daemon in #113. This layer is intentionally stateless so #113 owns token-prefix caching at the proxy boundary.
+
+## Authoritative API
+
+```haskell
+module Lib.GitHub.Auth.Identify
+    ( GitHubError (..)
+    , whoami
+    ) where
+
+whoami :: OAuthToken -> IO (Either GitHubError GH.Login)
+```
+
+```haskell
+module Lib.GitHub.Auth.TeamCheck
+    ( Org (..)
+    , TeamSlug (..)
+    , MembershipResult (..)
+    , checkTeamMembership
+    ) where
+
+newtype Org = Org Text
+newtype TeamSlug = TeamSlug Text
+
+data MembershipResult
+    = Active
+    | Pending
+    | NotMember
+    | TokenInvalid
+    | SSORequired { url :: Text }
+    | OtherError { status :: Int, body :: Text }
+
+checkTeamMembership
+    :: OAuthToken -> Org -> TeamSlug -> GH.Login -> IO MembershipResult
+```
+
+`OAuthToken` is imported from `Lib.GitHub.Auth.DeviceFlow`; this ticket must not redefine it.
+
+## Functional requirements
+
+- **F1** Add `Lib.GitHub.Auth.Identify` with `whoami`, backed by `GET https://api.github.com/user`.
+- **F2** Add `Lib.GitHub.Auth.TeamCheck` with `Org`, `TeamSlug`, `MembershipResult`, and `checkTeamMembership`, backed by `GET /orgs/{org}/teams/{team_slug}/memberships/{login}`.
+- **F3** Convert `OAuthToken` into the `github` package auth representation expected by the existing project, without logging or exposing the token bytes.
+- **F4** Map membership responses as follows: `200 state=active` to `Active`, `200 state=pending` to `Pending`, `404` to `NotMember`, `401` to `TokenInvalid`, `403` with `X-GitHub-SSO` URL to `SSORequired url`, and all other failures to `OtherError status body`.
+- **F5** Surface the SSO URL verbatim from the `X-GitHub-SSO` header when present.
+- **F6** Keep this layer stateless: no cache, no token persistence, no retry policy beyond the underlying HTTP client.
+- **F7** Unit tests use embedded fixture HTTP responses and never call github.com.
+- **F8** Add an operator-run live smoke that accepts a real token, calls `whoami`, calls `checkTeamMembership pragma antithesis <login>`, and redacts token material from all output.
+
+## Success criteria
+
+- **S1** Unit tests cover every `MembershipResult` constructor: active, pending, not member, invalid token, SSO required, and generic other error.
+- **S2** Unit tests verify `whoami` returns the expected `GH.Login` for a fixture `/user` response and reports an error for a non-success response.
+- **S3** The public `MembershipResult` type is pinned and announced to the parent epic after the first implementation slice passes its focused gate.
+- **S4** The live-boundary smoke is runnable with the real OAuth App client id from #110 and a real `pragma/antithesis` member token; the operator-run proof shows `whoami` returns the expected login and membership returns `Active`.
+- **S5** `./gate.sh` passes at every accepted implementation slice boundary.
+
+## Out of scope
+
+- Device Flow token acquisition; #111 owns that.
+- Proxy daemon auth, HTTP routes, or caching; #113 owns those.
+- CLI token storage and commands; #114 owns those.
+- GitHub retries beyond the HTTP client defaults.

--- a/specs/112-github-auth-identify-teamcheck/spec.md
+++ b/specs/112-github-auth-identify-teamcheck/spec.md
@@ -12,17 +12,21 @@ The parent epic (#109) gates Antithesis requests by GitHub team membership. Tick
 
 ```haskell
 module Lib.GitHub.Auth.Identify
-    ( GitHubError (..)
+    ( Login (..)
+    , GitHubError (..)
     , whoami
     ) where
 
-whoami :: OAuthToken -> IO (Either GitHubError GH.Login)
+newtype Login = Login { unLogin :: Text }
+
+whoami :: OAuthToken -> IO (Either GitHubError Login)
 ```
 
 ```haskell
 module Lib.GitHub.Auth.TeamCheck
     ( Org (..)
     , TeamSlug (..)
+    , Login (..)
     , MembershipResult (..)
     , checkTeamMembership
     ) where
@@ -39,15 +43,16 @@ data MembershipResult
     | OtherError { status :: Int, body :: Text }
 
 checkTeamMembership
-    :: OAuthToken -> Org -> TeamSlug -> GH.Login -> IO MembershipResult
+    :: OAuthToken -> Org -> TeamSlug -> Login -> IO MembershipResult
 ```
 
 `OAuthToken` is imported from `Lib.GitHub.Auth.DeviceFlow`; this ticket must not redefine it.
+`Login` is a moog-owned newtype because `github-0.30.0.2` does not expose the issue-body shorthand `GH.Login`. `Lib.GitHub.Auth.TeamCheck` re-exports `Login` so #113 can import the full team-check API surface from one module.
 
 ## Functional requirements
 
 - **F1** Add `Lib.GitHub.Auth.Identify` with `whoami`, backed by `GET https://api.github.com/user`.
-- **F2** Add `Lib.GitHub.Auth.TeamCheck` with `Org`, `TeamSlug`, `MembershipResult`, and `checkTeamMembership`, backed by `GET /orgs/{org}/teams/{team_slug}/memberships/{login}`.
+- **F2** Add `Lib.GitHub.Auth.TeamCheck` with `Org`, `TeamSlug`, `Login`, `MembershipResult`, and `checkTeamMembership`, backed by `GET /orgs/{org}/teams/{team_slug}/memberships/{login}`.
 - **F3** Convert `OAuthToken` into the `github` package auth representation expected by the existing project, without logging or exposing the token bytes.
 - **F4** Map membership responses as follows: `200 state=active` to `Active`, `200 state=pending` to `Pending`, `404` to `NotMember`, `401` to `TokenInvalid`, `403` with `X-GitHub-SSO` URL to `SSORequired url`, and all other failures to `OtherError status body`.
 - **F5** Surface the SSO URL verbatim from the `X-GitHub-SSO` header when present.
@@ -58,7 +63,7 @@ checkTeamMembership
 ## Success criteria
 
 - **S1** Unit tests cover every `MembershipResult` constructor: active, pending, not member, invalid token, SSO required, and generic other error.
-- **S2** Unit tests verify `whoami` returns the expected `GH.Login` for a fixture `/user` response and reports an error for a non-success response.
+- **S2** Unit tests verify `whoami` returns the expected `Login` for a fixture `/user` response and reports an error for a non-success response.
 - **S3** The public `MembershipResult` type is pinned and announced to the parent epic after the first implementation slice passes its focused gate.
 - **S4** The live-boundary smoke is runnable with the real OAuth App client id from #110 and a real `pragma/antithesis` member token; the operator-run proof shows `whoami` returns the expected login and membership returns `Active`.
 - **S5** `./gate.sh` passes at every accepted implementation slice boundary.

--- a/specs/112-github-auth-identify-teamcheck/tasks.md
+++ b/specs/112-github-auth-identify-teamcheck/tasks.md
@@ -24,7 +24,7 @@
 - [ ] T112-S2.1 Add `Lib.GitHub.Auth.Identify` to the library exposed modules and add a testable internal module as needed.
 - [ ] T112-S2.2 Add any cabal module declarations needed for the new source and test modules.
 - [ ] T112-S2.3 RED: add `test/Lib/GitHub/Auth/IdentifySpec.hs` covering a successful fixture `/user` response and a non-success response.
-- [ ] T112-S2.4 GREEN: implement `GitHubError` and `whoami :: OAuthToken -> IO (Either GitHubError GH.Login)`.
+- [ ] T112-S2.4 GREEN: implement `GitHubError` and `whoami :: OAuthToken -> IO (Either GitHubError Login)`.
 - [ ] T112-S2.5 Run the focused Identify unit tests and `./gate.sh` green.
 - [ ] T112-S2.6 Commit with subject `feat(auth): add GitHub whoami lookup` and trailer `Tasks: T112-S2`.
 

--- a/specs/112-github-auth-identify-teamcheck/tasks.md
+++ b/specs/112-github-auth-identify-teamcheck/tasks.md
@@ -30,13 +30,13 @@
 
 ## Slice 3 - Live-boundary auth smoke
 
-- [ ] T112-S3.1 Add the cabal executable stanza for `moog-github-auth-smoke`.
-- [ ] T112-S3.2 RED: add focused tests proving smoke output redacts token material and reports expected-login/membership outcomes.
-- [ ] T112-S3.3 GREEN: implement `app/Moog/GitHub/AuthSmoke.hs` and `app/moog-github-auth-smoke.hs` using the exported `whoami` and `checkTeamMembership` APIs.
-- [ ] T112-S3.4 Expose `moog-github-auth-smoke` through the flake package set for `nix run .#moog-github-auth-smoke`.
-- [ ] T112-S3.5 Run the focused smoke tests and `./gate.sh` green.
-- [ ] T112-S3.6 Commit with subject `feat(auth): add GitHub auth live smoke` and trailer `Tasks: T112-S3`.
-- [ ] T112-S3.7 Raise a parent Q-file asking the operator to run the live smoke with a real token for `pragma/antithesis`.
+- [X] T112-S3.1 Add the cabal executable stanza for `moog-github-auth-smoke`.
+- [X] T112-S3.2 RED: add focused tests proving smoke output redacts token material and reports expected-login/membership outcomes.
+- [X] T112-S3.3 GREEN: implement `app/Moog/GitHub/AuthSmoke.hs` and `app/moog-github-auth-smoke.hs` using the exported `whoami` and `checkTeamMembership` APIs.
+- [X] T112-S3.4 Expose `moog-github-auth-smoke` through the flake package set for `nix run .#moog-github-auth-smoke`.
+- [X] T112-S3.5 Run the focused smoke tests and `./gate.sh` green.
+- [X] T112-S3.6 Commit with subject `feat(auth): add GitHub auth live smoke` and trailer `Tasks: T112-S3`.
+- [X] T112-S3.7 Raise a parent Q-file asking the operator to run the live smoke with a real token for `pragma/antithesis`.
 
 ## Finalization (orchestrator)
 

--- a/specs/112-github-auth-identify-teamcheck/tasks.md
+++ b/specs/112-github-auth-identify-teamcheck/tasks.md
@@ -11,13 +11,13 @@
 
 ## Slice 1 - Team membership API and fixture matrix
 
-- [ ] T112-S1.1 Add `Lib.GitHub.Auth.TeamCheck` to the library exposed modules and add a testable internal module as needed.
-- [ ] T112-S1.2 Add any cabal module declarations needed for the new source and test modules.
-- [ ] T112-S1.3 RED: add `test/Lib/GitHub/Auth/TeamCheckSpec.hs` covering active, pending, not member, token invalid, SSO required, and other error fixture responses.
-- [ ] T112-S1.4 GREEN: implement `Org`, `TeamSlug`, `MembershipResult`, `checkTeamMembership`, token auth, status mapping, and SSO URL extraction.
-- [ ] T112-S1.5 Run the focused TeamCheck unit tests and `./gate.sh` green.
-- [ ] T112-S1.6 Commit with subject `feat(auth): add GitHub team membership check` and trailer `Tasks: T112-S1`.
-- [ ] T112-S1.7 Announce `NOTE RELEASE: membership-result-type-pinned at <commit-or-PR-url>` in `/tmp/epic-109/moog-112/STATUS.md`.
+- [X] T112-S1.1 Add `Lib.GitHub.Auth.TeamCheck` to the library exposed modules and add a testable internal module as needed.
+- [X] T112-S1.2 Add any cabal module declarations needed for the new source and test modules.
+- [X] T112-S1.3 RED: add `test/Lib/GitHub/Auth/TeamCheckSpec.hs` covering active, pending, not member, token invalid, SSO required, and other error fixture responses.
+- [X] T112-S1.4 GREEN: implement `Org`, `TeamSlug`, `MembershipResult`, `checkTeamMembership`, token auth, status mapping, and SSO URL extraction.
+- [X] T112-S1.5 Run the focused TeamCheck unit tests and `./gate.sh` green.
+- [X] T112-S1.6 Commit with subject `feat(auth): add GitHub team membership check` and trailer `Tasks: T112-S1`.
+- [X] T112-S1.7 Announce `NOTE RELEASE: membership-result-type-pinned at <commit-or-PR-url>` in `/tmp/epic-109/moog-112/STATUS.md`.
 
 ## Slice 2 - GitHub identity API
 

--- a/specs/112-github-auth-identify-teamcheck/tasks.md
+++ b/specs/112-github-auth-identify-teamcheck/tasks.md
@@ -21,12 +21,12 @@
 
 ## Slice 2 - GitHub identity API
 
-- [ ] T112-S2.1 Add `Lib.GitHub.Auth.Identify` to the library exposed modules and add a testable internal module as needed.
-- [ ] T112-S2.2 Add any cabal module declarations needed for the new source and test modules.
-- [ ] T112-S2.3 RED: add `test/Lib/GitHub/Auth/IdentifySpec.hs` covering a successful fixture `/user` response and a non-success response.
-- [ ] T112-S2.4 GREEN: implement `GitHubError` and `whoami :: OAuthToken -> IO (Either GitHubError Login)`.
-- [ ] T112-S2.5 Run the focused Identify unit tests and `./gate.sh` green.
-- [ ] T112-S2.6 Commit with subject `feat(auth): add GitHub whoami lookup` and trailer `Tasks: T112-S2`.
+- [X] T112-S2.1 Add `Lib.GitHub.Auth.Identify` to the library exposed modules and add a testable internal module as needed.
+- [X] T112-S2.2 Add any cabal module declarations needed for the new source and test modules.
+- [X] T112-S2.3 RED: add `test/Lib/GitHub/Auth/IdentifySpec.hs` covering a successful fixture `/user` response and a non-success response.
+- [X] T112-S2.4 GREEN: implement `GitHubError` and `whoami :: OAuthToken -> IO (Either GitHubError Login)`.
+- [X] T112-S2.5 Run the focused Identify unit tests and `./gate.sh` green.
+- [X] T112-S2.6 Commit with subject `feat(auth): add GitHub whoami lookup` and trailer `Tasks: T112-S2`.
 
 ## Slice 3 - Live-boundary auth smoke
 

--- a/specs/112-github-auth-identify-teamcheck/tasks.md
+++ b/specs/112-github-auth-identify-teamcheck/tasks.md
@@ -33,9 +33,10 @@
 - [ ] T112-S3.1 Add the cabal executable stanza for `moog-github-auth-smoke`.
 - [ ] T112-S3.2 RED: add focused tests proving smoke output redacts token material and reports expected-login/membership outcomes.
 - [ ] T112-S3.3 GREEN: implement `app/Moog/GitHub/AuthSmoke.hs` and `app/moog-github-auth-smoke.hs` using the exported `whoami` and `checkTeamMembership` APIs.
-- [ ] T112-S3.4 Run the focused smoke tests and `./gate.sh` green.
-- [ ] T112-S3.5 Commit with subject `feat(auth): add GitHub auth live smoke` and trailer `Tasks: T112-S3`.
-- [ ] T112-S3.6 Raise a parent Q-file asking the operator to run the live smoke with a real token for `pragma/antithesis`.
+- [ ] T112-S3.4 Expose `moog-github-auth-smoke` through the flake package set for `nix run .#moog-github-auth-smoke`.
+- [ ] T112-S3.5 Run the focused smoke tests and `./gate.sh` green.
+- [ ] T112-S3.6 Commit with subject `feat(auth): add GitHub auth live smoke` and trailer `Tasks: T112-S3`.
+- [ ] T112-S3.7 Raise a parent Q-file asking the operator to run the live smoke with a real token for `pragma/antithesis`.
 
 ## Finalization (orchestrator)
 

--- a/specs/112-github-auth-identify-teamcheck/tasks.md
+++ b/specs/112-github-auth-identify-teamcheck/tasks.md
@@ -1,0 +1,52 @@
+# Tasks - moog#112
+
+## Slice 0 - Orchestration bootstrap
+
+- [X] T112-S0.1 Confirm `/code/moog-issue-112` exists on `feat/112-identify-teamcheck` based on `origin/main`.
+- [X] T112-S0.2 Add `specs/112-github-auth-identify-teamcheck/spec.md`.
+- [X] T112-S0.3 Add `specs/112-github-auth-identify-teamcheck/plan.md`.
+- [X] T112-S0.4 Add `specs/112-github-auth-identify-teamcheck/tasks.md`.
+- [X] T112-S0.5 Commit with subject `docs(#112): add auth identify teamcheck plan`.
+- [X] T112-S0.6 Open a draft PR linked to #112.
+
+## Slice 1 - Team membership API and fixture matrix
+
+- [ ] T112-S1.1 Add `Lib.GitHub.Auth.TeamCheck` to the library exposed modules and add a testable internal module as needed.
+- [ ] T112-S1.2 Add any cabal module declarations needed for the new source and test modules.
+- [ ] T112-S1.3 RED: add `test/Lib/GitHub/Auth/TeamCheckSpec.hs` covering active, pending, not member, token invalid, SSO required, and other error fixture responses.
+- [ ] T112-S1.4 GREEN: implement `Org`, `TeamSlug`, `MembershipResult`, `checkTeamMembership`, token auth, status mapping, and SSO URL extraction.
+- [ ] T112-S1.5 Run the focused TeamCheck unit tests and `./gate.sh` green.
+- [ ] T112-S1.6 Commit with subject `feat(auth): add GitHub team membership check` and trailer `Tasks: T112-S1`.
+- [ ] T112-S1.7 Announce `NOTE RELEASE: membership-result-type-pinned at <commit-or-PR-url>` in `/tmp/epic-109/moog-112/STATUS.md`.
+
+## Slice 2 - GitHub identity API
+
+- [ ] T112-S2.1 Add `Lib.GitHub.Auth.Identify` to the library exposed modules and add a testable internal module as needed.
+- [ ] T112-S2.2 Add any cabal module declarations needed for the new source and test modules.
+- [ ] T112-S2.3 RED: add `test/Lib/GitHub/Auth/IdentifySpec.hs` covering a successful fixture `/user` response and a non-success response.
+- [ ] T112-S2.4 GREEN: implement `GitHubError` and `whoami :: OAuthToken -> IO (Either GitHubError GH.Login)`.
+- [ ] T112-S2.5 Run the focused Identify unit tests and `./gate.sh` green.
+- [ ] T112-S2.6 Commit with subject `feat(auth): add GitHub whoami lookup` and trailer `Tasks: T112-S2`.
+
+## Slice 3 - Live-boundary auth smoke
+
+- [ ] T112-S3.1 Add the cabal executable stanza for `moog-github-auth-smoke`.
+- [ ] T112-S3.2 RED: add focused tests proving smoke output redacts token material and reports expected-login/membership outcomes.
+- [ ] T112-S3.3 GREEN: implement `app/Moog/GitHub/AuthSmoke.hs` and `app/moog-github-auth-smoke.hs` using the exported `whoami` and `checkTeamMembership` APIs.
+- [ ] T112-S3.4 Run the focused smoke tests and `./gate.sh` green.
+- [ ] T112-S3.5 Commit with subject `feat(auth): add GitHub auth live smoke` and trailer `Tasks: T112-S3`.
+- [ ] T112-S3.6 Raise a parent Q-file asking the operator to run the live smoke with a real token for `pragma/antithesis`.
+
+## Finalization (orchestrator)
+
+- [ ] T112-F1 Audit the PR body against delivered behavior and test evidence.
+- [ ] T112-F2 Run final `./gate.sh` at HEAD.
+- [ ] T112-F3 Confirm all implementation tasks in this file are checked.
+- [ ] T112-F4 Mark the draft PR ready for review after required live-smoke evidence is recorded or explicitly parked by the parent.
+- [ ] T112-F5 Wait for review and merge. Do not self-merge.
+
+## Post-merge cleanup (orchestrator)
+
+- [ ] T112-C1 After merge, remove `/code/moog-issue-112`.
+- [ ] T112-C2 Delete local and remote branch `feat/112-identify-teamcheck`.
+- [ ] T112-C3 Run `git worktree prune`.

--- a/src/Lib/GitHub/Auth/Identify.hs
+++ b/src/Lib/GitHub/Auth/Identify.hs
@@ -1,19 +1,25 @@
--- | GitHub identity types shared across the auth modules.
+-- | GitHub identity types and the @whoami@ boundary.
 --
--- Slice 1 of #112 introduces only the 'Login' newtype, which pins the
--- public login parameter of 'Lib.GitHub.Auth.TeamCheck.checkTeamMembership'.
--- The @whoami@ boundary that produces a 'Login' is added in a later slice.
+-- Slice 1 of #112 introduced the 'Login' newtype, which pins the public
+-- login parameter of 'Lib.GitHub.Auth.TeamCheck.checkTeamMembership'.
+-- This module re-exports 'Login' (now defined in
+-- "Lib.GitHub.Auth.Identify.Internal") alongside 'whoami', which
+-- resolves the login of the token holder via @GET https://api.github.com/user@.
 module Lib.GitHub.Auth.Identify
     ( Login (..)
+    , GitHubError (..)
+    , whoami
     ) where
 
-import Data.Aeson (FromJSON, ToJSON)
-import Data.String (IsString)
-import Data.Text (Text)
+import Lib.GitHub.Auth.DeviceFlow (OAuthToken)
+import Lib.GitHub.Auth.Identify.Internal
+    ( GitHubError (..)
+    , Login (..)
+    , githubIdentifyEndpoint
+    , whoamiWith
+    )
 
--- | A GitHub login (username). A distinct newtype so it cannot be
--- confused with an 'Lib.GitHub.Auth.TeamCheck.Org' or
--- 'Lib.GitHub.Auth.TeamCheck.TeamSlug' at a call site.
-newtype Login = Login {unLogin :: Text}
-    deriving stock (Show, Eq, Ord)
-    deriving newtype (IsString, ToJSON, FromJSON)
+-- | Look up the login of the authenticated user, using the supplied
+-- OAuth token against the live GitHub REST API.
+whoami :: OAuthToken -> IO (Either GitHubError Login)
+whoami = whoamiWith githubIdentifyEndpoint

--- a/src/Lib/GitHub/Auth/Identify.hs
+++ b/src/Lib/GitHub/Auth/Identify.hs
@@ -1,0 +1,19 @@
+-- | GitHub identity types shared across the auth modules.
+--
+-- Slice 1 of #112 introduces only the 'Login' newtype, which pins the
+-- public login parameter of 'Lib.GitHub.Auth.TeamCheck.checkTeamMembership'.
+-- The @whoami@ boundary that produces a 'Login' is added in a later slice.
+module Lib.GitHub.Auth.Identify
+    ( Login (..)
+    ) where
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.String (IsString)
+import Data.Text (Text)
+
+-- | A GitHub login (username). A distinct newtype so it cannot be
+-- confused with an 'Lib.GitHub.Auth.TeamCheck.Org' or
+-- 'Lib.GitHub.Auth.TeamCheck.TeamSlug' at a call site.
+newtype Login = Login {unLogin :: Text}
+    deriving stock (Show, Eq, Ord)
+    deriving newtype (IsString, ToJSON, FromJSON)

--- a/src/Lib/GitHub/Auth/Identify/Internal.hs
+++ b/src/Lib/GitHub/Auth/Identify/Internal.hs
@@ -1,0 +1,132 @@
+-- | Internal client for the GitHub identity API.
+--
+-- This module exposes the response-mapping logic and an injectable
+-- endpoint so tests can point the client at a local fixture server
+-- while the public "Lib.GitHub.Auth.Identify" wrapper targets GitHub.
+--
+-- The 'Login' newtype lives here (rather than in the public module) so
+-- that 'whoamiWith' can return it without an import cycle; the public
+-- "Lib.GitHub.Auth.Identify" re-exports it unchanged.
+module Lib.GitHub.Auth.Identify.Internal
+    ( -- * Public types
+      Login (..)
+    , GitHubError (..)
+
+      -- * Injectable client
+    , IdentifyEndpoint (..)
+    , githubIdentifyEndpoint
+    , whoamiWith
+    ) where
+
+import Control.Exception (try)
+import Data.Aeson
+    ( FromJSON (parseJSON)
+    , ToJSON
+    , eitherDecode
+    , withObject
+    , (.:)
+    )
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as LBS
+import Data.String (IsString)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
+import Lib.GitHub.Auth.DeviceFlow (OAuthToken (..))
+import Network.HTTP.Client
+    ( HttpException
+    , Request (method, requestHeaders)
+    , Response (responseBody, responseStatus)
+    , httpLbs
+    , newManager
+    , parseRequest
+    )
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Network.HTTP.Types (hAccept, hAuthorization, hUserAgent)
+import Network.HTTP.Types.Status (statusCode)
+
+-- | A GitHub login (username). A distinct newtype so it cannot be
+-- confused with an 'Lib.GitHub.Auth.TeamCheck.Org' or
+-- 'Lib.GitHub.Auth.TeamCheck.TeamSlug' at a call site.
+newtype Login = Login {unLogin :: Text}
+    deriving stock (Show, Eq, Ord)
+    deriving newtype (IsString, ToJSON, FromJSON)
+
+-- | A failure at the GitHub identity boundary, carrying the HTTP status
+-- code and the raw response body for diagnosis. A status of @0@ denotes
+-- a transport-level failure.
+data GitHubError = GitHubError
+    { status :: Int
+    , body :: Text
+    }
+    deriving stock (Eq, Show)
+
+-- | Base URL the identity client targets. Injected so tests can point
+-- at a local fixture server.
+newtype IdentifyEndpoint = IdentifyEndpoint
+    { identifyBaseUrl :: String
+    }
+    deriving stock (Eq, Show)
+
+-- | The production GitHub REST API base URL.
+githubIdentifyEndpoint :: IdentifyEndpoint
+githubIdentifyEndpoint =
+    IdentifyEndpoint{identifyBaseUrl = "https://api.github.com"}
+
+-- | Look up the authenticated user against an injectable endpoint.
+-- The OAuth token is sent as an @Authorization: Bearer@ header; its
+-- bytes are never logged.
+whoamiWith
+    :: IdentifyEndpoint
+    -> OAuthToken
+    -> IO (Either GitHubError Login)
+whoamiWith endpoint token = do
+    manager <- newManager tlsManagerSettings
+    requestResult <- try @HttpException $ do
+        baseRequest <- parseRequest $ identifyBaseUrl endpoint <> "/user"
+        let request =
+                baseRequest
+                    { method = "GET"
+                    , requestHeaders =
+                        [ (hAccept, "application/vnd.github+json")
+                        , (hAuthorization, "Bearer " <> unOAuthToken token)
+                        , (hUserAgent, "moog")
+                        ]
+                    }
+        httpLbs request manager
+    pure $ case requestResult of
+        Left err -> Left $ GitHubError 0 $ T.pack $ show err
+        Right response -> classifyResponse response
+
+-- | Map a raw HTTP response to either a 'Login' or a 'GitHubError'.
+classifyResponse :: Response LBS.ByteString -> Either GitHubError Login
+classifyResponse response =
+    case statusCode (responseStatus response) of
+        200 -> case decodeLogin rawBody of
+            Right login -> Right login
+            Left _ -> Left $ GitHubError 200 bodyText
+        code -> Left $ GitHubError code bodyText
+  where
+    rawBody = responseBody response
+    bodyText = decodeBodyText rawBody
+
+-- | The @login@ field of a @GET /user@ payload.
+newtype UserLogin = UserLogin Login
+
+instance FromJSON UserLogin where
+    parseJSON =
+        withObject "UserLogin" $ \o ->
+            UserLogin <$> o .: "login"
+
+-- | Decode the @login@ field of a 200 @GET /user@ payload.
+decodeLogin :: LBS.ByteString -> Either String Login
+decodeLogin raw =
+    (\(UserLogin login) -> login) <$> eitherDecode raw
+
+decodeBodyText :: LBS.ByteString -> Text
+decodeBodyText = decodeUtf8Lenient . LBS.toStrict
+
+decodeUtf8Lenient :: ByteString -> Text
+decodeUtf8Lenient = T.decodeUtf8With lenientDecode
+  where
+    lenientDecode _ _ = Just '\xfffd'

--- a/src/Lib/GitHub/Auth/TeamCheck.hs
+++ b/src/Lib/GitHub/Auth/TeamCheck.hs
@@ -1,0 +1,38 @@
+-- | Public GitHub team-membership API.
+--
+-- 'checkTeamMembership' reports whether a GitHub login is a member of a
+-- given team within an organisation, mapping the REST responses to a
+-- 'MembershipResult'.
+module Lib.GitHub.Auth.TeamCheck
+    ( Org (..)
+    , TeamSlug (..)
+    , MembershipResult (..)
+    , Login (..)
+    , checkTeamMembership
+    ) where
+
+import Lib.GitHub.Auth.DeviceFlow (OAuthToken)
+import Lib.GitHub.Auth.Identify (Login (..))
+import Lib.GitHub.Auth.TeamCheck.Internal
+    ( MembershipResult (..)
+    , Org (..)
+    , TeamSlug (..)
+    , checkTeamMembershipWith
+    , githubTeamCheckEndpoint
+    )
+
+-- | Check whether @login@ is a member of @team@ within @org@, using the
+-- supplied OAuth token against the live GitHub REST API.
+checkTeamMembership
+    :: OAuthToken
+    -> Org
+    -> TeamSlug
+    -> Login
+    -> IO MembershipResult
+checkTeamMembership token org team login =
+    checkTeamMembershipWith
+        githubTeamCheckEndpoint
+        token
+        org
+        team
+        (unLogin login)

--- a/src/Lib/GitHub/Auth/TeamCheck/Internal.hs
+++ b/src/Lib/GitHub/Auth/TeamCheck/Internal.hs
@@ -1,0 +1,170 @@
+-- | Internal client for the GitHub team-membership API.
+--
+-- This module exposes the response-mapping logic and an injectable
+-- endpoint so tests can point the client at a local fixture server
+-- while the public "Lib.GitHub.Auth.TeamCheck" wrapper targets GitHub.
+module Lib.GitHub.Auth.TeamCheck.Internal
+    ( -- * Public types
+      Org (..)
+    , TeamSlug (..)
+    , MembershipResult (..)
+
+      -- * Injectable client
+    , TeamCheckEndpoint (..)
+    , githubTeamCheckEndpoint
+    , checkTeamMembershipWith
+
+      -- * Helpers
+    , parseSsoUrl
+    ) where
+
+import Control.Exception (try)
+import Data.Aeson
+    ( FromJSON (parseJSON)
+    , eitherDecode
+    , withObject
+    , (.:)
+    )
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
+import Lib.GitHub.Auth.DeviceFlow (OAuthToken (..))
+import Network.HTTP.Client
+    ( HttpException
+    , Request (method, requestHeaders)
+    , Response (responseBody, responseHeaders, responseStatus)
+    , httpLbs
+    , newManager
+    , parseRequest
+    )
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Network.HTTP.Types (hAccept, hAuthorization, hUserAgent)
+import Network.HTTP.Types.Status (statusCode)
+
+-- | A GitHub organisation login.
+newtype Org = Org Text
+    deriving stock (Eq, Show)
+
+-- | A GitHub team slug within an organisation.
+newtype TeamSlug = TeamSlug Text
+    deriving stock (Eq, Show)
+
+-- | Outcome of a team-membership check.
+data MembershipResult
+    = -- | The login is an active member of the team.
+      Active
+    | -- | The login has a pending invitation to the team.
+      Pending
+    | -- | The login is not a member of the team.
+      NotMember
+    | -- | The supplied token was rejected.
+      TokenInvalid
+    | -- | SAML SSO authorisation is required; carries the URL to visit.
+      SSORequired {url :: Text}
+    | -- | Any other response, carrying the status code and raw body.
+      OtherError {status :: Int, body :: Text}
+    deriving stock (Eq, Show)
+
+-- | Base URL the membership client targets. Injected so tests can
+-- point at a local fixture server.
+newtype TeamCheckEndpoint = TeamCheckEndpoint
+    { teamCheckBaseUrl :: String
+    }
+    deriving stock (Eq, Show)
+
+-- | The production GitHub REST API base URL.
+githubTeamCheckEndpoint :: TeamCheckEndpoint
+githubTeamCheckEndpoint =
+    TeamCheckEndpoint{teamCheckBaseUrl = "https://api.github.com"}
+
+-- | Check team membership against an injectable endpoint.
+checkTeamMembershipWith
+    :: TeamCheckEndpoint
+    -> OAuthToken
+    -> Org
+    -> TeamSlug
+    -> Text
+    -> IO MembershipResult
+checkTeamMembershipWith endpoint token (Org org) (TeamSlug team) login = do
+    manager <- newManager tlsManagerSettings
+    requestResult <- try @HttpException $ do
+        baseRequest <-
+            parseRequest $ membershipUrl endpoint org team login
+        let request =
+                baseRequest
+                    { method = "GET"
+                    , requestHeaders =
+                        [ (hAccept, "application/vnd.github+json")
+                        , (hAuthorization, "Bearer " <> unOAuthToken token)
+                        , (hUserAgent, "moog")
+                        ]
+                    }
+        httpLbs request manager
+    pure $ case requestResult of
+        Left err -> OtherError 0 $ T.pack $ show err
+        Right response -> classifyResponse response
+
+-- | Build the membership URL for a login within a team.
+membershipUrl :: TeamCheckEndpoint -> Text -> Text -> Text -> String
+membershipUrl endpoint org team login =
+    teamCheckBaseUrl endpoint
+        <> "/orgs/"
+        <> T.unpack org
+        <> "/teams/"
+        <> T.unpack team
+        <> "/memberships/"
+        <> T.unpack login
+
+-- | Map a raw HTTP response to a 'MembershipResult'.
+classifyResponse :: Response LBS.ByteString -> MembershipResult
+classifyResponse response =
+    case statusCode (responseStatus response) of
+        200 -> case decodeState rawBody of
+            Right "active" -> Active
+            Right "pending" -> Pending
+            _ -> OtherError 200 bodyText
+        401 -> TokenInvalid
+        403 -> case ssoUrl of
+            Just ssoTarget -> SSORequired ssoTarget
+            Nothing -> OtherError 403 bodyText
+        404 -> NotMember
+        code -> OtherError code bodyText
+  where
+    rawBody = responseBody response
+    bodyText = decodeBodyText rawBody
+    ssoUrl = do
+        rawHeader <- lookup "X-GitHub-SSO" (responseHeaders response)
+        parseSsoUrl $ decodeUtf8Lenient rawHeader
+
+-- | The @state@ field of a membership payload.
+newtype MembershipState = MembershipState Text
+
+instance FromJSON MembershipState where
+    parseJSON =
+        withObject "MembershipState" $ \o ->
+            MembershipState <$> o .: "state"
+
+-- | Decode the @state@ field of a 200 membership payload.
+decodeState :: LBS.ByteString -> Either String Text
+decodeState raw =
+    (\(MembershipState state) -> state) <$> eitherDecode raw
+
+-- | Extract the SSO target URL from an @X-GitHub-SSO@ header value,
+-- preserving the URL verbatim and dropping only the @url=@ prefix and
+-- any leading metadata such as @required; @.
+parseSsoUrl :: Text -> Maybe Text
+parseSsoUrl headerValue =
+    case T.breakOn "url=" headerValue of
+        (_, rest)
+            | not (T.null rest) -> Just $ T.drop (T.length "url=") rest
+        _ -> Nothing
+
+decodeBodyText :: LBS.ByteString -> Text
+decodeBodyText = decodeUtf8Lenient . LBS.toStrict
+
+decodeUtf8Lenient :: ByteString -> Text
+decodeUtf8Lenient = T.decodeUtf8With lenientDecode
+  where
+    lenientDecode _ _ = Just '\xfffd'

--- a/test/Lib/GitHub/Auth/AuthSmokeSpec.hs
+++ b/test/Lib/GitHub/Auth/AuthSmokeSpec.hs
@@ -63,13 +63,13 @@ spec = do
                     (const False)
 
     describe "parseSmokeArgs" $ do
-        it "defaults org and team to pragma/antithesis" $ do
+        it "defaults org and team to pragma-org/antithesis-access" $ do
             parseSmokeArgs ["--expected-login", "alice"]
                 `shouldBe` Right
                     SmokeConfig
                         { expectedLogin = Login "alice"
-                        , org = Org "pragma"
-                        , team = TeamSlug "antithesis"
+                        , org = Org "pragma-org"
+                        , team = TeamSlug "antithesis-access"
                         }
 
         it "accepts explicit org and team overrides" $ do

--- a/test/Lib/GitHub/Auth/AuthSmokeSpec.hs
+++ b/test/Lib/GitHub/Auth/AuthSmokeSpec.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Lib.GitHub.Auth.AuthSmokeSpec
+    ( spec
+    )
+where
+
+import Data.Text qualified as T
+import Lib.GitHub.Auth.DeviceFlow (OAuthToken (..))
+import Lib.GitHub.Auth.Identify (GitHubError (..), Login (..))
+import Lib.GitHub.Auth.TeamCheck
+    ( MembershipResult (..)
+    , Org (..)
+    , TeamSlug (..)
+    )
+import Moog.GitHub.AuthSmoke
+    ( SmokeConfig (..)
+    , parseSmokeArgs
+    , renderLoginCheck
+    , renderMembershipCheck
+    , renderTokenEvidence
+    , tokenFromEnv
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    , shouldSatisfy
+    )
+
+spec :: Spec
+spec = do
+    describe "renderTokenEvidence" $ do
+        it "shows the token prefix and length without the full token" $ do
+            let token = "ghp_abcdefghijklmnopqrstuvwxyz"
+                evidence = renderTokenEvidence $ OAuthToken token
+            evidence `shouldSatisfy` T.isInfixOf "ghp_"
+            evidence `shouldSatisfy` T.isInfixOf "30"
+            evidence
+                `shouldSatisfy` not
+                . T.isInfixOf "ghp_abcdefghijklmnopqrstuvwxyz"
+
+    describe "tokenFromEnv" $ do
+        it "fails closed when the variable is unset" $ do
+            tokenFromEnv Nothing
+                `shouldSatisfy` either
+                    (T.isInfixOf "MOOG_GITHUB_OAUTH_TOKEN")
+                    (const False)
+
+        it "fails closed when the variable is empty" $ do
+            tokenFromEnv (Just "")
+                `shouldSatisfy` either (const True) (const False)
+
+        it "accepts a non-empty token" $ do
+            tokenFromEnv (Just "ghp_secret")
+                `shouldBe` Right (OAuthToken "ghp_secret")
+
+        it "never echoes the token bytes in the error path" $ do
+            tokenFromEnv Nothing
+                `shouldSatisfy` either
+                    (not . T.isInfixOf "ghp_")
+                    (const False)
+
+    describe "parseSmokeArgs" $ do
+        it "defaults org and team to pragma/antithesis" $ do
+            parseSmokeArgs ["--expected-login", "alice"]
+                `shouldBe` Right
+                    SmokeConfig
+                        { expectedLogin = Login "alice"
+                        , org = Org "pragma"
+                        , team = TeamSlug "antithesis"
+                        }
+
+        it "accepts explicit org and team overrides" $ do
+            parseSmokeArgs
+                [ "--expected-login"
+                , "alice"
+                , "--org"
+                , "acme"
+                , "--team"
+                , "core"
+                ]
+                `shouldBe` Right
+                    SmokeConfig
+                        { expectedLogin = Login "alice"
+                        , org = Org "acme"
+                        , team = TeamSlug "core"
+                        }
+
+        it "rejects a missing --expected-login" $ do
+            parseSmokeArgs ["--org", "acme"]
+                `shouldSatisfy` either
+                    (T.isInfixOf "--expected-login")
+                    (const False)
+
+    describe "renderLoginCheck" $ do
+        it "confirms a matching login" $ do
+            renderLoginCheck (Login "alice") (Right (Login "alice"))
+                `shouldSatisfy` either (const False) (T.isInfixOf "alice")
+
+        it "reports a login mismatch with both logins" $ do
+            let outcome =
+                    renderLoginCheck
+                        (Login "alice")
+                        (Right (Login "bob"))
+            outcome `shouldSatisfy` isLeft
+            outcome `shouldSatisfy` leftSatisfies (T.isInfixOf "alice")
+            outcome `shouldSatisfy` leftSatisfies (T.isInfixOf "bob")
+
+        it "reports a whoami error with its status" $ do
+            renderLoginCheck
+                (Login "alice")
+                (Left (GitHubError 401 "bad creds"))
+                `shouldSatisfy` leftSatisfies (T.isInfixOf "401")
+
+    describe "renderMembershipCheck" $ do
+        it "succeeds only on Active membership" $ do
+            renderMembershipCheck Active
+                `shouldSatisfy` either (const False) (const True)
+
+        it "fails on NotMember" $ do
+            renderMembershipCheck NotMember `shouldSatisfy` isLeft
+
+        it "fails on TokenInvalid" $ do
+            renderMembershipCheck TokenInvalid `shouldSatisfy` isLeft
+
+        it "fails on Pending" $ do
+            renderMembershipCheck Pending `shouldSatisfy` isLeft
+
+        it "fails on SSORequired and surfaces the URL" $ do
+            renderMembershipCheck (SSORequired "https://sso.example")
+                `shouldSatisfy` leftSatisfies
+                    (T.isInfixOf "https://sso.example")
+
+        it "fails on OtherError and surfaces the status" $ do
+            renderMembershipCheck (OtherError 500 "boom")
+                `shouldSatisfy` leftSatisfies (T.isInfixOf "500")
+
+isLeft :: Either a b -> Bool
+isLeft = either (const True) (const False)
+
+leftSatisfies :: (a -> Bool) -> Either a b -> Bool
+leftSatisfies p = either p (const False)

--- a/test/Lib/GitHub/Auth/IdentifySpec.hs
+++ b/test/Lib/GitHub/Auth/IdentifySpec.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Lib.GitHub.Auth.IdentifySpec
+    ( spec
+    )
+where
+
+import Data.Aeson (Value, encode, object, (.=))
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text (Text)
+import Lib.GitHub.Auth.DeviceFlow (OAuthToken (..))
+import Lib.GitHub.Auth.Identify (GitHubError (..), Login (..))
+import Lib.GitHub.Auth.Identify.Internal
+    ( IdentifyEndpoint (..)
+    , whoamiWith
+    )
+import Network.HTTP.Types
+    ( ResponseHeaders
+    , Status
+    , hContentType
+    , status200
+    , status401
+    )
+import Network.Wai
+    ( Application
+    , responseLBS
+    )
+import Network.Wai.Handler.Warp (testWithApplication)
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+
+spec :: Spec
+spec = do
+    describe "whoamiWith" $ do
+        it "maps 200 {login} to Right (Login ...)" $ do
+            result <-
+                withMockUser
+                    status200
+                    [(hContentType, "application/json")]
+                    (jsonResponse $ object ["login" .= ("octocat" :: Text)])
+                    runWhoami
+            result `shouldBe` Right (Login "octocat")
+
+        it "maps a non-success response to Left GitHubError" $ do
+            result <-
+                withMockUser status401 [] "bad creds" runWhoami
+            result `shouldBe` Left (GitHubError 401 "bad creds")
+
+runWhoami :: IdentifyEndpoint -> IO (Either GitHubError Login)
+runWhoami endpoint =
+    whoamiWith endpoint (OAuthToken "test-token")
+
+withMockUser
+    :: Status
+    -> ResponseHeaders
+    -> LBS.ByteString
+    -> (IdentifyEndpoint -> IO a)
+    -> IO a
+withMockUser status headers body action =
+    testWithApplication (pure $ application status headers body) $ \port ->
+        action
+            IdentifyEndpoint
+                { identifyBaseUrl = "http://127.0.0.1:" <> show port
+                }
+
+application :: Status -> ResponseHeaders -> LBS.ByteString -> Application
+application status headers body _request respond =
+    respond $ responseLBS status headers body
+
+jsonResponse :: Value -> LBS.ByteString
+jsonResponse = encode

--- a/test/Lib/GitHub/Auth/TeamCheckSpec.hs
+++ b/test/Lib/GitHub/Auth/TeamCheckSpec.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Lib.GitHub.Auth.TeamCheckSpec
+    ( spec
+    )
+where
+
+import Data.Aeson (Value, encode, object, (.=))
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text (Text)
+import Lib.GitHub.Auth.DeviceFlow (OAuthToken (..))
+import Lib.GitHub.Auth.TeamCheck
+    ( MembershipResult (..)
+    , Org (..)
+    , TeamSlug (..)
+    )
+import Lib.GitHub.Auth.TeamCheck.Internal
+    ( TeamCheckEndpoint (..)
+    , checkTeamMembershipWith
+    )
+import Network.HTTP.Types
+    ( ResponseHeaders
+    , Status
+    , hContentType
+    , status200
+    , status401
+    , status403
+    , status404
+    , status500
+    )
+import Network.Wai
+    ( Application
+    , responseLBS
+    )
+import Network.Wai.Handler.Warp (testWithApplication)
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+
+spec :: Spec
+spec = do
+    describe "checkTeamMembershipWith" $ do
+        it "maps 200 active to Active" $ do
+            result <-
+                withMockTeam
+                    status200
+                    [(hContentType, "application/json")]
+                    (jsonResponse $ object ["state" .= ("active" :: Text)])
+                    runCheck
+            result `shouldBe` Active
+
+        it "maps 200 pending to Pending" $ do
+            result <-
+                withMockTeam
+                    status200
+                    [(hContentType, "application/json")]
+                    (jsonResponse $ object ["state" .= ("pending" :: Text)])
+                    runCheck
+            result `shouldBe` Pending
+
+        it "maps 404 to NotMember" $ do
+            result <-
+                withMockTeam status404 [] "" runCheck
+            result `shouldBe` NotMember
+
+        it "maps 401 to TokenInvalid" $ do
+            result <-
+                withMockTeam status401 [] "" runCheck
+            result `shouldBe` TokenInvalid
+
+        it "maps 403 with X-GitHub-SSO to SSORequired carrying the verbatim url" $ do
+            result <-
+                withMockTeam
+                    status403
+                    [ ( "X-GitHub-SSO"
+                      , "required; url=https://github.com/orgs/myorg/sso?authorization_request=ABC123"
+                      )
+                    ]
+                    ""
+                    runCheck
+            result
+                `shouldBe` SSORequired
+                    "https://github.com/orgs/myorg/sso?authorization_request=ABC123"
+
+        it "maps 500 to OtherError carrying status and body" $ do
+            result <-
+                withMockTeam status500 [] "boom" runCheck
+            result `shouldBe` OtherError 500 "boom"
+
+runCheck :: TeamCheckEndpoint -> IO MembershipResult
+runCheck endpoint =
+    checkTeamMembershipWith
+        endpoint
+        (OAuthToken "test-token")
+        (Org "myorg")
+        (TeamSlug "myteam")
+        "octocat"
+
+withMockTeam
+    :: Status
+    -> ResponseHeaders
+    -> LBS.ByteString
+    -> (TeamCheckEndpoint -> IO a)
+    -> IO a
+withMockTeam status headers body action =
+    testWithApplication (pure $ application status headers body) $ \port ->
+        action
+            TeamCheckEndpoint
+                { teamCheckBaseUrl = "http://127.0.0.1:" <> show port
+                }
+
+application :: Status -> ResponseHeaders -> LBS.ByteString -> Application
+application status headers body _request respond =
+    respond $ responseLBS status headers body
+
+jsonResponse :: Value -> LBS.ByteString
+jsonResponse = encode


### PR DESCRIPTION
Closes #112. Part of #109.

## Summary
- Adds `Lib.GitHub.Auth.TeamCheck` with `Org`, `TeamSlug`, `Login`, `MembershipResult`, and `checkTeamMembership`.
- Adds `Lib.GitHub.Auth.Identify` with the moog-owned `Login` newtype, `GitHubError`, and `whoami`.
- Adds `moog-github-auth-smoke`, exposed via `nix run .#moog-github-auth-smoke`, for the real GitHub token/team-membership boundary.
- Corrects the live-smoke default GitHub team slugs to `pragma-org` / `antithesis-access` after operator verification in A-003.

## Verification
- `./gate.sh` passed after TeamCheck: 163 examples, 0 failures.
- `./gate.sh` passed after Identify: 165 examples, 0 failures.
- `./gate.sh` passed after auth smoke: 182 examples, 0 failures.
- `./gate.sh` passed after slug correction: 182 examples, 0 failures.
- `nix run .#moog-github-auth-smoke -- --expected-login dummy` resolves and fails closed without `MOOG_GITHUB_OAUTH_TOKEN`.
- Operator live smoke passed with the real corrected GitHub slugs:

```text
MOOG_GITHUB_OAUTH_TOKEN=<paolino's PAT, read:org scope, redacted> \
  nix run .#moog-github-auth-smoke -- \
    --expected-login paolino \
    --org pragma-org \
    --team antithesis-access

Token evidence: ghp_ len=40
identity confirmed: paolino
active team membership confirmed
exit=0
```

## Slug Correction
- Briefed values `pragma` / `antithesis` were wrong for the GitHub team-membership check.
- Canonical GitHub slugs are `pragma-org` / `antithesis-access`.
- The Antithesis tenant context is unchanged: tenant `amaru-cardano` and Antithesis HTTP API username `pragma` are not GitHub slugs.
