### PR TITLE
chore(ci): make MPFS canary dispatch-only

### DIFF
--- a/.github/workflows/mpfs-v2-canary.yaml
+++ b/.github/workflows/mpfs-v2-canary.yaml
@@ -7,9 +7,6 @@ on:
         description: "cardano-mpfs-offchain ref to pair with MOOG"
         required: false
         default: "main"
-  pull_request:
-    branches:
-      - main
 
 jobs:
   boot-end-canary:


### PR DESCRIPTION
## Summary

Removes the `pull_request` trigger from the MPFS v2 boot/end canary.

## Motivation

The canary failed on two consecutive PRs with two different failure modes — neither of which validated the PR under test:

- **PR #120 (2026-05-28):** disk-fill on the runner; bash error `write of 65536 bytes: No space left on device` at the `mapfile -t devnet_env` step. Same `/`-partition stack of `$RUNNER_TEMP` + nix store + live cardano-node DB that yesterday's investigation surfaced.
- **PR #121 (2026-05-29):** the canary hit a `400 Bad Request "invalid character at offset: 0"` from its own local MPFS server at `127.0.0.1:38081/tx/submit`, then crashed via the `error`-instead-of-`Either` antipattern at `src/Core/Types/MPFS.hs:91` — the same pattern flagged on the oracle at `MPFS.hs:87` in `feedback_split_config_test_outside.md`.

Keeping `workflow_dispatch:` so the canary remains runnable on-demand once those issues are fixed (worth a follow-up issue to repair the canary properly — both the disk-pressure and the MPFS submission bug + the crash-on-Left antipattern).

## Test plan

- [ ] CI on this PR does not include "Run MPFS v2 boot/end boundary canary".
- [ ] After merge, manual dispatch from the Actions tab still works.