### PR TITLE
feat(cli): add antithesis runs command

### DIFF
--- a/moog.cabal
+++ b/moog.cabal
@@ -171,6 +171,8 @@ library
     User.Agent.PushTest
     User.Agent.Types
     User.Antithesis.Cli
+    User.Antithesis.Constants
+    User.Antithesis.Login
     User.Requester.Cli
     User.Requester.Options
     User.Types
@@ -212,6 +214,7 @@ library
     , crypton-box
     , directory
     , exceptions
+    , filepath
     , github
     , haskeline
     , HaskellNet
@@ -240,6 +243,7 @@ library
     , text
     , time
     , transformers
+    , unix
     , vector
     , vault
     , wai
@@ -509,6 +513,7 @@ test-suite unit-tests
     User.Agent.PushTestSpec
     User.Agent.TypesSpec
     User.Antithesis.CliSpec
+    User.Antithesis.LoginSpec
     User.Requester.CliSpec
     User.TypesSpec
     Wallet.CliSpec
@@ -589,6 +594,7 @@ test-suite unit-tests
     , text
     , time
     , transformers
+    , unix
     , vector
     , vault
     , wai

--- a/moog.cabal
+++ b/moog.cabal
@@ -173,6 +173,7 @@ library
     User.Antithesis.Cli
     User.Antithesis.Constants
     User.Antithesis.Login
+    User.Antithesis.ProxyClient
     User.Requester.Cli
     User.Requester.Options
     User.Types
@@ -514,6 +515,7 @@ test-suite unit-tests
     User.Agent.TypesSpec
     User.Antithesis.CliSpec
     User.Antithesis.LoginSpec
+    User.Antithesis.ProxyClientSpec
     User.Requester.CliSpec
     User.TypesSpec
     Wallet.CliSpec

--- a/moog.cabal
+++ b/moog.cabal
@@ -170,6 +170,7 @@ library
     User.Agent.PublishResults.Email
     User.Agent.PushTest
     User.Agent.Types
+    User.Antithesis.Cli
     User.Requester.Cli
     User.Requester.Options
     User.Types
@@ -507,6 +508,7 @@ test-suite unit-tests
     User.Agent.PublishResults.EmailSpec
     User.Agent.PushTestSpec
     User.Agent.TypesSpec
+    User.Antithesis.CliSpec
     User.Requester.CliSpec
     User.TypesSpec
     Wallet.CliSpec

--- a/specs/114-antithesis-cli/plan.md
+++ b/specs/114-antithesis-cli/plan.md
@@ -1,0 +1,42 @@
+# Implementation Plan: Antithesis Runs CLI
+
+## Modules
+
+- `src/User/Antithesis/Constants.hs` embeds the public OAuth client id and
+  scope constants.
+- `src/User/Antithesis/Login.hs` owns the GitHub OAuth cache file and the
+  `ensureToken` boundary.
+- `src/User/Antithesis/ProxyClient.hs` owns the HTTP call to the proxy,
+  response classification, JSON decoding, and one-time reauth retry.
+- `src/User/Antithesis/Cli.hs` owns the optparse command group and command
+  execution.
+- `src/Cli.hs` and `src/Options.hs` wire the new command into the existing
+  executable.
+
+## Slices
+
+### Slice 1: Parser and command wiring
+
+Add the Antithesis command type, parser, and top-level `Cli.Command`
+constructor. Prove with a parser unit test that `antithesis runs` resolves to
+the new command. This slice may include a stub runtime that exits only after
+later slices fill the behavior.
+
+### Slice 2: Login token cache
+
+Implement constants plus token cache read/write/delete helpers and
+`ensureToken`. Prove cache miss writes the token, cache hit avoids the device
+flow callback, and the token file mode is `0600`.
+
+### Slice 3: Proxy client and runtime command
+
+Implement proxy URL resolution, `GET /api/v1/runs`, JSON decoding, error
+classification, 401 cache invalidation and one retry, command-level stderr and
+exit codes, and `ExitCode` passthrough in `App`. Prove the 401 evict/retry path
+with a local WAI proxy test.
+
+## Verification
+
+Each slice runs its focused RED test to failure first, then GREEN, then
+`./gate.sh`. Final verification repeats `./gate.sh` at branch head and records
+manual smoke status.

--- a/specs/114-antithesis-cli/spec.md
+++ b/specs/114-antithesis-cli/spec.md
@@ -1,0 +1,42 @@
+# Feature Specification: Antithesis Runs CLI
+
+## Primary User Story
+
+As a Moog operator, I can run `moog antithesis runs` to authenticate with
+GitHub through device flow, call the Moog Antithesis proxy, and receive the
+proxied Antithesis runs JSON on stdout.
+
+## Functional Requirements
+
+- Add a top-level `antithesis` command group to the `moog` binary.
+- Support the v1 subcommand `moog antithesis runs` with no flags.
+- On first use, read no cached token, start GitHub device-flow auth with the
+  public Moog OAuth client id and `read:org` scope, print the verification URL
+  and user code to stderr, cache the OAuth token, and continue.
+- On later uses, read `~/.config/moog/github-oauth.json` and reuse the cached
+  token.
+- Create the token cache file with mode `0600`.
+- Call `GET $MOOG_ANTITHESIS_PROXY_URL/api/v1/runs`, defaulting the proxy URL
+  to `https://antithesis-proxy.plutimus.com`.
+- Print the JSON response to stdout and exit 0 on success.
+- On proxy 401, delete the cached token, perform device-flow auth once more,
+  and retry once.
+- On 403, print the proxy body, include the SSO URL when present, and exit 2.
+- On proxy 5xx or network failure, print a clear stderr message and exit 3.
+- On HTTP 200 with non-JSON body, print a clear stderr message and exit 4.
+- Document the exit codes in `moog antithesis runs --help`.
+
+## Out Of Scope
+
+- `moog antithesis run <id>` and run-create commands.
+- Paging and filtering flags.
+- A standalone `moog auth login` or logout command.
+
+## Acceptance Criteria
+
+- Unit tests cover token cache write, cache read, file mode `0600`, and
+  cache eviction plus one retry after a 401 response.
+- The parser recognizes `moog antithesis runs`.
+- The runtime command maps proxy outcomes to the requested exit codes.
+- Manual smoke is documented for an operator-run call against the deployed or
+  local staging proxy.

--- a/specs/114-antithesis-cli/tasks.md
+++ b/specs/114-antithesis-cli/tasks.md
@@ -2,12 +2,12 @@
 
 ## Slice 1: Parser and command wiring
 
-- [ ] T114-S1 Add `User.Antithesis.Cli` command type and parser for
+- [X] T114-S1 Add `User.Antithesis.Cli` command type and parser for
   `antithesis runs`.
-- [ ] T114-S1 Wire the command group into `Options.commandParser` and
+- [X] T114-S1 Wire the command group into `Options.commandParser` and
   `Cli.Command`.
-- [ ] T114-S1 Add a parser unit test that observes the new command.
-- [ ] T114-S1 Run the focused RED/GREEN test and `./gate.sh`.
+- [X] T114-S1 Add a parser unit test that observes the new command.
+- [X] T114-S1 Run the focused RED/GREEN test and `./gate.sh`.
 
 ## Slice 2: Login token cache
 

--- a/specs/114-antithesis-cli/tasks.md
+++ b/specs/114-antithesis-cli/tasks.md
@@ -19,10 +19,10 @@
 
 ## Slice 3: Proxy client and runtime command
 
-- [ ] T114-S3 Implement proxy URL resolution, runs HTTP request, JSON decode,
+- [X] T114-S3 Implement proxy URL resolution, runs HTTP request, JSON decode,
   and error classification.
-- [ ] T114-S3 Implement 401 cache eviction and one reauth retry.
-- [ ] T114-S3 Map runtime outcomes to stdout/stderr and exit codes 0/2/3/4.
-- [ ] T114-S3 Add unit coverage for cache eviction on 401 and retry.
-- [ ] T114-S3 Run focused RED/GREEN tests, `./gate.sh`, and record smoke
+- [X] T114-S3 Implement 401 cache eviction and one reauth retry.
+- [X] T114-S3 Map runtime outcomes to stdout/stderr and exit codes 0/2/3/4.
+- [X] T114-S3 Add unit coverage for cache eviction on 401 and retry.
+- [X] T114-S3 Run focused RED/GREEN tests, `./gate.sh`, and record smoke
   status.

--- a/specs/114-antithesis-cli/tasks.md
+++ b/specs/114-antithesis-cli/tasks.md
@@ -11,11 +11,11 @@
 
 ## Slice 2: Login token cache
 
-- [ ] T114-S2 Add OAuth constants and token cache helpers.
-- [ ] T114-S2 Implement `ensureToken` with device-flow fallback and stderr
+- [X] T114-S2 Add OAuth constants and token cache helpers.
+- [X] T114-S2 Implement `ensureToken` with device-flow fallback and stderr
   prompt callback.
-- [ ] T114-S2 Add unit tests for cache write, cache read, and mode `0600`.
-- [ ] T114-S2 Run the focused RED/GREEN test and `./gate.sh`.
+- [X] T114-S2 Add unit tests for cache write, cache read, and mode `0600`.
+- [X] T114-S2 Run the focused RED/GREEN test and `./gate.sh`.
 
 ## Slice 3: Proxy client and runtime command
 

--- a/specs/114-antithesis-cli/tasks.md
+++ b/specs/114-antithesis-cli/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: Antithesis Runs CLI
+
+## Slice 1: Parser and command wiring
+
+- [ ] T114-S1 Add `User.Antithesis.Cli` command type and parser for
+  `antithesis runs`.
+- [ ] T114-S1 Wire the command group into `Options.commandParser` and
+  `Cli.Command`.
+- [ ] T114-S1 Add a parser unit test that observes the new command.
+- [ ] T114-S1 Run the focused RED/GREEN test and `./gate.sh`.
+
+## Slice 2: Login token cache
+
+- [ ] T114-S2 Add OAuth constants and token cache helpers.
+- [ ] T114-S2 Implement `ensureToken` with device-flow fallback and stderr
+  prompt callback.
+- [ ] T114-S2 Add unit tests for cache write, cache read, and mode `0600`.
+- [ ] T114-S2 Run the focused RED/GREEN test and `./gate.sh`.
+
+## Slice 3: Proxy client and runtime command
+
+- [ ] T114-S3 Implement proxy URL resolution, runs HTTP request, JSON decode,
+  and error classification.
+- [ ] T114-S3 Implement 401 cache eviction and one reauth retry.
+- [ ] T114-S3 Map runtime outcomes to stdout/stderr and exit codes 0/2/3/4.
+- [ ] T114-S3 Add unit coverage for cache eviction on 401 and retry.
+- [ ] T114-S3 Run focused RED/GREEN tests, `./gate.sh`, and record smoke
+  status.

--- a/src/App.hs
+++ b/src/App.hs
@@ -6,7 +6,13 @@ module App
     ) where
 
 import Cli (cmd)
-import Control.Exception (SomeException (SomeException), catch, try)
+import Control.Exception
+    ( SomeException (SomeException)
+    , catch
+    , fromException
+    , throwIO
+    , try
+    )
 import Lib.Box (Box (..))
 import Network.HTTP.Client
     ( ManagerSettings (..)
@@ -15,6 +21,7 @@ import Network.HTTP.Client
     )
 import Options (Options (..), parseArgs)
 import Paths_moog (version)
+import System.Exit (ExitCode)
 import Text.JSON.Canonical (JSValue, ToJSON (..))
 
 data Result
@@ -31,7 +38,13 @@ client = do
         Left (SomeException _) -> return Help
         Right (Box (Options raw command)) -> do
             let action = Success raw <$> (cmd command >>= toJSON)
-            action `catch` (return . Exceptional raw)
+            action `catch` handleCommandException raw
+
+handleCommandException :: Bool -> SomeException -> IO Result
+handleCommandException raw ex =
+    case fromException ex of
+        Just (exitCode :: ExitCode) -> throwIO exitCode
+        Nothing -> return $ Exceptional raw ex
 
 _logRequests :: ManagerSettings -> ManagerSettings
 _logRequests settings =

--- a/src/Cli.hs
+++ b/src/Cli.hs
@@ -50,6 +50,10 @@ import User.Agent.Cli
     , IsReady (NotReady)
     , agentCmd
     )
+import User.Antithesis.Cli
+    ( AntithesisCommand
+    , antithesisCmd
+    )
 import User.Requester.Cli
     ( RequesterCommand
     , requesterCmd
@@ -77,6 +81,7 @@ data Command a where
         -> Command
             (AValidationResult TokenInfoFailure (Token WithValidation))
     SSHSelectors :: SSHClient 'WithoutSelector -> Command [Selection]
+    AntithesisCommand :: AntithesisCommand a -> Command a
 
 deriving instance Show (Token WithValidation)
 deriving instance Eq (Token WithValidation)
@@ -161,6 +166,8 @@ cmd = \case
                                 pure $ WithValidation r req
                         lift $ fmapMToken f token
     SSHSelectors sshClient -> sshKeySelectors sshClient
+    AntithesisCommand antithesisCommand ->
+        liftIO $ antithesisCmd antithesisCommand
 
 data TokenInfoFailure
     = TokenInfoTokenNotParsable TokenId

--- a/src/Options.hs
+++ b/src/Options.hs
@@ -67,6 +67,7 @@ import Path
 import System.Directory (makeAbsolute)
 import User.Agent.Options (agentCommandParser, testRunIdOption)
 import User.Agent.Types (TestRunId)
+import User.Antithesis.Cli (antithesisCommandParser)
 import User.Requester.Options
     ( requesterCommandParser
     , sshClientOption
@@ -124,6 +125,8 @@ commandParser =
                 <*> tokenIdOption
         , command "ssh-selectors" "List key selectors for an SSH key file"
             $ Box . SSHSelectors <$> sshClientOptionWithoutSelector
+        , command "antithesis" "Manage Antithesis proxy operations"
+            $ fmapBox AntithesisCommand <$> antithesisCommandParser
         ]
 
 factsSelectionParser :: Parser (Box FactsSelection)

--- a/src/User/Antithesis/Cli.hs
+++ b/src/User/Antithesis/Cli.hs
@@ -7,16 +7,29 @@ module User.Antithesis.Cli
 where
 
 import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy.Char8 qualified as LBS8
 import Lib.Box (Box (..))
 import Lib.JSON.Canonical.Extra ()
 import OptEnvConf (Parser, command, commands)
+import System.Exit (ExitCode (..), exitWith)
+import System.IO (hPutStrLn, stderr)
+import User.Antithesis.Login
+    ( defaultTokenFile
+    , ensureToken
+    , evictCachedToken
+    )
+import User.Antithesis.ProxyClient
+    ( ClientErr (..)
+    , proxyUrlFromEnv
+    , runsRequestWithRefresh
+    )
 
 data AntithesisCommand a where
     Runs :: AntithesisCommand Aeson.Value
 
 antithesisCmd :: AntithesisCommand a -> IO a
 antithesisCmd = \case
-    Runs -> pure $ Aeson.object []
+    Runs -> runRuns
 
 antithesisCommandParser :: Parser (Box AntithesisCommand)
 antithesisCommandParser =
@@ -30,3 +43,37 @@ runsHelp =
     "List Antithesis runs via the Moog proxy. Exit codes: \
     \0 success, 2 authorization or SSO failure, 3 proxy or network failure, \
     \4 invalid JSON from proxy."
+
+runRuns :: IO Aeson.Value
+runRuns = do
+    proxyUrl <- proxyUrlFromEnv
+    result <-
+        runsRequestWithRefresh
+            proxyUrl
+            ensureToken
+            (defaultTokenFile >>= evictCachedToken)
+    case result of
+        Right value -> pure value
+        Left err -> do
+            hPutStrLn stderr $ renderClientErr err
+            exitWith $ ExitFailure $ clientErrExitCode err
+
+clientErrExitCode :: ClientErr -> Int
+clientErrExitCode = \case
+    Unauthorized -> 2
+    Forbidden{} -> 2
+    ProxyFailure{} -> 3
+    InvalidJson{} -> 4
+
+renderClientErr :: ClientErr -> String
+renderClientErr = \case
+    Unauthorized ->
+        "proxy rejected refreshed GitHub token with 401"
+    Forbidden body maybeSsoUrl ->
+        "proxy authorization failed: "
+            <> LBS8.unpack body
+            <> maybe "" (("\nSSO URL: " <>) . show) maybeSsoUrl
+    ProxyFailure message ->
+        "proxy request failed: " <> show message
+    InvalidJson message ->
+        "proxy returned non-JSON response: " <> show message

--- a/src/User/Antithesis/Cli.hs
+++ b/src/User/Antithesis/Cli.hs
@@ -1,0 +1,32 @@
+-- | User-facing Antithesis CLI commands.
+module User.Antithesis.Cli
+    ( AntithesisCommand (..)
+    , antithesisCmd
+    , antithesisCommandParser
+    )
+where
+
+import Data.Aeson qualified as Aeson
+import Lib.Box (Box (..))
+import Lib.JSON.Canonical.Extra ()
+import OptEnvConf (Parser, command, commands)
+
+data AntithesisCommand a where
+    Runs :: AntithesisCommand Aeson.Value
+
+antithesisCmd :: AntithesisCommand a -> IO a
+antithesisCmd = \case
+    Runs -> pure $ Aeson.object []
+
+antithesisCommandParser :: Parser (Box AntithesisCommand)
+antithesisCommandParser =
+    commands
+        [ command "runs" runsHelp $
+            pure $ Box Runs
+        ]
+
+runsHelp :: String
+runsHelp =
+    "List Antithesis runs via the Moog proxy. Exit codes: \
+    \0 success, 2 authorization or SSO failure, 3 proxy or network failure, \
+    \4 invalid JSON from proxy."

--- a/src/User/Antithesis/Constants.hs
+++ b/src/User/Antithesis/Constants.hs
@@ -1,0 +1,14 @@
+-- | Public OAuth constants for the Moog Antithesis CLI.
+module User.Antithesis.Constants
+    ( moogOAuthClientId
+    , moogOAuthScopes
+    )
+where
+
+import Lib.GitHub.Auth.DeviceFlow (ClientId (..), Scope (..))
+
+moogOAuthClientId :: ClientId
+moogOAuthClientId = ClientId "Ov23liVVFVtdBez1QDxq"
+
+moogOAuthScopes :: [Scope]
+moogOAuthScopes = [Scope "read:org"]

--- a/src/User/Antithesis/Login.hs
+++ b/src/User/Antithesis/Login.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | GitHub OAuth token cache and device-flow login boundary.
+module User.Antithesis.Login
+    ( defaultTokenFile
+    , ensureToken
+    , ensureTokenAt
+    , evictCachedToken
+    , readCachedToken
+    , writeCachedToken
+    )
+where
+
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+import Lib.GitHub.Auth.DeviceFlow
+    ( DeviceCodeResponse (..)
+    , DeviceFlowError
+    , OAuthToken (..)
+    , runDeviceFlow
+    )
+import System.Directory
+    ( createDirectoryIfMissing
+    , doesFileExist
+    , getHomeDirectory
+    , removeFile
+    )
+import System.FilePath ((</>), takeDirectory)
+import System.IO (hPutStrLn, stderr)
+import System.Posix.Files
+    ( ownerReadMode
+    , ownerWriteMode
+    , setFileMode
+    , unionFileModes
+    )
+import System.Posix.Types (FileMode)
+import User.Antithesis.Constants
+    ( moogOAuthClientId
+    , moogOAuthScopes
+    )
+
+newtype CachedOAuthToken = CachedOAuthToken OAuthToken
+    deriving stock (Eq, Show)
+
+instance Aeson.ToJSON CachedOAuthToken where
+    toJSON (CachedOAuthToken (OAuthToken token)) =
+        Aeson.object ["access_token" Aeson..= TE.decodeUtf8 token]
+
+instance Aeson.FromJSON CachedOAuthToken where
+    parseJSON =
+        Aeson.withObject "CachedOAuthToken" $ \objectValue ->
+            CachedOAuthToken . OAuthToken . TE.encodeUtf8
+                <$> objectValue Aeson..: "access_token"
+
+defaultTokenFile :: IO FilePath
+defaultTokenFile = do
+    home <- getHomeDirectory
+    pure $ home </> ".config" </> "moog" </> "github-oauth.json"
+
+ensureToken :: IO OAuthToken
+ensureToken = do
+    path <- defaultTokenFile
+    ensureTokenAt path $
+        runDeviceFlow moogOAuthClientId moogOAuthScopes printDeviceCode
+
+ensureTokenAt
+    :: FilePath
+    -> IO (Either DeviceFlowError OAuthToken)
+    -> IO OAuthToken
+ensureTokenAt path acquireToken = do
+    cached <- readCachedToken path
+    case cached of
+        Just token -> pure token
+        Nothing -> do
+            result <- acquireToken
+            case result of
+                Left err ->
+                    ioError
+                        $ userError
+                        $ "GitHub device-flow login failed: " <> show err
+                Right token -> do
+                    writeCachedToken path token
+                    pure token
+
+readCachedToken :: FilePath -> IO (Maybe OAuthToken)
+readCachedToken path = do
+    exists <- doesFileExist path
+    if exists
+        then do
+            body <- LBS.readFile path
+            case Aeson.eitherDecode body of
+                Left err ->
+                    ioError
+                        $ userError
+                        $ "Failed to parse GitHub OAuth cache: " <> err
+                Right (CachedOAuthToken token) -> pure $ Just token
+        else pure Nothing
+
+writeCachedToken :: FilePath -> OAuthToken -> IO ()
+writeCachedToken path token = do
+    createDirectoryIfMissing True $ takeDirectory path
+    LBS.writeFile path $ Aeson.encode $ CachedOAuthToken token
+    setFileMode path tokenFileMode
+
+evictCachedToken :: FilePath -> IO ()
+evictCachedToken path = do
+    exists <- doesFileExist path
+    if exists
+        then removeFile path
+        else pure ()
+
+printDeviceCode :: DeviceCodeResponse -> IO ()
+printDeviceCode deviceCode =
+    hPutStrLn stderr $
+        "Visit "
+            <> T.unpack (dcVerificationUri deviceCode)
+            <> " and enter code "
+            <> T.unpack (dcUserCode deviceCode)
+
+tokenFileMode :: FileMode
+tokenFileMode = ownerReadMode `unionFileModes` ownerWriteMode

--- a/src/User/Antithesis/ProxyClient.hs
+++ b/src/User/Antithesis/ProxyClient.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | HTTP client for the Moog Antithesis proxy.
+module User.Antithesis.ProxyClient
+    ( ClientErr (..)
+    , ProxyUrl (..)
+    , defaultProxyUrl
+    , proxyUrlFromEnv
+    , runsRequest
+    , runsRequestWithRefresh
+    )
+where
+
+import Control.Exception (try)
+import Data.Aeson (Value)
+import Data.Aeson qualified as Aeson
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text (Text)
+import Data.Text qualified as T
+import Lib.GitHub.Auth.DeviceFlow (OAuthToken (..))
+import Network.HTTP.Client
+    ( HttpException
+    , Request (method, requestHeaders)
+    , Response (responseBody, responseHeaders, responseStatus)
+    , httpLbs
+    , newManager
+    , parseRequest
+    )
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Network.HTTP.Types
+    ( hAccept
+    , hAuthorization
+    , statusCode
+    )
+import System.Environment (lookupEnv)
+
+newtype ProxyUrl = ProxyUrl String
+    deriving stock (Eq, Show)
+
+data ClientErr
+    = Unauthorized
+    | Forbidden LBS.ByteString (Maybe ByteString)
+    | ProxyFailure Text
+    | InvalidJson Text
+    deriving stock (Eq, Show)
+
+defaultProxyUrl :: ProxyUrl
+defaultProxyUrl = ProxyUrl "https://antithesis-proxy.plutimus.com"
+
+proxyUrlFromEnv :: IO ProxyUrl
+proxyUrlFromEnv =
+    maybe defaultProxyUrl ProxyUrl <$> lookupEnv "MOOG_ANTITHESIS_PROXY_URL"
+
+runsRequest :: ProxyUrl -> OAuthToken -> IO (Either ClientErr Value)
+runsRequest proxyUrl token = do
+    manager <- newManager tlsManagerSettings
+    requestResult <- try @HttpException $ do
+        baseRequest <- parseRequest $ runsUrl proxyUrl
+        httpLbs
+            baseRequest
+                { method = "GET"
+                , requestHeaders =
+                    [ (hAccept, "application/json")
+                    , (hAuthorization, "Bearer " <> unOAuthToken token)
+                    ]
+                }
+            manager
+    pure $ case requestResult of
+        Left err ->
+            Left $ ProxyFailure $ T.pack $ show err
+        Right response ->
+            classifyResponse response
+
+runsRequestWithRefresh
+    :: ProxyUrl
+    -> IO OAuthToken
+    -> IO ()
+    -> IO (Either ClientErr Value)
+runsRequestWithRefresh proxyUrl acquireToken invalidateToken = do
+    token <- acquireToken
+    first <- runsRequest proxyUrl token
+    case first of
+        Left Unauthorized -> do
+            invalidateToken
+            refreshedToken <- acquireToken
+            runsRequest proxyUrl refreshedToken
+        _ -> pure first
+
+classifyResponse :: Response LBS.ByteString -> Either ClientErr Value
+classifyResponse response =
+    let code = statusCode $ responseStatus response
+        body = responseBody response
+     in case code of
+            200 -> case Aeson.eitherDecode body of
+                Left err -> Left $ InvalidJson $ T.pack err
+                Right value -> Right value
+            401 -> Left Unauthorized
+            403 ->
+                Left $
+                    Forbidden body $
+                        lookup "X-Moog-SSO-Url" $
+                            responseHeaders response
+            _
+                | code >= 500 ->
+                    Left $
+                        ProxyFailure $
+                            "proxy request failed with status " <> T.pack (show code)
+                | otherwise ->
+                    Left $
+                        ProxyFailure $
+                            "proxy request failed with status " <> T.pack (show code)
+
+runsUrl :: ProxyUrl -> String
+runsUrl (ProxyUrl baseUrl) =
+    stripTrailingSlash baseUrl <> "/api/v1/runs"
+
+stripTrailingSlash :: String -> String
+stripTrailingSlash =
+    reverse . dropWhile (== '/') . reverse

--- a/test/User/Antithesis/CliSpec.hs
+++ b/test/User/Antithesis/CliSpec.hs
@@ -1,0 +1,22 @@
+module User.Antithesis.CliSpec
+    ( spec
+    )
+where
+
+import Cli (Command (..))
+import Lib.Box (Box (..))
+import Options (Options (..), parseArgs)
+import Paths_moog (version)
+import System.Environment (withArgs)
+import Test.Hspec (Spec, describe, expectationFailure, it)
+import User.Antithesis.Cli (AntithesisCommand (..))
+
+spec :: Spec
+spec =
+    describe "User.Antithesis.Cli" $
+        it "parses moog antithesis runs" $ do
+            Box (Options _ command) <-
+                withArgs ["antithesis", "runs"] $ parseArgs version
+            case command of
+                AntithesisCommand Runs -> pure ()
+                _ -> expectationFailure "expected AntithesisCommand Runs"

--- a/test/User/Antithesis/LoginSpec.hs
+++ b/test/User/Antithesis/LoginSpec.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module User.Antithesis.LoginSpec
+    ( spec
+    )
+where
+
+import Lib.GitHub.Auth.DeviceFlow (OAuthToken (..))
+import System.FilePath ((</>))
+import System.Posix.Files
+    ( fileMode
+    , getFileStatus
+    , intersectFileModes
+    , ownerReadMode
+    , ownerWriteMode
+    , unionFileModes
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    , shouldReturn
+    )
+import System.IO.Temp (withSystemTempDirectory)
+import User.Antithesis.Login
+    ( ensureTokenAt
+    , readCachedToken
+    , writeCachedToken
+    )
+
+spec :: Spec
+spec =
+    describe "User.Antithesis.Login" $ do
+        it "writes a missing token cache with mode 0600" $
+            withSystemTempDirectory "moog-antithesis-login" $ \tmp -> do
+                let path = tmp </> "github-oauth.json"
+                    expected = OAuthToken "gh-token-one"
+
+                token <- ensureTokenAt path $ pure $ Right expected
+
+                token `shouldBe` expected
+                readCachedToken path `shouldReturn` Just expected
+                assertMode0600 path
+
+        it "reads a cached token without running the device flow" $
+            withSystemTempDirectory "moog-antithesis-login" $ \tmp -> do
+                let path = tmp </> "github-oauth.json"
+                    expected = OAuthToken "gh-token-two"
+                writeCachedToken path expected
+
+                token <-
+                    ensureTokenAt path $ do
+                        expectationFailure "device flow should not run"
+                        pure $ Right $ OAuthToken "unexpected"
+
+                token `shouldBe` expected
+
+assertMode0600 :: FilePath -> IO ()
+assertMode0600 path = do
+    status <- getFileStatus path
+    let permissionBits = fileMode status `intersectFileModes` 0o777
+    permissionBits `shouldBe` (ownerReadMode `unionFileModes` ownerWriteMode)

--- a/test/User/Antithesis/ProxyClientSpec.hs
+++ b/test/User/Antithesis/ProxyClientSpec.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module User.Antithesis.ProxyClientSpec
+    ( spec
+    )
+where
+
+import Data.Aeson qualified as Aeson
+import Data.ByteString (ByteString)
+import Data.IORef
+    ( IORef
+    , atomicModifyIORef'
+    , newIORef
+    , readIORef
+    , writeIORef
+    )
+import Lib.GitHub.Auth.DeviceFlow (OAuthToken (..))
+import Network.HTTP.Types
+    ( hAuthorization
+    , status200
+    , status401
+    )
+import Network.Wai
+    ( Application
+    , Request (requestHeaders)
+    , responseLBS
+    )
+import Network.Wai.Handler.Warp (testWithApplication)
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+import User.Antithesis.ProxyClient
+    ( ProxyUrl (..)
+    , runsRequestWithRefresh
+    )
+
+spec :: Spec
+spec =
+    describe "User.Antithesis.ProxyClient" $
+        it "evicts the cached token and retries once after 401" $ do
+            seenAuthRef <- newIORef []
+            evictionsRef <- newIORef (0 :: Int)
+            tokensRef <- newIORef [OAuthToken "stale-token", OAuthToken "fresh-token"]
+
+            result <-
+                withRunsProxy seenAuthRef $ \baseUrl ->
+                    runsRequestWithRefresh
+                        (ProxyUrl baseUrl)
+                        (popToken tokensRef)
+                        (increment evictionsRef)
+
+            result `shouldBe` Right (Aeson.object ["runs" Aeson..= ([] :: [Aeson.Value])])
+            seenAuth <- readIORef seenAuthRef
+            seenAuth `shouldBe` ["Bearer stale-token", "Bearer fresh-token"]
+            evictions <- readIORef evictionsRef
+            evictions `shouldBe` 1
+
+withRunsProxy :: IORef [ByteString] -> (String -> IO a) -> IO a
+withRunsProxy seenAuthRef action =
+    testWithApplication (pure $ runsProxy seenAuthRef) $ \port ->
+        action $ "http://127.0.0.1:" <> show port
+
+runsProxy :: IORef [ByteString] -> Application
+runsProxy seenAuthRef request respond = do
+    let auth = lookup hAuthorization $ requestHeaders request
+    writeIORef seenAuthRef . (<> maybe [] (: []) auth) =<< readIORef seenAuthRef
+    case auth of
+        Just "Bearer fresh-token" ->
+            respond
+                $ responseLBS
+                    status200
+                    [("Content-Type", "application/json")]
+                    "{\"runs\":[]}"
+        _ ->
+            respond $ responseLBS status401 [] "bad credentials"
+
+popToken :: IORef [OAuthToken] -> IO OAuthToken
+popToken tokensRef =
+    atomicModifyIORef' tokensRef $ \case
+        [] -> ([], error "no token left")
+        token : rest -> (rest, token)
+
+increment :: IORef Int -> IO ()
+increment ref =
+    atomicModifyIORef' ref $ \count -> (count + 1, ())


### PR DESCRIPTION
## Summary

- add `moog antithesis runs` parser and top-level command wiring
- add GitHub device-flow token cache helpers using the public Moog OAuth client id and `read:org` scope
- add Antithesis proxy client for `GET /api/v1/runs`, JSON output, 401 cache eviction plus one retry, and exit codes 0/2/3/4

## Verification

- `nix run .#unit-tests -- --match User.Antithesis.Cli`
- `nix run .#unit-tests -- --match User.Antithesis.Login`
- `nix run .#unit-tests -- --match User.Antithesis.ProxyClient`
- `nix run .#moog -- antithesis runs --help`
- `./gate.sh` at branch head: 209 examples, 0 failures

## Smoke

Local help smoke confirms `moog antithesis runs --help` documents the exit codes. The deployed proxy smoke is operator-run because it requires GitHub device-flow approval and a token authorized for the Antithesis proxy team; the cache-evict/retry path is covered by a local WAI proxy unit test.

Closes #114
