### PR TITLE
feat(deploy): add antithesis proxy deployment artifacts

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -38,6 +38,29 @@ jobs:
         with:
           name: moog-agent-image
           path: ./moog-agent-image
+      - name: Build Antithesis proxy docker image
+        run: nix --quiet build .#moog-antithesis-proxy-docker-image -o moog-antithesis-proxy-image
+      - name: Smoke test Antithesis proxy docker image
+        run: |
+          IMAGE=$(docker load < moog-antithesis-proxy-image | grep "Loaded image:" | awk '{print $3}')
+          printf '%s\n' test-password > antithesis-password
+          CID=$(docker run -d -p 127.0.0.1::8080 \
+            -v "$PWD/antithesis-password:/run/secrets/antithesis-password:ro" \
+            "$IMAGE")
+          trap 'docker logs "$CID"; docker rm -f "$CID"' EXIT
+          PORT=$(docker port "$CID" 8080/tcp | sed 's/.*://')
+          for _ in $(seq 1 20); do
+            if curl -fsS "http://127.0.0.1:$PORT/healthz" | grep -x ok; then
+              exit 0
+            fi
+            sleep 1
+          done
+          exit 1
+      - name: Upload Antithesis proxy artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: moog-antithesis-proxy-image
+          path: ./moog-antithesis-proxy-image
   build-aarch64:
     name: Build and upload ARM64 docker images
     runs-on: ubuntu-24.04-arm
@@ -69,3 +92,26 @@ jobs:
         with:
           name: moog-agent-image-aarch64
           path: ./moog-agent-image-aarch64
+      - name: Build Antithesis proxy docker image
+        run: nix --quiet build .#moog-antithesis-proxy-docker-image -o moog-antithesis-proxy-image-aarch64
+      - name: Smoke test Antithesis proxy docker image
+        run: |
+          IMAGE=$(docker load < moog-antithesis-proxy-image-aarch64 | grep "Loaded image:" | awk '{print $3}')
+          printf '%s\n' test-password > antithesis-password
+          CID=$(docker run -d -p 127.0.0.1::8080 \
+            -v "$PWD/antithesis-password:/run/secrets/antithesis-password:ro" \
+            "$IMAGE")
+          trap 'docker logs "$CID"; docker rm -f "$CID"' EXIT
+          PORT=$(docker port "$CID" 8080/tcp | sed 's/.*://')
+          for _ in $(seq 1 20); do
+            if curl -fsS "http://127.0.0.1:$PORT/healthz" | grep -x ok; then
+              exit 0
+            fi
+            sleep 1
+          done
+          exit 1
+      - name: Upload Antithesis proxy artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: moog-antithesis-proxy-image-aarch64
+          path: ./moog-antithesis-proxy-image-aarch64

--- a/docs/antithesis-proxy.compose.example.yaml
+++ b/docs/antithesis-proxy.compose.example.yaml
@@ -29,7 +29,7 @@ services:
       - traefik.http.routers.moog-antithesis-proxy.rule=Host(`antithesis-proxy.plutimus.com`)
       - traefik.http.routers.moog-antithesis-proxy.entrypoints=websecure
       - traefik.http.routers.moog-antithesis-proxy.tls=true
-      - traefik.http.routers.moog-antithesis-proxy.tls.certresolver=letsencrypt
+      - traefik.http.routers.moog-antithesis-proxy.tls.certresolver=le
       - traefik.http.services.moog-antithesis-proxy.loadbalancer.server.port=8080
     logging:
       driver: json-file

--- a/docs/antithesis-proxy.compose.example.yaml
+++ b/docs/antithesis-proxy.compose.example.yaml
@@ -1,0 +1,42 @@
+services:
+  moog-antithesis-proxy:
+    image: ghcr.io/cardano-foundation/moog/moog-antithesis-proxy:${MOOG_VERSION:?pin-to-a-commit-or-release-tag}
+    restart: unless-stopped
+    networks:
+      - web
+    environment:
+      - MOOG_PROXY_BIND_ADDR=0.0.0.0
+      - MOOG_PROXY_BIND_PORT=8080
+      - MOOG_ANTITHESIS_URL=https://amaru-cardano.antithesis.com
+      - MOOG_ANTITHESIS_USER=pragma
+      - MOOG_ANTITHESIS_PASSWORD_FILE=/run/secrets/antithesis-password
+      - MOOG_PROXY_AUTHORIZED_ORG=pragma-org
+      - MOOG_PROXY_AUTHORIZED_TEAM=antithesis-access
+      - MOOG_PROXY_MEMBERSHIP_TTL_SEC=60
+      - MOOG_PROXY_LOG_LEVEL=info
+    volumes:
+      - /secrets/moog-antithesis-proxy/new:/run/secrets:ro
+      - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8080/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=web
+      - traefik.http.routers.moog-antithesis-proxy.rule=Host(`antithesis-proxy.plutimus.com`)
+      - traefik.http.routers.moog-antithesis-proxy.entrypoints=websecure
+      - traefik.http.routers.moog-antithesis-proxy.tls=true
+      - traefik.http.routers.moog-antithesis-proxy.tls.certresolver=letsencrypt
+      - traefik.http.services.moog-antithesis-proxy.loadbalancer.server.port=8080
+    logging:
+      driver: json-file
+      options:
+        max-size: 50m
+        max-file: "10"
+
+networks:
+  web:
+    external: true

--- a/docs/antithesis-proxy.md
+++ b/docs/antithesis-proxy.md
@@ -1,0 +1,101 @@
+# Antithesis Proxy Deployment
+
+`moog-antithesis-proxy` exposes selected Antithesis tenant API routes behind
+GitHub team authorization. It keeps the Antithesis tenant password on
+plutimus and accepts GitHub bearer tokens from clients such as
+`moog antithesis runs`.
+
+```mermaid
+flowchart LR
+  CLI[moog antithesis runs] -->|GitHub bearer token| Traefik[Traefik on plutimus]
+  Traefik --> Proxy[moog-antithesis-proxy]
+  Proxy -->|whoami and team check| GitHub[GitHub API]
+  Proxy -->|server-side basic auth| Antithesis[Antithesis tenant API]
+```
+
+## Repository Artifacts
+
+- Image: `ghcr.io/cardano-foundation/moog/moog-antithesis-proxy:<tag>`.
+- Compose example: `docs/antithesis-proxy.compose.example.yaml`.
+- Runtime port: `8080`.
+- Public route: `https://antithesis-proxy.plutimus.com`.
+
+Pin `MOOG_VERSION` to a concrete commit or release tag. Do not deploy
+`latest`.
+
+## Plutimus Layout
+
+Copy the compose example to:
+
+```text
+/opt/hal/infrastructure/moog/antithesis-proxy/docker-compose.yaml
+```
+
+Create the secrets layout:
+
+```text
+/secrets/moog-antithesis-proxy/
+  new/
+    secrets.yaml
+    antithesis-password
+  old/
+    secrets.yaml
+    antithesis-password
+```
+
+`secrets.yaml` mirrors the agent rotation discipline and carries:
+
+```yaml
+antithesisPassword: "<same value as moog-agent>"
+```
+
+`antithesis-password` is the plain-text value read by
+`MOOG_ANTITHESIS_PASSWORD_FILE`.
+
+## Deploy
+
+```bash
+cd /opt/hal/infrastructure/moog/antithesis-proxy
+MOOG_VERSION=<pinned-tag> docker compose pull moog-antithesis-proxy
+MOOG_VERSION=<pinned-tag> docker compose up -d moog-antithesis-proxy
+```
+
+Restart the service after config or secret changes:
+
+```bash
+MOOG_VERSION=<pinned-tag> docker compose up -d --force-recreate moog-antithesis-proxy
+```
+
+Stop it with:
+
+```bash
+docker compose down
+```
+
+Read logs with:
+
+```bash
+docker logs antithesis-proxy-moog-antithesis-proxy-1
+```
+
+## Acceptance Checks
+
+```bash
+curl -i https://antithesis-proxy.plutimus.com/healthz
+curl -i https://antithesis-proxy.plutimus.com/api/v1/runs
+curl -i -H 'Authorization: Bearer garbage' \
+  https://antithesis-proxy.plutimus.com/api/v1/runs
+curl -i -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  https://antithesis-proxy.plutimus.com/api/v1/runs
+```
+
+Expected results:
+
+- `/healthz` returns `200` with body `ok`.
+- `/api/v1/runs` without auth returns `401` and
+  `WWW-Authenticate: Bearer realm="moog-antithesis-proxy"`.
+- `/api/v1/runs` with garbage auth returns `401`.
+- `/api/v1/runs` with a valid `pragma-org/antithesis-access` member token
+  returns `200` and an Antithesis JSON body.
+
+The full smoke script and failure-mode runbook are owned by #116.

--- a/docs/antithesis-proxy.md
+++ b/docs/antithesis-proxy.md
@@ -98,4 +98,21 @@ Expected results:
 - `/api/v1/runs` with a valid `pragma-org/antithesis-access` member token
   returns `200` and an Antithesis JSON body.
 
+## Live Deployment Status
+
+The proxy is deployed and healthy on plutimus. Operators can verify the
+public health endpoint at
+`https://antithesis-proxy.plutimus.com/healthz`.
+
+As of the #115 deployment, three of the four acceptance curls validate the
+live auth gate: `/healthz` returns `200 ok`, unauthenticated `/api/v1/runs`
+returns the proxy's bearer challenge, and a garbage bearer token returns
+`401`. A valid team-member token resolves through GitHub as `login:paolino`
+in the proxy audit log, proving `whoami` and
+`pragma-org/antithesis-access` membership succeeded before forwarding.
+The forwarded `/api/v1/runs` request currently receives `403` from the
+Antithesis upstream because that tenant endpoint is not exposed yet. Track
+that Antithesis-side blocker in
+[issue #78](https://github.com/cardano-foundation/moog/issues/78).
+
 The full smoke script and failure-mode runbook are owned by #116.

--- a/flake.nix
+++ b/flake.nix
@@ -107,6 +107,10 @@
               moog-agent-docker-image = import ./nix/moog-agent-docker.nix {
                 inherit pkgs project version;
               };
+              moog-antithesis-proxy-docker-image =
+                import ./nix/moog-antithesis-proxy-docker.nix {
+                  inherit pkgs project version;
+                };
               moog-docker-image = import ./nix/moog-docker.nix {
                 inherit pkgs version project;
               };

--- a/justfile
+++ b/justfile
@@ -219,6 +219,16 @@ build-moog-agent tag='latest':
     docker image tag ghcr.io/cardano-foundation/moog/moog-agent:"$version" \
         "ghcr.io/cardano-foundation/moog/moog-agent:latest"
 
+build-moog-antithesis-proxy tag='latest':
+    #!/usr/bin/env bash
+    nix build .#moog-antithesis-proxy-docker-image
+    docker load < result
+    version=$(nix eval --raw .#version)
+    docker image tag ghcr.io/cardano-foundation/moog/moog-antithesis-proxy:"$version" \
+        "ghcr.io/cardano-foundation/moog/moog-antithesis-proxy:{{ tag }}"
+    docker image tag ghcr.io/cardano-foundation/moog/moog-antithesis-proxy:"$version" \
+        "ghcr.io/cardano-foundation/moog/moog-antithesis-proxy:latest"
+
 build-moog tag='latest':
     #!/usr/bin/env bash
     nix build .#moog-docker-image
@@ -304,6 +314,7 @@ build-docker-images:
     just build-moog "$tag"
     just build-moog-light "$tag"
     just build-moog-agent "$tag"
+    just build-moog-antithesis-proxy "$tag"
     just build-moog-oracle "$tag"
 
 push-docker-images:
@@ -314,8 +325,10 @@ push-docker-images:
     docker push "ghcr.io/cardano-foundation/moog/moog-light:$tag"
     docker push "ghcr.io/cardano-foundation/moog/moog-light:latest"
     docker push "ghcr.io/cardano-foundation/moog/moog-agent:$tag"
+    docker push "ghcr.io/cardano-foundation/moog/moog-antithesis-proxy:$tag"
     docker push "ghcr.io/cardano-foundation/moog/moog-oracle:$tag"
     docker push "ghcr.io/cardano-foundation/moog/moog-agent:latest"
+    docker push "ghcr.io/cardano-foundation/moog/moog-antithesis-proxy:latest"
     docker push "ghcr.io/cardano-foundation/moog/moog-oracle:latest"
 
 cabal-version:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
     - Deployment: ops/deployment.md
     - Oracle Role: ops/oracle-role.md
     - Agent Role: ops/agent-role.md
+    - Antithesis Proxy: antithesis-proxy.md
     - MPFS v2 Canary: ops/mpfs-v2-canary.md
     - Real World: ops/real-world.md
     - Security: ops/security.md

--- a/nix/moog-antithesis-proxy-docker.nix
+++ b/nix/moog-antithesis-proxy-docker.nix
@@ -1,0 +1,20 @@
+{ pkgs, project, version, }:
+pkgs.dockerTools.buildImage {
+  name = "ghcr.io/cardano-foundation/moog/moog-antithesis-proxy";
+  tag = version;
+  architecture = if pkgs.stdenv.hostPlatform.isAarch64 then "arm64" else "amd64";
+  config = {
+    EntryPoint = [ "moog-antithesis-proxy" ];
+    ExposedPorts = { "8080/tcp" = { }; };
+  };
+  copyToRoot = pkgs.buildEnv {
+    name = "image-root";
+    paths = [
+      project.packages.moog-antithesis-proxy
+      pkgs.cacert
+      pkgs.curl
+      pkgs.coreutils
+      pkgs.bash
+    ];
+  };
+}

--- a/specs/115-antithesis-proxy-deploy/plan.md
+++ b/specs/115-antithesis-proxy-deploy/plan.md
@@ -1,0 +1,33 @@
+# Implementation Plan: Deploy moog-antithesis-proxy
+
+## Scope Split
+
+The Moog PR owns reusable artifacts: image packaging, documentation, and an
+example compose file. The live deployment is operator-bound and happens on
+plutimus after the PR artifacts are ready.
+
+## Image Packaging
+
+`moog-antithesis-proxy` already exists as a cabal executable and Nix package.
+The existing `moog-agent` image contains only `moog-agent`, so this ticket adds
+a sibling `moog-antithesis-proxy-docker-image` target instead of relying on the
+agent image. The GitHub Actions image workflow builds and smoke-tests it in
+the same jobs as `moog-agent` and `moog-oracle`.
+
+## Deployment Documentation
+
+`docs/antithesis-proxy.compose.example.yaml` is the source the operator copies
+to `/opt/hal/infrastructure/moog/antithesis-proxy/docker-compose.yaml`.
+It is pinned by `MOOG_VERSION`, joins the external `web` network, exposes only
+container port `8080`, mounts the secret directory read-only, and carries the
+requested Traefik labels for `antithesis-proxy.plutimus.com`.
+
+`docs/antithesis-proxy.md` records the architecture, secret layout,
+start/stop/log commands, and acceptance checks. The fuller operational
+runbook remains in #116.
+
+## Slice
+
+One bisect-safe slice lands all repository-owned artifacts and verification.
+The external deployment request is raised as a Q-file after the PR branch is
+pushed.

--- a/specs/115-antithesis-proxy-deploy/spec.md
+++ b/specs/115-antithesis-proxy-deploy/spec.md
@@ -1,0 +1,45 @@
+# Feature Specification: Deploy moog-antithesis-proxy
+
+## Primary User Story
+
+As a Moog operator, I need `moog-antithesis-proxy` deployed at
+`https://antithesis-proxy.plutimus.com` behind plutimus Traefik so team
+members can fetch Antithesis run data without receiving the tenant
+password.
+
+## Repository Deliverables
+
+- Produce a `moog-antithesis-proxy` container image target from the same
+  Nix/GitHub Actions image pipeline used by the other Moog images.
+- Add `docs/antithesis-proxy.compose.example.yaml` as the operator-copyable
+  plutimus compose file.
+- Add `docs/antithesis-proxy.md` with the deployment shape, commands,
+  acceptance checks, and handoff boundary for the fuller #116 runbook.
+
+## Plutimus Deliverables
+
+- Install `/opt/hal/infrastructure/moog/antithesis-proxy/docker-compose.yaml`
+  from the example in this PR, pinned to a concrete commit tag.
+- Install `/secrets/moog-antithesis-proxy/{old,new}/secrets.yaml` with
+  `antithesisPassword` mirroring the agent's Antithesis password.
+- Install `/secrets/moog-antithesis-proxy/{old,new}/antithesis-password`
+  because the daemon reads `MOOG_ANTITHESIS_PASSWORD_FILE`.
+- Point `antithesis-proxy.plutimus.com` A/AAAA records at plutimus.
+
+## Acceptance Criteria
+
+- `curl https://antithesis-proxy.plutimus.com/healthz` returns `200 ok`.
+- `curl https://antithesis-proxy.plutimus.com/api/v1/runs` returns `401`
+  with `WWW-Authenticate: Bearer realm="moog-antithesis-proxy"`.
+- `curl -H "Authorization: Bearer <garbage>" .../api/v1/runs` returns `401`.
+- A valid team-member bearer token returns `200` with the Antithesis JSON
+  body; #116 owns the full smoke record.
+- `docker compose up -d --force-recreate moog-antithesis-proxy` restarts
+  the service cleanly on plutimus.
+- `docker logs antithesis-proxy-moog-antithesis-proxy-1` shows proxy logs.
+
+## Out Of Scope
+
+- Changing proxy application behavior.
+- Running SSH deploy steps from this PR worker.
+- The full end-to-end client runbook and smoke evidence, owned by #116.

--- a/specs/115-antithesis-proxy-deploy/tasks.md
+++ b/specs/115-antithesis-proxy-deploy/tasks.md
@@ -1,0 +1,17 @@
+# Tasks: Deploy moog-antithesis-proxy
+
+## Slice 1 - Repository deploy artifacts
+
+- [X] T115-S1 Write the #115 spec, plan, and task contract.
+- [X] T115-S1 Add the `moog-antithesis-proxy` Docker image target to Nix,
+  GitHub Actions, and local image helper recipes.
+- [X] T115-S1 Add the plutimus compose example with Traefik labels, secret
+  mounts, healthcheck, and pinned-version guidance.
+- [X] T115-S1 Add the initial Antithesis proxy deployment runbook.
+- [X] T115-S1 Run repository verification and commit the slice with a
+  `Tasks: T115-S1` trailer.
+
+## Operator handoff
+
+- [ ] Q115-DEPLOY Raise `Q-NNN-deploy-on-plutimus.md` with exact plutimus
+  commands and curl expectations, then park for operator execution.


### PR DESCRIPTION
## Summary

- add a `moog-antithesis-proxy` Docker image target alongside the existing Moog images
- add CI/local image build hooks and a container `/healthz` smoke for the proxy image
- add the plutimus compose example plus initial deployment runbook and #115 spec artifacts
- record the live plutimus deployment status and the Antithesis-side `/api/v1/runs` blocker

## Verification

- `git diff --check`
- `MOOG_VERSION=test docker compose -f docs/antithesis-proxy.compose.example.yaml config`
- `yq e '.' .github/workflows/docker-images.yaml >/dev/null && yq e '.' docs/antithesis-proxy.compose.example.yaml >/dev/null`
- `nix eval --raw .#moog-antithesis-proxy-docker-image.name`
- `nix build --quiet .#moog-antithesis-proxy-docker-image`
- local Docker smoke: loaded `result`, mounted a temporary `antithesis-password`, and `curl /healthz` returned `ok`
- `./gate.sh` before deploy commit: 209 examples, 0 failures
- `./gate.sh` after deploy-status commit: 209 examples, 0 failures

## Live Deployment

Proxy is deployed and healthy at `https://antithesis-proxy.plutimus.com/healthz`.

Three live acceptance curls validate the proxy and auth gate: `/healthz` returns `200 ok`, unauthenticated `/api/v1/runs` returns `401` with `WWW-Authenticate: Bearer realm="moog-antithesis-proxy"`, and a garbage bearer token returns `401`. The valid team-member curl resolves `login:paolino` in the proxy audit log before forwarding, proving GitHub `whoami` and `pragma-org/antithesis-access` membership validation pass.

The forwarded `/api/v1/runs` call currently returns upstream `403` from Antithesis because the tenant endpoint is not exposed yet; this is tracked by #78 and is not a proxy auth failure.

Refs #115.