### PR TITLE
feat: add Antithesis proxy daemon

### DIFF
--- a/app/moog-antithesis-proxy.hs
+++ b/app/moog-antithesis-proxy.hs
@@ -1,0 +1,6 @@
+import Proxy.Antithesis.Config (loadSettings)
+
+main :: IO ()
+main = do
+    _settings <- loadSettings
+    pure ()

--- a/app/moog-antithesis-proxy.hs
+++ b/app/moog-antithesis-proxy.hs
@@ -1,6 +1,19 @@
-import Proxy.Antithesis.Config (loadSettings)
+import Data.String (fromString)
+import Network.Wai.Handler.Warp qualified as Warp
+import Proxy.Antithesis.Application (productionApplication)
+import Proxy.Antithesis.Config
+    ( Settings (..)
+    , loadSettings
+    )
 
 main :: IO ()
 main = do
-    _settings <- loadSettings
-    pure ()
+    settings <- loadSettings
+    application <- productionApplication settings
+    Warp.runSettings (warpSettings settings) application
+
+warpSettings :: Settings -> Warp.Settings
+warpSettings settings =
+    Warp.setHost (fromString $ settingsBindAddr settings)
+        $ Warp.setPort (settingsBindPort settings)
+        $ Warp.defaultSettings

--- a/moog.cabal
+++ b/moog.cabal
@@ -156,6 +156,9 @@ library
     Oracle.Validate.Requests.TestRun.Create
     Oracle.Validate.Requests.TestRun.Update
     Oracle.Validate.Types
+    Proxy.Antithesis.Audit
+    Proxy.Antithesis.Cache
+    Proxy.Antithesis.Config
     Submitting
     User.Agent.Cli
     User.Agent.Lib
@@ -311,6 +314,21 @@ executable moog-agent
     , moog
 
   -- Directories containing source files.
+
+  -- Base language which the package is written in.
+  default-language: Haskell2010
+
+executable moog-antithesis-proxy
+  -- Import common warning flags.
+  import:           warnings
+
+  -- .hs or .lhs file containing the Main module.
+  main-is:          app/moog-antithesis-proxy.hs
+
+  -- Other library packages from which modules are imported.
+  build-depends:
+    , base
+    , moog
 
   -- Base language which the package is written in.
   default-language: Haskell2010
@@ -471,6 +489,9 @@ test-suite unit-tests
     Oracle.Validate.Requests.TestRun.FinishSpec
     Oracle.Validate.Requests.TestRun.Lib
     Oracle.Validate.Requests.TestRun.RejectSpec
+    Proxy.Antithesis.AuditSpec
+    Proxy.Antithesis.CacheSpec
+    Proxy.Antithesis.ConfigSpec
     User.Agent.ProcessOptionsSpec
     User.Agent.PublishResults.EmailSpec
     User.Agent.PushTestSpec

--- a/moog.cabal
+++ b/moog.cabal
@@ -159,6 +159,7 @@ library
     Proxy.Antithesis.Audit
     Proxy.Antithesis.Cache
     Proxy.Antithesis.Config
+    Proxy.Antithesis.Handler.Runs
     Proxy.Antithesis.Middleware.Auth
     Submitting
     User.Agent.Cli
@@ -496,6 +497,7 @@ test-suite unit-tests
     Proxy.Antithesis.AuthSpec
     Proxy.Antithesis.CacheSpec
     Proxy.Antithesis.ConfigSpec
+    Proxy.Antithesis.Handler.RunsSpec
     User.Agent.ProcessOptionsSpec
     User.Agent.PublishResults.EmailSpec
     User.Agent.PushTestSpec

--- a/moog.cabal
+++ b/moog.cabal
@@ -157,6 +157,7 @@ library
     Oracle.Validate.Requests.TestRun.Update
     Oracle.Validate.Types
     Proxy.Antithesis.Audit
+    Proxy.Antithesis.Application
     Proxy.Antithesis.Cache
     Proxy.Antithesis.Config
     Proxy.Antithesis.Handler.Runs
@@ -333,6 +334,7 @@ executable moog-antithesis-proxy
   build-depends:
     , base
     , moog
+    , warp
 
   -- Base language which the package is written in.
   default-language: Haskell2010
@@ -494,6 +496,7 @@ test-suite unit-tests
     Oracle.Validate.Requests.TestRun.Lib
     Oracle.Validate.Requests.TestRun.RejectSpec
     Proxy.Antithesis.AuditSpec
+    Proxy.Antithesis.ApplicationSpec
     Proxy.Antithesis.AuthSpec
     Proxy.Antithesis.CacheSpec
     Proxy.Antithesis.ConfigSpec

--- a/moog.cabal
+++ b/moog.cabal
@@ -159,6 +159,7 @@ library
     Proxy.Antithesis.Audit
     Proxy.Antithesis.Cache
     Proxy.Antithesis.Config
+    Proxy.Antithesis.Middleware.Auth
     Submitting
     User.Agent.Cli
     User.Agent.Lib
@@ -237,6 +238,8 @@ library
     , time
     , transformers
     , vector
+    , vault
+    , wai
     , yaml
 
   -- Directories containing source files.
@@ -490,6 +493,7 @@ test-suite unit-tests
     Oracle.Validate.Requests.TestRun.Lib
     Oracle.Validate.Requests.TestRun.RejectSpec
     Proxy.Antithesis.AuditSpec
+    Proxy.Antithesis.AuthSpec
     Proxy.Antithesis.CacheSpec
     Proxy.Antithesis.ConfigSpec
     User.Agent.ProcessOptionsSpec
@@ -577,7 +581,9 @@ test-suite unit-tests
     , time
     , transformers
     , vector
+    , vault
     , wai
+    , wai-extra
     , warp
     , yaml
 

--- a/moog.cabal
+++ b/moog.cabal
@@ -330,6 +330,8 @@ executable moog-antithesis-proxy
   -- .hs or .lhs file containing the Main module.
   main-is:          app/moog-antithesis-proxy.hs
 
+  ghc-options:      -threaded
+
   -- Other library packages from which modules are imported.
   build-depends:
     , base

--- a/nix/moog-project.nix
+++ b/nix/moog-project.nix
@@ -77,6 +77,8 @@ in {
   packages.moog = project.hsPkgs.moog.components.exes.moog;
   packages.moog-oracle = project.hsPkgs.moog.components.exes.moog-oracle;
   packages.moog-agent = project.hsPkgs.moog.components.exes.moog-agent;
+  packages.moog-antithesis-proxy =
+    project.hsPkgs.moog.components.exes.moog-antithesis-proxy;
   packages.moog-mpfs-v2-canary =
     project.hsPkgs.moog.components.exes.moog-mpfs-v2-canary;
   packages.moog-github-device-flow-smoke =

--- a/specs/113-antithesis-proxy/plan.md
+++ b/specs/113-antithesis-proxy/plan.md
@@ -1,0 +1,61 @@
+# Implementation Plan: moog-antithesis-proxy
+
+## Technical Shape
+
+The proxy is implemented as a WAI application in the `moog` library and
+started by a new `moog-antithesis-proxy` executable. The application uses
+the public #112 APIs:
+
+- `Lib.GitHub.Auth.Identify.whoami`
+- `Lib.GitHub.Auth.TeamCheck.checkTeamMembership`
+
+The auth middleware is parameterized by those functions so tests can
+exercise every membership result without live GitHub calls. The
+production constructor wires the real functions.
+
+The Antithesis upstream client uses `http-client`. Tests use a local WAI
+`warp` server as the upstream boundary.
+
+## Slice Breakdown
+
+### Slice 1: Config, Cache, Audit, Cabal Scaffold
+
+Add environment parsing, the membership cache, audit event rendering,
+the executable stanza, and a skeletal `main` that can parse settings.
+This slice proves defaults, env overrides, secret-file loading, cache
+hit/miss/expiry, and audit sanitization.
+
+### Slice 2: Auth Middleware
+
+Add `Proxy.Antithesis.Middleware.Auth`, including bearer-token parsing,
+GitHub identity/team injection points, 60-second cache use, WAI vault
+login attachment, and required `401`/`403` response mapping.
+
+### Slice 3: Runs Handler
+
+Add `Proxy.Antithesis.Handler.Runs` forwarding
+`GET /api/v1/runs`, preserving query strings, attaching Antithesis basic
+auth, passing through safe response headers and body, sanitizing
+upstream 5xx responses, and reporting upstream status to audit context.
+
+### Slice 4: Application Assembly and Readiness
+
+Assemble the WAI app with `GET /healthz`, `GET /readyz`,
+`GET /api/v1/runs`, and `404` fallback. Add readiness checks against the
+Antithesis runs endpoint and GitHub API. Wire `app/moog-antithesis-proxy.hs`
+to Warp settings.
+
+### Slice 5: Final Verification and PR Metadata
+
+Run the full gate, build the executable target, smoke `/healthz`, update
+the PR body, and push the final branch state.
+
+## Verification
+
+Each implementation slice follows RED -> GREEN:
+
+1. Add focused tests and run the focused command to observe failure.
+2. Add minimal implementation.
+3. Run the focused command and `./gate.sh`.
+4. Commit one bisect-safe slice with a `Tasks:` trailer.
+5. Push only after local verification.

--- a/specs/113-antithesis-proxy/spec.md
+++ b/specs/113-antithesis-proxy/spec.md
@@ -1,0 +1,59 @@
+# Feature Specification: moog-antithesis-proxy
+
+## User Story
+
+As a Moog operator, I need a long-running HTTP proxy in front of the
+Antithesis tenant API so that access to run data is gated by GitHub
+team membership and the tenant basic-auth secret stays server-side.
+
+## Functional Requirements
+
+- `moog-antithesis-proxy` serves `GET /healthz` without auth and returns
+  `200 ok`.
+- `GET /readyz` returns `200 ready` only when the configured Antithesis
+  `/api/v1/runs` endpoint and GitHub API are reachable; otherwise it
+  returns `503`.
+- `GET /api/v1/runs` requires `Authorization: Bearer <token>`.
+- Missing or malformed bearer tokens return `401` with
+  `WWW-Authenticate: Bearer realm="moog-antithesis-proxy"`.
+- The proxy identifies the token owner with `whoami`, then checks
+  membership in `MOOG_PROXY_AUTHORIZED_ORG` /
+  `MOOG_PROXY_AUTHORIZED_TEAM`.
+- Invalid tokens return `401`; pending invitations and non-members return
+  `403`; SSO-required responses return `403` with `X-Moog-SSO-Url`.
+- Authorized requests forward to
+  `$MOOG_ANTITHESIS_URL/api/v1/runs`, preserving the query string and
+  sending server-held Antithesis basic auth from
+  `MOOG_ANTITHESIS_USER` plus `MOOG_ANTITHESIS_PASSWORD_FILE`.
+- The runs response passes through upstream status, body, content-type,
+  and content-length. Upstream 5xx client responses are sanitized.
+- Every request emits one JSON audit line without tokens or upstream
+  bodies, including timestamp, login, path, response status, optional
+  upstream status, latency, and request id.
+- Unknown endpoints return `404`.
+
+## Configuration
+
+- `MOOG_PROXY_BIND_ADDR`, default `0.0.0.0`
+- `MOOG_PROXY_BIND_PORT`, default `8080`
+- `MOOG_ANTITHESIS_URL`, default
+  `https://amaru-cardano.antithesis.com`
+- `MOOG_ANTITHESIS_USER`, default `pragma`
+- `MOOG_ANTITHESIS_PASSWORD_FILE`, default
+  `/run/secrets/antithesis-password`
+- `MOOG_PROXY_AUTHORIZED_ORG`, default `pragma-org`
+- `MOOG_PROXY_AUTHORIZED_TEAM`, default `antithesis-access`
+- `MOOG_PROXY_MEMBERSHIP_TTL_SEC`, default `60`
+- `MOOG_PROXY_LOG_LEVEL`, default `info`
+
+## Success Criteria
+
+- Unit tests cover auth middleware success and the required failure
+  shapes.
+- Unit tests cover membership cache TTL behavior without storing raw
+  tokens.
+- Unit tests cover runs proxying through a mock WAI upstream.
+- Integration-style unit tests cover `/readyz` success and failure
+  against mock endpoints.
+- `moog-antithesis-proxy` cabal target builds.
+- `./gate.sh` passes before every pushed slice.

--- a/specs/113-antithesis-proxy/tasks.md
+++ b/specs/113-antithesis-proxy/tasks.md
@@ -1,0 +1,43 @@
+# Tasks: moog-antithesis-proxy
+
+## Slice 1 - Config, Cache, Audit, Cabal Scaffold
+
+- [ ] T113-S1 Add failing tests for settings parsing, membership cache,
+  and audit rendering.
+- [ ] T113-S1 Implement `Proxy.Antithesis.Config`,
+  `Proxy.Antithesis.Cache`, and `Proxy.Antithesis.Audit`.
+- [ ] T113-S1 Add cabal exposure and a skeletal
+  `moog-antithesis-proxy` executable.
+- [ ] T113-S1 Run focused tests and `./gate.sh`, then commit.
+
+## Slice 2 - Auth Middleware
+
+- [ ] T113-S2 Add failing auth middleware tests for missing/malformed
+  token, invalid token, pending, not-member, SSO-required, other error,
+  and success.
+- [ ] T113-S2 Implement bearer auth, membership caching, vault login
+  attachment, and failure response mapping.
+- [ ] T113-S2 Run focused tests and `./gate.sh`, then commit.
+
+## Slice 3 - Runs Handler
+
+- [ ] T113-S3 Add failing runs handler tests with a WAI mock upstream.
+- [ ] T113-S3 Implement query-preserving forwarding, Antithesis basic
+  auth, pass-through headers, streamed response handling, and sanitized
+  upstream 5xx responses.
+- [ ] T113-S3 Run focused tests and `./gate.sh`, then commit.
+
+## Slice 4 - Application Assembly and Readiness
+
+- [ ] T113-S4 Add failing application tests for `/healthz`, `/readyz`,
+  `GET /api/v1/runs`, and unknown routes.
+- [ ] T113-S4 Assemble the WAI app, readiness checks, and Warp
+  executable entrypoint.
+- [ ] T113-S4 Run focused tests, executable build, and `./gate.sh`, then
+  commit.
+
+## Slice 5 - Final Verification and PR Metadata
+
+- [ ] T113-S5 Run final `./gate.sh`, build/smoke
+  `moog-antithesis-proxy`, update PR metadata, and mark the ticket
+  complete.

--- a/specs/113-antithesis-proxy/tasks.md
+++ b/specs/113-antithesis-proxy/tasks.md
@@ -2,13 +2,13 @@
 
 ## Slice 1 - Config, Cache, Audit, Cabal Scaffold
 
-- [ ] T113-S1 Add failing tests for settings parsing, membership cache,
+- [X] T113-S1 Add failing tests for settings parsing, membership cache,
   and audit rendering.
-- [ ] T113-S1 Implement `Proxy.Antithesis.Config`,
+- [X] T113-S1 Implement `Proxy.Antithesis.Config`,
   `Proxy.Antithesis.Cache`, and `Proxy.Antithesis.Audit`.
-- [ ] T113-S1 Add cabal exposure and a skeletal
+- [X] T113-S1 Add cabal exposure and a skeletal
   `moog-antithesis-proxy` executable.
-- [ ] T113-S1 Run focused tests and `./gate.sh`, then commit.
+- [X] T113-S1 Run focused tests and `./gate.sh`, then commit.
 
 ## Slice 2 - Auth Middleware
 

--- a/specs/113-antithesis-proxy/tasks.md
+++ b/specs/113-antithesis-proxy/tasks.md
@@ -12,12 +12,12 @@
 
 ## Slice 2 - Auth Middleware
 
-- [ ] T113-S2 Add failing auth middleware tests for missing/malformed
+- [X] T113-S2 Add failing auth middleware tests for missing/malformed
   token, invalid token, pending, not-member, SSO-required, other error,
   and success.
-- [ ] T113-S2 Implement bearer auth, membership caching, vault login
+- [X] T113-S2 Implement bearer auth, membership caching, vault login
   attachment, and failure response mapping.
-- [ ] T113-S2 Run focused tests and `./gate.sh`, then commit.
+- [X] T113-S2 Run focused tests and `./gate.sh`, then commit.
 
 ## Slice 3 - Runs Handler
 

--- a/specs/113-antithesis-proxy/tasks.md
+++ b/specs/113-antithesis-proxy/tasks.md
@@ -21,11 +21,11 @@
 
 ## Slice 3 - Runs Handler
 
-- [ ] T113-S3 Add failing runs handler tests with a WAI mock upstream.
-- [ ] T113-S3 Implement query-preserving forwarding, Antithesis basic
+- [X] T113-S3 Add failing runs handler tests with a WAI mock upstream.
+- [X] T113-S3 Implement query-preserving forwarding, Antithesis basic
   auth, pass-through headers, streamed response handling, and sanitized
   upstream 5xx responses.
-- [ ] T113-S3 Run focused tests and `./gate.sh`, then commit.
+- [X] T113-S3 Run focused tests and `./gate.sh`, then commit.
 
 ## Slice 4 - Application Assembly and Readiness
 

--- a/specs/113-antithesis-proxy/tasks.md
+++ b/specs/113-antithesis-proxy/tasks.md
@@ -29,11 +29,11 @@
 
 ## Slice 4 - Application Assembly and Readiness
 
-- [ ] T113-S4 Add failing application tests for `/healthz`, `/readyz`,
+- [X] T113-S4 Add failing application tests for `/healthz`, `/readyz`,
   `GET /api/v1/runs`, and unknown routes.
-- [ ] T113-S4 Assemble the WAI app, readiness checks, and Warp
+- [X] T113-S4 Assemble the WAI app, readiness checks, and Warp
   executable entrypoint.
-- [ ] T113-S4 Run focused tests, executable build, and `./gate.sh`, then
+- [X] T113-S4 Run focused tests, executable build, and `./gate.sh`, then
   commit.
 
 ## Slice 5 - Final Verification and PR Metadata

--- a/specs/113-antithesis-proxy/tasks.md
+++ b/specs/113-antithesis-proxy/tasks.md
@@ -38,6 +38,6 @@
 
 ## Slice 5 - Final Verification and PR Metadata
 
-- [ ] T113-S5 Run final `./gate.sh`, build/smoke
+- [X] T113-S5 Run final `./gate.sh`, build/smoke
   `moog-antithesis-proxy`, update PR metadata, and mark the ticket
   complete.

--- a/src/Proxy/Antithesis/Application.hs
+++ b/src/Proxy/Antithesis/Application.hs
@@ -1,0 +1,179 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | WAI application assembly for the Antithesis proxy daemon.
+module Proxy.Antithesis.Application
+    ( ProxyApplicationConfig (..)
+    , ReadinessConfig (..)
+    , productionApplication
+    , proxyApplication
+    , readinessCheck
+    )
+where
+
+import Control.Exception (SomeException, try)
+import Data.ByteString (ByteString)
+import Data.ByteString.Base64 qualified as Base64
+import Data.ByteString.Lazy qualified as LBS
+import Data.Time.Clock (getCurrentTime)
+import Lib.GitHub.Auth.Identify (whoami)
+import Lib.GitHub.Auth.TeamCheck (checkTeamMembership)
+import Network.HTTP.Client
+    ( Manager
+    , Request (method, requestHeaders)
+    , httpLbs
+    , newManager
+    , parseRequest
+    , responseStatus
+    )
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Network.HTTP.Types
+    ( RequestHeaders
+    , Status
+    , hAccept
+    , hAuthorization
+    , hContentType
+    , hUserAgent
+    , methodGet
+    , status200
+    , status404
+    , status503
+    , statusCode
+    )
+import Network.Wai
+    ( Application
+    , Request (pathInfo, requestMethod)
+    , Response
+    , responseLBS
+    )
+import Proxy.Antithesis.Cache (newMembershipCache)
+import Proxy.Antithesis.Config
+    ( Settings (..)
+    )
+import Proxy.Antithesis.Handler.Runs
+    ( RunsConfig (..)
+    , runsHandler
+    )
+import Proxy.Antithesis.Middleware.Auth
+    ( AuthConfig (..)
+    , authMiddleware
+    )
+
+data ProxyApplicationConfig = ProxyApplicationConfig
+    { proxyAuthConfig :: AuthConfig
+    , proxyRunsConfig :: RunsConfig
+    , proxyReadinessConfig :: ReadinessConfig
+    }
+
+data ReadinessConfig = ReadinessConfig
+    { readinessAntithesis :: IO Bool
+    , readinessGitHub :: IO Bool
+    }
+
+proxyApplication :: ProxyApplicationConfig -> Application
+proxyApplication config request respond =
+    case (requestMethod request, pathInfo request) of
+        ("GET", ["healthz"]) ->
+            respond $ plain status200 "ok"
+        ("GET", ["readyz"]) -> do
+            ready <- readinessCheck $ proxyReadinessConfig config
+            respond $
+                if ready
+                    then plain status200 "ready"
+                    else plain status503 "not ready"
+        ("GET", ["api", "v1", "runs"]) ->
+            authMiddleware
+                (proxyAuthConfig config)
+                (runsHandler $ proxyRunsConfig config)
+                request
+                respond
+        _ ->
+            respond $ plain status404 "not found"
+
+readinessCheck :: ReadinessConfig -> IO Bool
+readinessCheck config =
+    (&&)
+        <$> readinessAntithesis config
+        <*> readinessGitHub config
+
+productionApplication :: Settings -> IO Application
+productionApplication settings = do
+    manager <- newManager tlsManagerSettings
+    cache <-
+        newMembershipCache $
+            fromIntegral (settingsMembershipTtlSeconds settings)
+    pure $
+        proxyApplication
+            ProxyApplicationConfig
+                { proxyAuthConfig =
+                    AuthConfig
+                        { authOrg = settingsAuthorizedOrg settings
+                        , authTeam = settingsAuthorizedTeam settings
+                        , authCache = cache
+                        , authNow = getCurrentTime
+                        , authWhoami = whoami
+                        , authCheckTeamMembership = checkTeamMembership
+                        }
+                , proxyRunsConfig =
+                    RunsConfig
+                        { runsAntithesisUrl = settingsAntithesisUrl settings
+                        , runsAntithesisUser = settingsAntithesisUser settings
+                        , runsAntithesisPassword =
+                            settingsAntithesisPassword settings
+                        , runsManager = manager
+                        }
+                , proxyReadinessConfig =
+                    productionReadinessConfig settings manager
+                }
+
+productionReadinessConfig :: Settings -> Manager -> ReadinessConfig
+productionReadinessConfig settings manager =
+    ReadinessConfig
+        { readinessAntithesis =
+            probeEndpoint
+                manager
+                (antithesisRunsUrl settings)
+                [(hAuthorization, antithesisBasicAuthorization settings)]
+        , readinessGitHub =
+            probeEndpoint
+                manager
+                "https://api.github.com/rate_limit"
+                [ (hAccept, "application/vnd.github+json")
+                , (hUserAgent, "moog-antithesis-proxy")
+                ]
+        }
+
+probeEndpoint :: Manager -> String -> RequestHeaders -> IO Bool
+probeEndpoint manager url headers = do
+    result <- try @SomeException $ do
+        baseRequest <- parseRequest url
+        response <-
+            httpLbs
+                baseRequest
+                    { method = methodGet
+                    , requestHeaders = headers
+                    }
+                manager
+        pure $ statusCode (responseStatus response) < 500
+    pure $ either (const False) id result
+
+antithesisRunsUrl :: Settings -> String
+antithesisRunsUrl settings =
+    stripTrailingSlash (settingsAntithesisUrl settings) <> "/api/v1/runs"
+
+antithesisBasicAuthorization :: Settings -> ByteString
+antithesisBasicAuthorization settings =
+    "Basic "
+        <> Base64.encode
+            ( settingsAntithesisUser settings
+                <> ":"
+                <> settingsAntithesisPassword settings
+            )
+
+plain :: Status -> ByteString -> Response
+plain status body =
+    responseLBS status [(hContentType, "text/plain")] $ LBS.fromStrict body
+
+stripTrailingSlash :: String -> String
+stripTrailingSlash =
+    reverse . dropWhile (== '/') . reverse

--- a/src/Proxy/Antithesis/Application.hs
+++ b/src/Proxy/Antithesis/Application.hs
@@ -15,17 +15,16 @@ import Control.Exception (SomeException, try)
 import Data.ByteString (ByteString)
 import Data.ByteString.Base64 qualified as Base64
 import Data.ByteString.Lazy qualified as LBS
-import Data.Time.Clock (getCurrentTime)
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Maybe (fromMaybe)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
+import Data.Text.Encoding.Error (lenientDecode)
+import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
+import Data.Vault.Lazy qualified as Vault
 import Lib.GitHub.Auth.Identify (whoami)
 import Lib.GitHub.Auth.TeamCheck (checkTeamMembership)
-import Network.HTTP.Client
-    ( Manager
-    , Request (method, requestHeaders)
-    , httpLbs
-    , newManager
-    , parseRequest
-    , responseStatus
-    )
+import Network.HTTP.Client qualified as HC
 import Network.HTTP.Client.TLS (tlsManagerSettings)
 import Network.HTTP.Types
     ( RequestHeaders
@@ -42,13 +41,19 @@ import Network.HTTP.Types
     )
 import Network.Wai
     ( Application
-    , Request (pathInfo, requestMethod)
+    , Request (pathInfo, rawPathInfo, requestHeaders, requestMethod, vault)
     , Response
     , responseLBS
     )
+import Network.Wai.Internal (Response (..))
 import Proxy.Antithesis.Cache (newMembershipCache)
 import Proxy.Antithesis.Config
     ( Settings (..)
+    )
+import Proxy.Antithesis.Audit
+    ( AuditEvent (..)
+    , RequestId (..)
+    , renderAuditEvent
     )
 import Proxy.Antithesis.Handler.Runs
     ( RunsConfig (..)
@@ -57,7 +62,9 @@ import Proxy.Antithesis.Handler.Runs
 import Proxy.Antithesis.Middleware.Auth
     ( AuthConfig (..)
     , authMiddleware
+    , authorizedLoginKey
     )
+import System.IO (hFlush, stdout)
 
 data ProxyApplicationConfig = ProxyApplicationConfig
     { proxyAuthConfig :: AuthConfig
@@ -73,22 +80,55 @@ data ReadinessConfig = ReadinessConfig
 proxyApplication :: ProxyApplicationConfig -> Application
 proxyApplication config request respond =
     case (requestMethod request, pathInfo request) of
-        ("GET", ["healthz"]) ->
-            respond $ plain status200 "ok"
+        ("GET", ["healthz"]) -> do
+            start <- getCurrentTime
+            auditAndRespond request start Nothing (plain status200 "ok") respond
         ("GET", ["readyz"]) -> do
+            start <- getCurrentTime
             ready <- readinessCheck $ proxyReadinessConfig config
-            respond $
-                if ready
+            auditAndRespond
+                request
+                start
+                Nothing
+                ( if ready
                     then plain status200 "ready"
                     else plain status503 "not ready"
-        ("GET", ["api", "v1", "runs"]) ->
+                )
+                respond
+        ("GET", ["api", "v1", "runs"]) -> do
+            authHandled <- newIORef False
+            start <- getCurrentTime
             authMiddleware
                 (proxyAuthConfig config)
-                (runsHandler $ proxyRunsConfig config)
+                ( \authorizedRequest authorizedRespond -> do
+                    writeIORef authHandled True
+                    runsHandler
+                        (proxyRunsConfig config)
+                        authorizedRequest
+                        $ \response ->
+                            auditAndRespond
+                                authorizedRequest
+                                start
+                                (Just $ waiResponseStatus response)
+                                response
+                                authorizedRespond
+                )
                 request
-                respond
-        _ ->
-            respond $ plain status404 "not found"
+                ( \response -> do
+                    handled <- readIORef authHandled
+                    if handled
+                        then respond response
+                        else
+                            auditAndRespond
+                                request
+                                start
+                                Nothing
+                                response
+                                respond
+                )
+        _ -> do
+            start <- getCurrentTime
+            auditAndRespond request start Nothing (plain status404 "not found") respond
 
 readinessCheck :: ReadinessConfig -> IO Bool
 readinessCheck config =
@@ -98,7 +138,7 @@ readinessCheck config =
 
 productionApplication :: Settings -> IO Application
 productionApplication settings = do
-    manager <- newManager tlsManagerSettings
+    manager <- HC.newManager tlsManagerSettings
     cache <-
         newMembershipCache $
             fromIntegral (settingsMembershipTtlSeconds settings)
@@ -126,7 +166,7 @@ productionApplication settings = do
                     productionReadinessConfig settings manager
                 }
 
-productionReadinessConfig :: Settings -> Manager -> ReadinessConfig
+productionReadinessConfig :: Settings -> HC.Manager -> ReadinessConfig
 productionReadinessConfig settings manager =
     ReadinessConfig
         { readinessAntithesis =
@@ -143,18 +183,18 @@ productionReadinessConfig settings manager =
                 ]
         }
 
-probeEndpoint :: Manager -> String -> RequestHeaders -> IO Bool
+probeEndpoint :: HC.Manager -> String -> RequestHeaders -> IO Bool
 probeEndpoint manager url headers = do
     result <- try @SomeException $ do
-        baseRequest <- parseRequest url
+        baseRequest <- HC.parseRequest url
         response <-
-            httpLbs
+            HC.httpLbs
                 baseRequest
-                    { method = methodGet
-                    , requestHeaders = headers
+                    { HC.method = methodGet
+                    , HC.requestHeaders = headers
                     }
                 manager
-        pure $ statusCode (responseStatus response) < 500
+        pure $ statusCode (HC.responseStatus response) < 500
     pure $ either (const False) id result
 
 antithesisRunsUrl :: Settings -> String
@@ -177,3 +217,49 @@ plain status body =
 stripTrailingSlash :: String -> String
 stripTrailingSlash =
     reverse . dropWhile (== '/') . reverse
+
+auditAndRespond
+    :: Request
+    -> UTCTime
+    -> Maybe Status
+    -> Response
+    -> (Response -> IO responseReceived)
+    -> IO responseReceived
+auditAndRespond request start upstreamStatus response respond = do
+    end <- getCurrentTime
+    LBS.putStr $
+        renderAuditEvent
+            AuditEvent
+                { auditTimestamp = end
+                , auditLogin =
+                    Vault.lookup authorizedLoginKey (vault request)
+                , auditPath =
+                    T.decodeUtf8With lenientDecode $ rawPathInfo request
+                , auditStatus = waiResponseStatus response
+                , auditUpstreamStatus = upstreamStatus
+                , auditLatencyMs =
+                    floor $ diffUTCTime end start * 1000
+                , auditRequestId = requestId request
+                }
+    hFlush stdout
+    respond response
+
+requestId :: Request -> RequestId
+requestId request =
+    RequestId $
+        T.decodeUtf8With lenientDecode $
+            fromMaybe "-" $
+                lookup "X-Request-Id" $
+                    requestHeaders request
+
+waiResponseStatus :: Response -> Status
+waiResponseStatus response =
+    case response of
+        ResponseFile status _ _ _ ->
+            status
+        ResponseBuilder status _ _ ->
+            status
+        ResponseStream status _ _ ->
+            status
+        ResponseRaw _ fallback ->
+            waiResponseStatus fallback

--- a/src/Proxy/Antithesis/Audit.hs
+++ b/src/Proxy/Antithesis/Audit.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | JSON audit-line rendering for proxy requests.
+module Proxy.Antithesis.Audit
+    ( AuditEvent (..)
+    , RequestId (..)
+    , renderAuditEvent
+    )
+where
+
+import Data.Aeson (encode, object, (.=))
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Time.Clock (UTCTime)
+import Data.Time.Format
+    ( defaultTimeLocale
+    , formatTime
+    )
+import Lib.GitHub.Auth.Identify (Login)
+import Network.HTTP.Types (Status, statusCode)
+
+newtype RequestId = RequestId Text
+    deriving stock (Eq, Show)
+
+data AuditEvent = AuditEvent
+    { auditTimestamp :: UTCTime
+    , auditLogin :: Maybe Login
+    , auditPath :: Text
+    , auditStatus :: Status
+    , auditUpstreamStatus :: Maybe Status
+    , auditLatencyMs :: Int
+    , auditRequestId :: RequestId
+    }
+    deriving stock (Eq, Show)
+
+renderAuditEvent :: AuditEvent -> LBS.ByteString
+renderAuditEvent event =
+    encode
+        ( object
+            [ "ts" .= renderTimestamp (auditTimestamp event)
+            , "login" .= auditLogin event
+            , "path" .= auditPath event
+            , "status" .= statusCode (auditStatus event)
+            , "upstream_status" .= fmap statusCode (auditUpstreamStatus event)
+            , "latency_ms" .= auditLatencyMs event
+            , "request_id" .= unRequestId (auditRequestId event)
+            ]
+        )
+        <> "\n"
+
+unRequestId :: RequestId -> Text
+unRequestId (RequestId requestId) = requestId
+
+renderTimestamp :: UTCTime -> Text
+renderTimestamp =
+    T.pack . formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ"

--- a/src/Proxy/Antithesis/Cache.hs
+++ b/src/Proxy/Antithesis/Cache.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Short-lived membership cache for GitHub token authorization.
+module Proxy.Antithesis.Cache
+    ( MembershipCache
+    , TokenPrefixHash
+    , cachedMembership
+    , newMembershipCache
+    , tokenPrefixHash
+    )
+where
+
+import Crypto.Hash (Digest, SHA256, hash)
+import Data.ByteString.Char8 qualified as BC
+import Data.IORef
+    ( IORef
+    , atomicModifyIORef'
+    , newIORef
+    , readIORef
+    )
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Time.Clock (NominalDiffTime, UTCTime, diffUTCTime)
+import Lib.GitHub.Auth.DeviceFlow (OAuthToken (..))
+import Lib.GitHub.Auth.TeamCheck (MembershipResult)
+
+data MembershipCache = MembershipCache
+    { cacheTtl :: NominalDiffTime
+    , cacheEntries :: IORef (Map TokenPrefixHash (UTCTime, MembershipResult))
+    }
+
+newtype TokenPrefixHash = TokenPrefixHash Text
+    deriving stock (Eq, Show)
+    deriving newtype (Ord)
+
+newMembershipCache :: NominalDiffTime -> IO MembershipCache
+newMembershipCache ttl =
+    MembershipCache ttl <$> newIORef Map.empty
+
+cachedMembership
+    :: MembershipCache
+    -> IO UTCTime
+    -> OAuthToken
+    -> IO MembershipResult
+    -> IO MembershipResult
+cachedMembership cache getNow token fetchMembership = do
+    now <- getNow
+    entries <- readIORef $ cacheEntries cache
+    case Map.lookup key entries of
+        Just (insertedAt, result)
+            | diffUTCTime now insertedAt <= cacheTtl cache ->
+                pure result
+        _ -> do
+            result <- fetchMembership
+            atomicModifyIORef'
+                (cacheEntries cache)
+                ( \oldEntries ->
+                    (Map.insert key (now, result) oldEntries, ())
+                )
+            pure result
+  where
+    key = tokenPrefixHash token
+
+tokenPrefixHash :: OAuthToken -> TokenPrefixHash
+tokenPrefixHash (OAuthToken token) =
+    TokenPrefixHash
+        $ T.pack
+        $ show (hash (BC.take 16 token) :: Digest SHA256)

--- a/src/Proxy/Antithesis/Config.hs
+++ b/src/Proxy/Antithesis/Config.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Runtime configuration for the Antithesis proxy daemon.
+module Proxy.Antithesis.Config
+    ( Settings (..)
+    , loadSettings
+    , loadSettingsWith
+    )
+where
+
+import Data.ByteString.Char8 qualified as BC
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Lib.GitHub.Auth.TeamCheck (Org (..), TeamSlug (..))
+import System.Environment (lookupEnv)
+import Text.Read (readMaybe)
+
+data Settings = Settings
+    { settingsBindAddr :: String
+    , settingsBindPort :: Int
+    , settingsAntithesisUrl :: String
+    , settingsAntithesisUser :: BC.ByteString
+    , settingsAntithesisPassword :: BC.ByteString
+    , settingsAuthorizedOrg :: Org
+    , settingsAuthorizedTeam :: TeamSlug
+    , settingsMembershipTtlSeconds :: Int
+    , settingsLogLevel :: Text
+    }
+    deriving stock (Eq, Show)
+
+loadSettings :: IO Settings
+loadSettings = loadSettingsWith lookupEnv BC.readFile
+
+loadSettingsWith
+    :: (String -> IO (Maybe String))
+    -> (FilePath -> IO BC.ByteString)
+    -> IO Settings
+loadSettingsWith lookupSetting readSecret = do
+    passwordFile <-
+        settingString
+            lookupSetting
+            "MOOG_ANTITHESIS_PASSWORD_FILE"
+            "/run/secrets/antithesis-password"
+    password <- stripTrailingNewline <$> readSecret passwordFile
+    Settings
+        <$> settingString lookupSetting "MOOG_PROXY_BIND_ADDR" "0.0.0.0"
+        <*> settingInt lookupSetting "MOOG_PROXY_BIND_PORT" 8080
+        <*> settingString
+            lookupSetting
+            "MOOG_ANTITHESIS_URL"
+            "https://amaru-cardano.antithesis.com"
+        <*> ( BC.pack
+                <$> settingString
+                    lookupSetting
+                    "MOOG_ANTITHESIS_USER"
+                    "pragma"
+            )
+        <*> pure password
+        <*> ( Org . T.pack
+                <$> settingString
+                    lookupSetting
+                    "MOOG_PROXY_AUTHORIZED_ORG"
+                    "pragma-org"
+            )
+        <*> ( TeamSlug . T.pack
+                <$> settingString
+                    lookupSetting
+                    "MOOG_PROXY_AUTHORIZED_TEAM"
+                    "antithesis-access"
+            )
+        <*> settingInt lookupSetting "MOOG_PROXY_MEMBERSHIP_TTL_SEC" 60
+        <*> ( T.pack
+                <$> settingString lookupSetting "MOOG_PROXY_LOG_LEVEL" "info"
+            )
+
+settingString
+    :: (String -> IO (Maybe String))
+    -> String
+    -> String
+    -> IO String
+settingString lookupSetting name defaultValue =
+    fromMaybe defaultValue <$> lookupSetting name
+
+settingInt
+    :: (String -> IO (Maybe String))
+    -> String
+    -> Int
+    -> IO Int
+settingInt lookupSetting name defaultValue = do
+    raw <- lookupSetting name
+    pure $ fromMaybe defaultValue $ raw >>= readMaybe
+
+stripTrailingNewline :: BC.ByteString -> BC.ByteString
+stripTrailingNewline =
+    BC.dropWhileEnd $ \c -> c == '\n' || c == '\r'

--- a/src/Proxy/Antithesis/Handler/Runs.hs
+++ b/src/Proxy/Antithesis/Handler/Runs.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Handler for proxying Antithesis run listings.
+module Proxy.Antithesis.Handler.Runs
+    ( RunsConfig (..)
+    , runsHandler
+    )
+where
+
+import Control.Monad (unless)
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Base64 qualified as Base64
+import Data.ByteString.Builder qualified as Builder
+import Data.ByteString.Char8 qualified as BC
+import Network.HTTP.Client
+    ( BodyReader
+    , Manager
+    , Request (method, requestHeaders)
+    , brRead
+    , parseRequest
+    , responseBody
+    , responseHeaders
+    , responseStatus
+    , withResponse
+    )
+import Network.HTTP.Types
+    ( Header
+    , hAuthorization
+    , hContentLength
+    , hContentType
+    , statusCode
+    )
+import Network.Wai
+    ( Application
+    , Request (rawQueryString)
+    , responseLBS
+    , responseStream
+    )
+
+data RunsConfig = RunsConfig
+    { runsAntithesisUrl :: String
+    , runsAntithesisUser :: ByteString
+    , runsAntithesisPassword :: ByteString
+    , runsManager :: Manager
+    }
+
+runsHandler :: RunsConfig -> Application
+runsHandler config request respond = do
+    upstreamRequest <- parseRequest $ runsUrl config (rawQueryString request)
+    withResponse
+        upstreamRequest
+            { method = "GET"
+            , requestHeaders =
+                [(hAuthorization, basicAuthorization config)]
+            }
+        (runsManager config)
+        $ \upstreamResponse ->
+            if statusCode (responseStatus upstreamResponse) >= 500
+                then
+                    respond
+                        $ responseLBS
+                            (responseStatus upstreamResponse)
+                            [(hContentType, "text/plain")]
+                            "upstream request failed"
+                else
+                    respond
+                        $ responseStream
+                            (responseStatus upstreamResponse)
+                            (forwardedHeaders $ responseHeaders upstreamResponse)
+                            (streamBody $ responseBody upstreamResponse)
+
+runsUrl :: RunsConfig -> ByteString -> String
+runsUrl config query =
+    stripTrailingSlash (runsAntithesisUrl config)
+        <> "/api/v1/runs"
+        <> BC.unpack query
+
+basicAuthorization :: RunsConfig -> ByteString
+basicAuthorization config =
+    "Basic "
+        <> Base64.encode
+            (runsAntithesisUser config <> ":" <> runsAntithesisPassword config)
+
+forwardedHeaders :: [Header] -> [Header]
+forwardedHeaders =
+    filter
+        ( \header ->
+            fst header == hContentType
+                || fst header == hContentLength
+        )
+
+stripTrailingSlash :: String -> String
+stripTrailingSlash =
+    reverse . dropWhile (== '/') . reverse
+
+streamBody :: BodyReader -> (Builder.Builder -> IO ()) -> IO () -> IO ()
+streamBody reader write flush = go
+  where
+    go = do
+        chunk <- brRead reader
+        unless (BS.null chunk) $ do
+            write $ Builder.byteString chunk
+            flush
+            go

--- a/src/Proxy/Antithesis/Middleware/Auth.hs
+++ b/src/Proxy/Antithesis/Middleware/Auth.hs
@@ -1,0 +1,141 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Bearer-token authorization middleware for the Antithesis proxy.
+module Proxy.Antithesis.Middleware.Auth
+    ( AuthConfig (..)
+    , authMiddleware
+    , authorizedLoginKey
+    )
+where
+
+import Data.ByteString (ByteString)
+import Data.ByteString.Char8 qualified as BC
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text (Text)
+import Data.Text.Encoding qualified as T
+import Data.Time.Clock (UTCTime)
+import Data.Vault.Lazy qualified as Vault
+import Lib.GitHub.Auth.DeviceFlow (OAuthToken (..))
+import Lib.GitHub.Auth.Identify
+    ( GitHubError (..)
+    , Login
+    )
+import Lib.GitHub.Auth.TeamCheck
+    ( MembershipResult (..)
+    , Org
+    , TeamSlug
+    )
+import Network.HTTP.Types
+    ( ResponseHeaders
+    , Status
+    , hAuthorization
+    , status401
+    , status403
+    , status502
+    )
+import Network.Wai
+    ( Middleware
+    , Request (requestHeaders, vault)
+    , Response
+    , responseLBS
+    )
+import Proxy.Antithesis.Cache
+    ( MembershipCache
+    , cachedMembership
+    )
+import System.IO.Unsafe (unsafePerformIO)
+
+data AuthConfig = AuthConfig
+    { authOrg :: Org
+    , authTeam :: TeamSlug
+    , authCache :: MembershipCache
+    , authNow :: IO UTCTime
+    , authWhoami :: OAuthToken -> IO (Either GitHubError Login)
+    , authCheckTeamMembership
+        :: OAuthToken -> Org -> TeamSlug -> Login -> IO MembershipResult
+    }
+
+authorizedLoginKey :: Vault.Key Login
+authorizedLoginKey = unsafePerformIO Vault.newKey
+{-# NOINLINE authorizedLoginKey #-}
+
+authMiddleware :: AuthConfig -> Middleware
+authMiddleware config app request respond =
+    case bearerToken request of
+        Nothing ->
+            respond unauthorizedBearer
+        Just token -> do
+            authWhoami config token >>= \case
+                Left GitHubError{status = 401} ->
+                    respond $ plain status401 [] "invalid token"
+                Left _ ->
+                    respond $ plain status502 [] "github identity check failed"
+                Right login -> do
+                    membership <-
+                        cachedMembership
+                            (authCache config)
+                            (authNow config)
+                            token
+                            ( authCheckTeamMembership
+                                config
+                                token
+                                (authOrg config)
+                                (authTeam config)
+                                login
+                            )
+                    case membership of
+                        Active ->
+                            app
+                                request
+                                    { vault =
+                                        Vault.insert
+                                            authorizedLoginKey
+                                            login
+                                            (vault request)
+                                    }
+                                respond
+                        Pending ->
+                            respond $ plain status403 [] "forbidden"
+                        NotMember ->
+                            respond $ plain status403 [] "forbidden"
+                        TokenInvalid ->
+                            respond $ plain status401 [] "invalid token"
+                        SSORequired{url} ->
+                            respond
+                                $ plain
+                                    status403
+                                    [("X-Moog-SSO-Url", textUtf8 url)]
+                                    "sso required"
+                        OtherError{} ->
+                            respond
+                                $ plain
+                                    status502
+                                    []
+                                    "github membership check failed"
+
+bearerToken :: Request -> Maybe OAuthToken
+bearerToken request =
+    case lookup hAuthorization $ requestHeaders request of
+        Just raw
+            | ["Bearer", token] <- BC.words raw
+            , not (BC.null token) ->
+                Just $ OAuthToken token
+        _ -> Nothing
+
+unauthorizedBearer :: Response
+unauthorizedBearer =
+    plain
+        status401
+        [("WWW-Authenticate", "Bearer realm=\"moog-antithesis-proxy\"")]
+        "missing bearer token"
+
+plain
+    :: Status
+    -> ResponseHeaders
+    -> LBS.ByteString
+    -> Response
+plain status headers body =
+    responseLBS status headers body
+
+textUtf8 :: Text -> ByteString
+textUtf8 = T.encodeUtf8

--- a/test/Proxy/Antithesis/ApplicationSpec.hs
+++ b/test/Proxy/Antithesis/ApplicationSpec.hs
@@ -1,0 +1,195 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Proxy.Antithesis.ApplicationSpec
+    ( spec
+    )
+where
+
+import Data.ByteString.Char8 qualified as BC
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.Text (Text)
+import Data.Text.Encoding qualified as T
+import Data.Time.Clock (UTCTime (..), secondsToDiffTime)
+import Lib.GitHub.Auth.DeviceFlow (OAuthToken)
+import Lib.GitHub.Auth.Identify (Login (..))
+import Lib.GitHub.Auth.TeamCheck
+    ( MembershipResult (..)
+    , Org (..)
+    , TeamSlug (..)
+    )
+import Network.HTTP.Client (defaultManagerSettings, newManager)
+import Network.HTTP.Types
+    ( RequestHeaders
+    , hAuthorization
+    , status200
+    , status401
+    , status404
+    , status503
+    )
+import Network.Wai
+    ( Application
+    , Request (pathInfo, rawPathInfo, rawQueryString, requestHeaders, requestMethod)
+    , responseLBS
+    )
+import Network.Wai.Handler.Warp (testWithApplication)
+import Network.Wai.Test
+    ( SResponse (..)
+    , defaultRequest
+    , request
+    , runSession
+    )
+import Proxy.Antithesis.Application
+    ( ProxyApplicationConfig (..)
+    , ReadinessConfig (..)
+    , proxyApplication
+    )
+import Proxy.Antithesis.Cache (newMembershipCache)
+import Proxy.Antithesis.Handler.Runs (RunsConfig (..))
+import Proxy.Antithesis.Middleware.Auth (AuthConfig (..))
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec :: Spec
+spec =
+    describe "Proxy.Antithesis.Application" $ do
+        it "serves health without auth" $ do
+            response <- runProxyApp True True (requestFor "/healthz" [])
+
+            simpleStatus response `shouldBe` status200
+            simpleBody response `shouldBe` "ok"
+
+        it "serves readiness only when Antithesis and GitHub are reachable" $ do
+            ready <- runProxyApp True True (requestFor "/readyz" [])
+            notReady <- runProxyApp True False (requestFor "/readyz" [])
+
+            simpleStatus ready `shouldBe` status200
+            simpleBody ready `shouldBe` "ready"
+            simpleStatus notReady `shouldBe` status503
+            simpleBody notReady `shouldBe` "not ready"
+
+        it "returns 404 for unknown routes" $ do
+            response <- runProxyApp True True (requestFor "/missing" [])
+
+            simpleStatus response `shouldBe` status404
+            simpleBody response `shouldBe` "not found"
+
+        it "protects and routes GET /api/v1/runs" $ do
+            seenRef <- newIORef Nothing
+            response <-
+                withUpstream (captureRuns seenRef) $ \baseUrl ->
+                    runProxyAppWithUpstream
+                        baseUrl
+                        ( requestFor
+                            "/api/v1/runs"
+                            [(hAuthorization, "Bearer gh-token")]
+                        )
+                            { rawQueryString = "?limit=2"
+                            }
+
+            simpleStatus response `shouldBe` status200
+            simpleBody response `shouldBe` "runs-body"
+            seen <- readIORef seenRef
+            seen
+                `shouldBe` Just
+                    ( "?limit=2"
+                    , Just "Basic cHJhZ21hOnNlY3JldA=="
+                    )
+
+        it "applies auth to GET /api/v1/runs" $ do
+            response <- runProxyApp True True (requestFor "/api/v1/runs" [])
+
+            simpleStatus response `shouldBe` status401
+
+runProxyApp :: Bool -> Bool -> Network.Wai.Request -> IO SResponse
+runProxyApp antithesisReady githubReady request' =
+    withUpstream (\_ respond -> respond $ responseLBS status200 [] "[]") $ \baseUrl ->
+        runProxyAppWithReadiness baseUrl antithesisReady githubReady request'
+
+runProxyAppWithUpstream :: String -> Network.Wai.Request -> IO SResponse
+runProxyAppWithUpstream baseUrl =
+    runProxyAppWithReadiness baseUrl True True
+
+runProxyAppWithReadiness
+    :: String
+    -> Bool
+    -> Bool
+    -> Network.Wai.Request
+    -> IO SResponse
+runProxyAppWithReadiness baseUrl antithesisReady githubReady request' = do
+    application <- testApplication baseUrl antithesisReady githubReady
+    runSession (request request') application
+
+testApplication :: String -> Bool -> Bool -> IO Application
+testApplication baseUrl antithesisReady githubReady = do
+    manager <- newManager defaultManagerSettings
+    cache <- newMembershipCache 60
+    pure $
+        proxyApplication
+            ProxyApplicationConfig
+                { proxyAuthConfig =
+                    AuthConfig
+                        { authOrg = Org "pragma-org"
+                        , authTeam = TeamSlug "antithesis-access"
+                        , authCache = cache
+                        , authNow = pure baseTime
+                        , authWhoami = const $ pure $ Right $ Login "octocat"
+                        , authCheckTeamMembership = activeMembership
+                        }
+                , proxyRunsConfig =
+                    RunsConfig
+                        { runsAntithesisUrl = baseUrl
+                        , runsAntithesisUser = "pragma"
+                        , runsAntithesisPassword = "secret"
+                        , runsManager = manager
+                        }
+                , proxyReadinessConfig =
+                    ReadinessConfig
+                        { readinessAntithesis = pure antithesisReady
+                        , readinessGitHub = pure githubReady
+                        }
+                }
+
+requestFor :: BC.ByteString -> RequestHeaders -> Network.Wai.Request
+requestFor path headers =
+    defaultRequest
+        { requestMethod = "GET"
+        , rawPathInfo = path
+        , pathInfo = splitPath path
+        , requestHeaders = headers
+        }
+
+splitPath :: BC.ByteString -> [Text]
+splitPath =
+    fmap decodeSegment . filter (not . BC.null) . BC.split '/'
+
+decodeSegment :: BC.ByteString -> Text
+decodeSegment =
+    T.decodeUtf8
+
+activeMembership
+    :: OAuthToken
+    -> Org
+    -> TeamSlug
+    -> Login
+    -> IO MembershipResult
+activeMembership _ _ _ _ =
+    pure Active
+
+withUpstream :: Application -> (String -> IO a) -> IO a
+withUpstream upstream action =
+    testWithApplication (pure upstream) $ \port ->
+        action $ "http://127.0.0.1:" <> show port
+
+captureRuns
+    :: IORef (Maybe (BC.ByteString, Maybe BC.ByteString))
+    -> Application
+captureRuns seenRef request' respond = do
+    writeIORef
+        seenRef
+        $ Just
+            ( rawQueryString request'
+            , lookup hAuthorization $ requestHeaders request'
+            )
+    respond $ responseLBS status200 [] "runs-body"
+
+baseTime :: UTCTime
+baseTime = UTCTime (toEnum 0) (secondsToDiffTime 0)

--- a/test/Proxy/Antithesis/AuditSpec.hs
+++ b/test/Proxy/Antithesis/AuditSpec.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Proxy.Antithesis.AuditSpec
+    ( spec
+    )
+where
+
+import Data.Aeson
+    ( FromJSON (parseJSON)
+    , Value (..)
+    , eitherDecode
+    , withObject
+    , (.:)
+    )
+import Data.ByteString.Lazy.Char8 qualified as LBC
+import Data.List qualified as List
+import Data.Text (Text)
+import Data.Time.Clock (UTCTime (..), secondsToDiffTime)
+import Lib.GitHub.Auth.Identify (Login (..))
+import Network.HTTP.Types (status200)
+import Proxy.Antithesis.Audit
+    ( AuditEvent (..)
+    , RequestId (..)
+    , renderAuditEvent
+    )
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+
+spec :: Spec
+spec =
+    describe "Proxy.Antithesis.Audit" $
+        it "renders a sanitized JSON line with correlation fields" $ do
+            let rendered =
+                    renderAuditEvent
+                        AuditEvent
+                            { auditTimestamp = baseTime
+                            , auditLogin = Just (Login "octocat")
+                            , auditPath = "/api/v1/runs"
+                            , auditStatus = status200
+                            , auditUpstreamStatus = Just status200
+                            , auditLatencyMs = 12
+                            , auditRequestId = RequestId "req-123"
+                            }
+
+            rendered `shouldSatisfy` LBC.isSuffixOf "\n"
+            decoded rendered
+                `shouldBe` Right
+                    ( "octocat"
+                    , "/api/v1/runs"
+                    , 200
+                    , Just 200
+                    , 12
+                    , "req-123"
+                    )
+            rendered `shouldSatisfy` not . contains "secret-token"
+            rendered `shouldSatisfy` not . contains "upstream-body"
+
+baseTime :: UTCTime
+baseTime = UTCTime (toEnum 0) (secondsToDiffTime 0)
+
+newtype AuditTuple = AuditTuple
+    (Text, Text, Int, Maybe Int, Int, Text)
+    deriving stock (Eq, Show)
+
+instance FromJSON AuditTuple where
+    parseJSON =
+        withObject "AuditTuple" $ \o ->
+            AuditTuple
+                <$> ( (,,,,,)
+                        <$> o .: "login"
+                        <*> o .: "path"
+                        <*> o .: "status"
+                        <*> o .: "upstream_status"
+                        <*> o .: "latency_ms"
+                        <*> o .: "request_id"
+                    )
+
+decoded :: LBC.ByteString -> Either String (Text, Text, Int, Maybe Int, Int, Text)
+decoded raw = do
+    AuditTuple tuple <- eitherDecode raw
+    pure tuple
+
+contains :: LBC.ByteString -> LBC.ByteString -> Bool
+contains needle haystack =
+    LBC.unpack needle `List.isInfixOf` LBC.unpack haystack

--- a/test/Proxy/Antithesis/AuditSpec.hs
+++ b/test/Proxy/Antithesis/AuditSpec.hs
@@ -7,7 +7,6 @@ where
 
 import Data.Aeson
     ( FromJSON (parseJSON)
-    , Value (..)
     , eitherDecode
     , withObject
     , (.:)

--- a/test/Proxy/Antithesis/AuthSpec.hs
+++ b/test/Proxy/Antithesis/AuthSpec.hs
@@ -1,0 +1,194 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Proxy.Antithesis.AuthSpec
+    ( spec
+    )
+where
+
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as LBS
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.Text (Text)
+import Data.Text.Encoding qualified as T
+import Data.Time.Clock (UTCTime (..), secondsToDiffTime)
+import Data.Vault.Lazy qualified as Vault
+import Lib.GitHub.Auth.DeviceFlow (OAuthToken (..))
+import Lib.GitHub.Auth.Identify (GitHubError (..), Login (..))
+import Lib.GitHub.Auth.TeamCheck
+    ( MembershipResult (..)
+    , Org (..)
+    , TeamSlug (..)
+    )
+import Network.HTTP.Types
+    ( hAuthorization
+    , HeaderName
+    , status200
+    , status401
+    , status403
+    , status502
+    )
+import Network.Wai
+    ( Application
+    , Middleware
+    , Request (requestHeaders)
+    , responseLBS
+    , vault
+    )
+import Network.Wai.Test
+    ( SResponse (..)
+    , defaultRequest
+    , request
+    , runSession
+    )
+import Proxy.Antithesis.Cache (newMembershipCache)
+import Proxy.Antithesis.Middleware.Auth
+    ( AuthConfig (..)
+    , authMiddleware
+    , authorizedLoginKey
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+
+spec :: Spec
+spec =
+    describe "Proxy.Antithesis.Middleware.Auth" $ do
+        it "rejects a missing bearer token with a challenge" $ do
+            response <- exercise Active []
+            simpleStatus response `shouldBe` status401
+            lookup "WWW-Authenticate" (simpleHeaders response)
+                `shouldBe` Just "Bearer realm=\"moog-antithesis-proxy\""
+
+        it "rejects a malformed bearer token with a challenge" $ do
+            response <- exercise Active [(hAuthorization, "Basic abc")]
+            simpleStatus response `shouldBe` status401
+            lookup "WWW-Authenticate" (simpleHeaders response)
+                `shouldBe` Just "Bearer realm=\"moog-antithesis-proxy\""
+
+        it "maps whoami 401 to 401" $ do
+            response <-
+                exerciseWith
+                    (Left $ GitHubError 401 "bad credentials")
+                    Active
+                    bearer
+            simpleStatus response `shouldBe` status401
+
+        it "maps membership TokenInvalid to 401" $ do
+            response <- exercise TokenInvalid bearer
+            simpleStatus response `shouldBe` status401
+
+        it "maps Pending to 403" $ do
+            response <- exercise Pending bearer
+            simpleStatus response `shouldBe` status403
+
+        it "maps NotMember to 403" $ do
+            response <- exercise NotMember bearer
+            simpleStatus response `shouldBe` status403
+
+        it "maps SSORequired to 403 with the SSO URL header" $ do
+            response <- exercise (SSORequired ssoUrl) bearer
+            simpleStatus response `shouldBe` status403
+            lookup "X-Moog-SSO-Url" (simpleHeaders response)
+                `shouldBe` Just (T.encodeUtf8 ssoUrl)
+
+        it "maps OtherError to a sanitized 502" $ do
+            response <- exercise (OtherError 500 "upstream secret") bearer
+            simpleStatus response `shouldBe` status502
+            simpleBody response `shouldBe` "github membership check failed"
+
+        it "attaches the authorized login to the request vault" $ do
+            response <- exercise Active bearer
+            simpleStatus response `shouldBe` status200
+            simpleBody response `shouldBe` "octocat"
+
+        it "reuses a cached membership result for the same token prefix" $ do
+            callsRef <- newIORef (0 :: Int)
+            middleware <- mkMiddleware RightOctocat Active callsRef
+            first <- runAuth middleware bearer
+            second <- runAuth middleware bearer
+            calls <- readIORef callsRef
+
+            simpleStatus first `shouldBe` status200
+            simpleStatus second `shouldBe` status200
+            calls `shouldBe` 1
+
+bearer :: [(HeaderName, ByteString)]
+bearer = [(hAuthorization, "Bearer test-token")]
+
+ssoUrl :: Text
+ssoUrl = "https://github.com/orgs/pragma-org/sso"
+
+data WhoamiResult = RightOctocat | WhoamiFailure GitHubError
+
+exercise :: MembershipResult -> [(HeaderName, ByteString)] -> IO SResponse
+exercise = exerciseWith (Right $ Login "octocat")
+
+exerciseWith
+    :: Either GitHubError Login
+    -> MembershipResult
+    -> [(HeaderName, ByteString)]
+    -> IO SResponse
+exerciseWith whoamiResult membership headers = do
+    callsRef <- newIORef (0 :: Int)
+    middleware <-
+        mkMiddleware
+            (either WhoamiFailure (const RightOctocat) whoamiResult)
+            membership
+            callsRef
+    runAuthWithWhoami middleware whoamiResult headers
+
+mkMiddleware
+    :: WhoamiResult
+    -> MembershipResult
+    -> IORef Int
+    -> IO Middleware
+mkMiddleware whoamiResult membership callsRef = do
+    cache <- newMembershipCache 60
+    pure $
+        authMiddleware
+            AuthConfig
+                { authOrg = Org "pragma-org"
+                , authTeam = TeamSlug "antithesis-access"
+                , authCache = cache
+                , authNow = pure baseTime
+                , authWhoami = const $ pure $ case whoamiResult of
+                    RightOctocat -> Right $ Login "octocat"
+                    WhoamiFailure err -> Left err
+                , authCheckTeamMembership = \_ _ _ _ -> do
+                    calls <- readIORef callsRef
+                    writeIORef callsRef $ calls + 1
+                    pure membership
+                }
+
+runAuth :: Middleware -> [(HeaderName, ByteString)] -> IO SResponse
+runAuth middleware = runAuthWithWhoami middleware (Right $ Login "octocat")
+
+runAuthWithWhoami
+    :: Middleware
+    -> Either GitHubError Login
+    -> [(HeaderName, ByteString)]
+    -> IO SResponse
+runAuthWithWhoami middleware _whoamiResult headers =
+    runSession
+        ( request
+            defaultRequest{requestHeaders = headers}
+        )
+        (middleware protectedApp)
+
+protectedApp :: Application
+protectedApp request' respond =
+    case Vault.lookup authorizedLoginKey (vault request') of
+        Just (Login login) ->
+            respond
+                $ responseLBS
+                    status200
+                    []
+                    (LBS.fromStrict $ T.encodeUtf8 login)
+        Nothing ->
+            respond $ responseLBS status502 [] "missing login"
+
+baseTime :: UTCTime
+baseTime = UTCTime (toEnum 0) (secondsToDiffTime 0)

--- a/test/Proxy/Antithesis/CacheSpec.hs
+++ b/test/Proxy/Antithesis/CacheSpec.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Proxy.Antithesis.CacheSpec
+    ( spec
+    )
+where
+
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.Time.Clock
+    ( NominalDiffTime
+    , UTCTime (..)
+    , addUTCTime
+    , secondsToDiffTime
+    )
+import Lib.GitHub.Auth.DeviceFlow (OAuthToken (..))
+import Lib.GitHub.Auth.TeamCheck (MembershipResult (..))
+import Proxy.Antithesis.Cache
+    ( cachedMembership
+    , newMembershipCache
+    , tokenPrefixHash
+    )
+import Test.Hspec (Spec, describe, it, shouldBe, shouldNotBe)
+
+spec :: Spec
+spec =
+    describe "Proxy.Antithesis.Cache" $ do
+        it "caches membership results inside the configured TTL" $ do
+            nowRef <- newIORef baseTime
+            callsRef <- newIORef (0 :: Int)
+            cache <- newMembershipCache (60 :: NominalDiffTime)
+
+            first <-
+                cachedMembership
+                    cache
+                    (readIORef nowRef)
+                    token
+                    (fetch callsRef Active)
+            writeIORef nowRef $ addUTCTime 30 baseTime
+            second <-
+                cachedMembership
+                    cache
+                    (readIORef nowRef)
+                    token
+                    (fetch callsRef NotMember)
+
+            calls <- readIORef callsRef
+            first `shouldBe` Active
+            second `shouldBe` Active
+            calls `shouldBe` 1
+
+        it "expires membership results after the configured TTL" $ do
+            nowRef <- newIORef baseTime
+            callsRef <- newIORef (0 :: Int)
+            cache <- newMembershipCache (60 :: NominalDiffTime)
+
+            first <-
+                cachedMembership
+                    cache
+                    (readIORef nowRef)
+                    token
+                    (fetch callsRef Active)
+            writeIORef nowRef $ addUTCTime 61 baseTime
+            second <-
+                cachedMembership
+                    cache
+                    (readIORef nowRef)
+                    token
+                    (fetch callsRef NotMember)
+
+            calls <- readIORef callsRef
+            first `shouldBe` Active
+            second `shouldBe` NotMember
+            calls `shouldBe` 2
+
+        it "hashes only the first sixteen token bytes" $ do
+            tokenPrefixHash (OAuthToken "abcdefghijklmnopAAAA")
+                `shouldBe` tokenPrefixHash (OAuthToken "abcdefghijklmnopBBBB")
+            tokenPrefixHash (OAuthToken "abcdefghijklmnopAAAA")
+                `shouldNotBe` tokenPrefixHash (OAuthToken "abcdefghijklmnoXAAAA")
+
+token :: OAuthToken
+token = OAuthToken "abcdefghijklmnop-rest"
+
+baseTime :: UTCTime
+baseTime = UTCTime (toEnum 0) (secondsToDiffTime 0)
+
+fetch :: IORef Int -> MembershipResult -> IO MembershipResult
+fetch callsRef result = do
+    calls <- readIORef callsRef
+    writeIORef callsRef $ calls + 1
+    pure result

--- a/test/Proxy/Antithesis/ConfigSpec.hs
+++ b/test/Proxy/Antithesis/ConfigSpec.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Proxy.Antithesis.ConfigSpec
+    ( spec
+    )
+where
+
+import Data.ByteString.Char8 qualified as BC
+import Lib.GitHub.Auth.TeamCheck (Org (..), TeamSlug (..))
+import Proxy.Antithesis.Config
+    ( Settings (..)
+    , loadSettingsWith
+    )
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec :: Spec
+spec =
+    describe "Proxy.Antithesis.Config" $ do
+        it "loads documented defaults and reads the password file" $ do
+            settings <-
+                loadSettingsWith
+                    (lookupEnvFrom [])
+                    (readFileFrom [("/run/secrets/antithesis-password", "secret\n")])
+
+            settingsBindAddr settings `shouldBe` "0.0.0.0"
+            settingsBindPort settings `shouldBe` 8080
+            settingsAntithesisUrl settings
+                `shouldBe` "https://amaru-cardano.antithesis.com"
+            settingsAntithesisUser settings `shouldBe` "pragma"
+            settingsAntithesisPassword settings `shouldBe` "secret"
+            settingsAuthorizedOrg settings `shouldBe` Org "pragma-org"
+            settingsAuthorizedTeam settings `shouldBe` TeamSlug "antithesis-access"
+            settingsMembershipTtlSeconds settings `shouldBe` 60
+            settingsLogLevel settings `shouldBe` "info"
+
+        it "honours environment overrides" $ do
+            settings <-
+                loadSettingsWith
+                    ( lookupEnvFrom
+                        [ ("MOOG_PROXY_BIND_ADDR", "127.0.0.1")
+                        , ("MOOG_PROXY_BIND_PORT", "19090")
+                        , ("MOOG_ANTITHESIS_URL", "http://upstream")
+                        , ("MOOG_ANTITHESIS_USER", "tenant-user")
+                        , ("MOOG_ANTITHESIS_PASSWORD_FILE", "/tmp/pw")
+                        , ("MOOG_PROXY_AUTHORIZED_ORG", "my-org")
+                        , ("MOOG_PROXY_AUTHORIZED_TEAM", "my-team")
+                        , ("MOOG_PROXY_MEMBERSHIP_TTL_SEC", "5")
+                        , ("MOOG_PROXY_LOG_LEVEL", "debug")
+                        ]
+                    )
+                    (readFileFrom [("/tmp/pw", "top-secret\n")])
+
+            settingsBindAddr settings `shouldBe` "127.0.0.1"
+            settingsBindPort settings `shouldBe` 19090
+            settingsAntithesisUrl settings `shouldBe` "http://upstream"
+            settingsAntithesisUser settings `shouldBe` "tenant-user"
+            settingsAntithesisPassword settings `shouldBe` "top-secret"
+            settingsAuthorizedOrg settings `shouldBe` Org "my-org"
+            settingsAuthorizedTeam settings `shouldBe` TeamSlug "my-team"
+            settingsMembershipTtlSeconds settings `shouldBe` 5
+            settingsLogLevel settings `shouldBe` "debug"
+
+lookupEnvFrom :: [(String, String)] -> String -> IO (Maybe String)
+lookupEnvFrom env name = pure $ lookup name env
+
+readFileFrom :: [(FilePath, BC.ByteString)] -> FilePath -> IO BC.ByteString
+readFileFrom files path =
+    case lookup path files of
+        Just contents -> pure contents
+        Nothing -> fail $ "unexpected password file: " <> path

--- a/test/Proxy/Antithesis/Handler/RunsSpec.hs
+++ b/test/Proxy/Antithesis/Handler/RunsSpec.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Proxy.Antithesis.Handler.RunsSpec
+    ( spec
+    )
+where
+
+import Data.ByteString.Char8 qualified as BC
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Network.HTTP.Client (defaultManagerSettings, newManager)
+import Network.HTTP.Types
+    ( hAuthorization
+    , hContentLength
+    , hContentType
+    , Status
+    , status200
+    , status503
+    )
+import Network.Wai
+    ( Application
+    , Request (rawQueryString, requestHeaders)
+    , responseLBS
+    )
+import Network.Wai.Handler.Warp (testWithApplication)
+import Network.Wai.Test
+    ( SResponse (..)
+    , defaultRequest
+    , request
+    , runSession
+    )
+import Proxy.Antithesis.Handler.Runs
+    ( RunsConfig (..)
+    , runsHandler
+    )
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec :: Spec
+spec =
+    describe "Proxy.Antithesis.Handler.Runs" $ do
+        it "forwards GET /api/v1/runs with query and basic auth" $ do
+            seenRef <- newIORef Nothing
+            response <-
+                withUpstream
+                    (captureRuns seenRef status200)
+                    $ \baseUrl -> runProxy baseUrl
+
+            simpleStatus response `shouldBe` status200
+            simpleBody response `shouldBe` "runs-body"
+            lookup hContentType (simpleHeaders response)
+                `shouldBe` Just "application/json"
+            lookup hContentLength (simpleHeaders response)
+                `shouldBe` Just "9"
+            seen <- readIORef seenRef
+            seen
+                `shouldBe` Just
+                    ( "?limit=5&cursor=a%2Fb"
+                    , Just "Basic cHJhZ21hOnNlY3JldA=="
+                    )
+
+        it "sanitizes upstream 5xx bodies" $ do
+            response <-
+                withUpstream
+                    (\_ respond -> respond $ responseLBS status503 [] "secret upstream body")
+                    $ \baseUrl -> runProxy baseUrl
+
+            simpleStatus response `shouldBe` status503
+            simpleBody response `shouldBe` "upstream request failed"
+
+runProxy :: String -> IO SResponse
+runProxy baseUrl = do
+    manager <- newManager defaultManagerSettings
+    runSession
+        ( request
+            defaultRequest
+                { rawQueryString = "?limit=5&cursor=a%2Fb"
+                }
+        )
+        $ runsHandler
+            RunsConfig
+                { runsAntithesisUrl = baseUrl
+                , runsAntithesisUser = "pragma"
+                , runsAntithesisPassword = "secret"
+                , runsManager = manager
+                }
+
+withUpstream :: Application -> (String -> IO a) -> IO a
+withUpstream upstream action =
+    testWithApplication (pure upstream) $ \port ->
+        action $ "http://127.0.0.1:" <> show port
+
+captureRuns
+    :: IORef (Maybe (BC.ByteString, Maybe BC.ByteString))
+    -> Status
+    -> Application
+captureRuns seenRef status request' respond = do
+    writeIORef
+        seenRef
+        $ Just
+            ( rawQueryString request'
+            , lookup hAuthorization $ requestHeaders request'
+            )
+    respond $
+        responseLBS
+            status
+            [(hContentType, "application/json"), (hContentLength, "9")]
+            "runs-body"


### PR DESCRIPTION
Closes #113.

## Summary
- add `moog-antithesis-proxy` WAI/Warp daemon with env-driven configuration, `/healthz`, `/readyz`, and 404 routing
- protect `GET /api/v1/runs` with GitHub bearer-token identity, team membership checks, and short-lived membership caching
- stream Antithesis runs through server-held basic auth, preserve safe upstream headers, sanitize upstream 5xx bodies, and emit flushed JSON audit lines

## Verification
- `./gate.sh` (205 examples, 0 failures)
- `nix build .#moog-antithesis-proxy`
- local `moog-antithesis-proxy` `/healthz` smoke with a temporary secret file returned `ok` and emitted an audit line
