### PR TITLE
fix(proxy): forward /api/v0/runs with Bearer Antithesis API key

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -43,9 +43,9 @@ jobs:
       - name: Smoke test Antithesis proxy docker image
         run: |
           IMAGE=$(docker load < moog-antithesis-proxy-image | grep "Loaded image:" | awk '{print $3}')
-          printf '%s\n' test-password > antithesis-password
+          printf '%s\n' test-api-key > antithesis-api-key
           CID=$(docker run -d -p 127.0.0.1::8080 \
-            -v "$PWD/antithesis-password:/run/secrets/antithesis-password:ro" \
+            -v "$PWD/antithesis-api-key:/run/secrets/antithesis-api-key:ro" \
             "$IMAGE")
           trap 'docker logs "$CID"; docker rm -f "$CID"' EXIT
           PORT=$(docker port "$CID" 8080/tcp | sed 's/.*://')
@@ -97,9 +97,9 @@ jobs:
       - name: Smoke test Antithesis proxy docker image
         run: |
           IMAGE=$(docker load < moog-antithesis-proxy-image-aarch64 | grep "Loaded image:" | awk '{print $3}')
-          printf '%s\n' test-password > antithesis-password
+          printf '%s\n' test-api-key > antithesis-api-key
           CID=$(docker run -d -p 127.0.0.1::8080 \
-            -v "$PWD/antithesis-password:/run/secrets/antithesis-password:ro" \
+            -v "$PWD/antithesis-api-key:/run/secrets/antithesis-api-key:ro" \
             "$IMAGE")
           trap 'docker logs "$CID"; docker rm -f "$CID"' EXIT
           PORT=$(docker port "$CID" 8080/tcp | sed 's/.*://')

--- a/docs/antithesis-proxy.compose.example.yaml
+++ b/docs/antithesis-proxy.compose.example.yaml
@@ -8,8 +8,7 @@ services:
       - MOOG_PROXY_BIND_ADDR=0.0.0.0
       - MOOG_PROXY_BIND_PORT=8080
       - MOOG_ANTITHESIS_URL=https://amaru-cardano.antithesis.com
-      - MOOG_ANTITHESIS_USER=pragma
-      - MOOG_ANTITHESIS_PASSWORD_FILE=/run/secrets/antithesis-password
+      - MOOG_ANTITHESIS_API_KEY_FILE=/run/secrets/antithesis-api-key
       - MOOG_PROXY_AUTHORIZED_ORG=pragma-org
       - MOOG_PROXY_AUTHORIZED_TEAM=antithesis-access
       - MOOG_PROXY_MEMBERSHIP_TTL_SEC=60

--- a/docs/antithesis-proxy.md
+++ b/docs/antithesis-proxy.md
@@ -1,16 +1,15 @@
 # Antithesis Proxy Deployment
 
-`moog-antithesis-proxy` exposes selected Antithesis tenant API routes behind
-GitHub team authorization. It keeps the Antithesis tenant password on
-plutimus and accepts GitHub bearer tokens from clients such as
-`moog antithesis runs`.
+`moog-antithesis-proxy` exposes the Antithesis tenant read API behind GitHub
+team authorization. It keeps the Antithesis API key on plutimus and accepts
+GitHub bearer tokens from clients such as `moog antithesis runs`.
 
 ```mermaid
 flowchart LR
   CLI[moog antithesis runs] -->|GitHub bearer token| Traefik[Traefik on plutimus]
   Traefik --> Proxy[moog-antithesis-proxy]
   Proxy -->|whoami and team check| GitHub[GitHub API]
-  Proxy -->|server-side basic auth| Antithesis[Antithesis tenant API]
+  Proxy -->|server-side Bearer API key| Antithesis[Antithesis tenant API]
 ```
 
 ## Repository Artifacts
@@ -22,6 +21,19 @@ flowchart LR
 
 Pin `MOOG_VERSION` to a concrete commit or release tag. Do not deploy
 `latest`.
+
+## Upstream API model
+
+The proxy forwards `GET /api/v0/runs` (the live read endpoint per the
+`antithesis-api` skill) on the tenant host (`amaru-cardano.antithesis.com`
+by default), attaching the server-held Antithesis API key as
+`Authorization: Bearer <key>`. The API key is **different** from the
+`pragma:<password>` basic-auth pair `moog-agent` uses to call
+`POST /api/v1/launch/<launcher>`; the launch pair is not valid for the
+read API.
+
+Obtain the API key from Antithesis support or from your forward-deployed
+engineer.
 
 ## Plutimus Layout
 
@@ -36,21 +48,14 @@ Create the secrets layout:
 ```text
 /secrets/moog-antithesis-proxy/
   new/
-    secrets.yaml
-    antithesis-password
+    antithesis-api-key
   old/
-    secrets.yaml
-    antithesis-password
+    antithesis-api-key
 ```
 
-`secrets.yaml` mirrors the agent rotation discipline and carries:
-
-```yaml
-antithesisPassword: "<same value as moog-agent>"
-```
-
-`antithesis-password` is the plain-text value read by
-`MOOG_ANTITHESIS_PASSWORD_FILE`.
+`antithesis-api-key` is the plain-text value read by
+`MOOG_ANTITHESIS_API_KEY_FILE` (default
+`/run/secrets/antithesis-api-key`).
 
 ## Deploy
 
@@ -82,37 +87,44 @@ docker logs antithesis-proxy-moog-antithesis-proxy-1
 
 ```bash
 curl -i https://antithesis-proxy.plutimus.com/healthz
-curl -i https://antithesis-proxy.plutimus.com/api/v1/runs
+curl -i https://antithesis-proxy.plutimus.com/api/v0/runs
 curl -i -H 'Authorization: Bearer garbage' \
-  https://antithesis-proxy.plutimus.com/api/v1/runs
+  https://antithesis-proxy.plutimus.com/api/v0/runs
 curl -i -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-  https://antithesis-proxy.plutimus.com/api/v1/runs
+  https://antithesis-proxy.plutimus.com/api/v0/runs
 ```
 
 Expected results:
 
 - `/healthz` returns `200` with body `ok`.
-- `/api/v1/runs` without auth returns `401` and
+- `/api/v0/runs` without auth returns `401` and
   `WWW-Authenticate: Bearer realm="moog-antithesis-proxy"`.
-- `/api/v1/runs` with garbage auth returns `401`.
-- `/api/v1/runs` with a valid `pragma-org/antithesis-access` member token
-  returns `200` and an Antithesis JSON body.
+- `/api/v0/runs` with garbage auth returns `401`.
+- `/api/v0/runs` with a valid `pragma-org/antithesis-access` member token
+  returns `200` and the Antithesis runs JSON body.
+
+## Secret rotation
+
+Rotate the Antithesis API key by mirroring the `moog-agent` rotation
+pattern: write the new value to
+`/secrets/moog-antithesis-proxy/new/antithesis-api-key`, move the previous
+file to `old/`, then force-recreate the container.
+
+```bash
+read -rs KEY
+printf '%s' "$KEY" \
+  | sudo tee /secrets/moog-antithesis-proxy/new/antithesis-api-key >/dev/null
+unset KEY
+sudo chmod 0400 /secrets/moog-antithesis-proxy/new/antithesis-api-key
+cd /opt/hal/infrastructure/moog/antithesis-proxy
+MOOG_VERSION=<pinned-tag> sudo -E docker compose up -d --force-recreate moog-antithesis-proxy
+```
 
 ## Live Deployment Status
 
 The proxy is deployed and healthy on plutimus. Operators can verify the
 public health endpoint at
-`https://antithesis-proxy.plutimus.com/healthz`.
-
-As of the #115 deployment, three of the four acceptance curls validate the
-live auth gate: `/healthz` returns `200 ok`, unauthenticated `/api/v1/runs`
-returns the proxy's bearer challenge, and a garbage bearer token returns
-`401`. A valid team-member token resolves through GitHub as `login:paolino`
-in the proxy audit log, proving `whoami` and
-`pragma-org/antithesis-access` membership succeeded before forwarding.
-The forwarded `/api/v1/runs` request currently receives `403` from the
-Antithesis upstream because that tenant endpoint is not exposed yet. Track
-that Antithesis-side blocker in
-[issue #78](https://github.com/cardano-foundation/moog/issues/78).
-
-The full smoke script and failure-mode runbook are owned by #116.
+`https://antithesis-proxy.plutimus.com/healthz`. The full end-to-end smoke
+(device-flow login from a clean container + `moog antithesis runs`) is
+covered by the `antithesis-api` skill's `anti runs` flow once a member of
+`pragma-org/antithesis-access` has authorized the `moog` OAuth App.

--- a/src/Proxy/Antithesis/Application.hs
+++ b/src/Proxy/Antithesis/Application.hs
@@ -13,7 +13,6 @@ where
 
 import Control.Exception (SomeException, try)
 import Data.ByteString (ByteString)
-import Data.ByteString.Base64 qualified as Base64
 import Data.ByteString.Lazy qualified as LBS
 import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Maybe (fromMaybe)
@@ -95,7 +94,7 @@ proxyApplication config request respond =
                     else plain status503 "not ready"
                 )
                 respond
-        ("GET", ["api", "v1", "runs"]) -> do
+        ("GET", ["api", "v0", "runs"]) -> do
             authHandled <- newIORef False
             start <- getCurrentTime
             authMiddleware
@@ -157,9 +156,8 @@ productionApplication settings = do
                 , proxyRunsConfig =
                     RunsConfig
                         { runsAntithesisUrl = settingsAntithesisUrl settings
-                        , runsAntithesisUser = settingsAntithesisUser settings
-                        , runsAntithesisPassword =
-                            settingsAntithesisPassword settings
+                        , runsAntithesisApiKey =
+                            settingsAntithesisApiKey settings
                         , runsManager = manager
                         }
                 , proxyReadinessConfig =
@@ -173,7 +171,7 @@ productionReadinessConfig settings manager =
             probeEndpoint
                 manager
                 (antithesisRunsUrl settings)
-                [(hAuthorization, antithesisBasicAuthorization settings)]
+                [(hAuthorization, antithesisBearerAuthorization settings)]
         , readinessGitHub =
             probeEndpoint
                 manager
@@ -199,16 +197,11 @@ probeEndpoint manager url headers = do
 
 antithesisRunsUrl :: Settings -> String
 antithesisRunsUrl settings =
-    stripTrailingSlash (settingsAntithesisUrl settings) <> "/api/v1/runs"
+    stripTrailingSlash (settingsAntithesisUrl settings) <> "/api/v0/runs"
 
-antithesisBasicAuthorization :: Settings -> ByteString
-antithesisBasicAuthorization settings =
-    "Basic "
-        <> Base64.encode
-            ( settingsAntithesisUser settings
-                <> ":"
-                <> settingsAntithesisPassword settings
-            )
+antithesisBearerAuthorization :: Settings -> ByteString
+antithesisBearerAuthorization settings =
+    "Bearer " <> settingsAntithesisApiKey settings
 
 plain :: Status -> ByteString -> Response
 plain status body =

--- a/src/Proxy/Antithesis/Config.hs
+++ b/src/Proxy/Antithesis/Config.hs
@@ -20,8 +20,7 @@ data Settings = Settings
     { settingsBindAddr :: String
     , settingsBindPort :: Int
     , settingsAntithesisUrl :: String
-    , settingsAntithesisUser :: BC.ByteString
-    , settingsAntithesisPassword :: BC.ByteString
+    , settingsAntithesisApiKey :: BC.ByteString
     , settingsAuthorizedOrg :: Org
     , settingsAuthorizedTeam :: TeamSlug
     , settingsMembershipTtlSeconds :: Int
@@ -37,12 +36,12 @@ loadSettingsWith
     -> (FilePath -> IO BC.ByteString)
     -> IO Settings
 loadSettingsWith lookupSetting readSecret = do
-    passwordFile <-
+    apiKeyFile <-
         settingString
             lookupSetting
-            "MOOG_ANTITHESIS_PASSWORD_FILE"
-            "/run/secrets/antithesis-password"
-    password <- stripTrailingNewline <$> readSecret passwordFile
+            "MOOG_ANTITHESIS_API_KEY_FILE"
+            "/run/secrets/antithesis-api-key"
+    apiKey <- stripTrailingNewline <$> readSecret apiKeyFile
     Settings
         <$> settingString lookupSetting "MOOG_PROXY_BIND_ADDR" "0.0.0.0"
         <*> settingInt lookupSetting "MOOG_PROXY_BIND_PORT" 8080
@@ -50,13 +49,7 @@ loadSettingsWith lookupSetting readSecret = do
             lookupSetting
             "MOOG_ANTITHESIS_URL"
             "https://amaru-cardano.antithesis.com"
-        <*> ( BC.pack
-                <$> settingString
-                    lookupSetting
-                    "MOOG_ANTITHESIS_USER"
-                    "pragma"
-            )
-        <*> pure password
+        <*> pure apiKey
         <*> ( Org . T.pack
                 <$> settingString
                     lookupSetting

--- a/src/Proxy/Antithesis/Handler/Runs.hs
+++ b/src/Proxy/Antithesis/Handler/Runs.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Handler for proxying Antithesis run listings.
+--
+-- Forwards client `GET /api/v0/runs` to the same path on the Antithesis
+-- upstream, attaching the server-held Antithesis API key as a
+-- `Authorization: Bearer …` header.
 module Proxy.Antithesis.Handler.Runs
     ( RunsConfig (..)
     , runsHandler
@@ -10,7 +14,6 @@ where
 import Control.Monad (unless)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
-import Data.ByteString.Base64 qualified as Base64
 import Data.ByteString.Builder qualified as Builder
 import Data.ByteString.Char8 qualified as BC
 import Network.HTTP.Client
@@ -40,8 +43,7 @@ import Network.Wai
 
 data RunsConfig = RunsConfig
     { runsAntithesisUrl :: String
-    , runsAntithesisUser :: ByteString
-    , runsAntithesisPassword :: ByteString
+    , runsAntithesisApiKey :: ByteString
     , runsManager :: Manager
     }
 
@@ -52,7 +54,7 @@ runsHandler config request respond = do
         upstreamRequest
             { method = "GET"
             , requestHeaders =
-                [(hAuthorization, basicAuthorization config)]
+                [(hAuthorization, bearerAuthorization config)]
             }
         (runsManager config)
         $ \upstreamResponse ->
@@ -73,14 +75,12 @@ runsHandler config request respond = do
 runsUrl :: RunsConfig -> ByteString -> String
 runsUrl config query =
     stripTrailingSlash (runsAntithesisUrl config)
-        <> "/api/v1/runs"
+        <> "/api/v0/runs"
         <> BC.unpack query
 
-basicAuthorization :: RunsConfig -> ByteString
-basicAuthorization config =
-    "Basic "
-        <> Base64.encode
-            (runsAntithesisUser config <> ":" <> runsAntithesisPassword config)
+bearerAuthorization :: RunsConfig -> ByteString
+bearerAuthorization config =
+    "Bearer " <> runsAntithesisApiKey config
 
 forwardedHeaders :: [Header] -> [Header]
 forwardedHeaders =

--- a/src/User/Antithesis/ProxyClient.hs
+++ b/src/User/Antithesis/ProxyClient.hs
@@ -113,7 +113,7 @@ classifyResponse response =
 
 runsUrl :: ProxyUrl -> String
 runsUrl (ProxyUrl baseUrl) =
-    stripTrailingSlash baseUrl <> "/api/v1/runs"
+    stripTrailingSlash baseUrl <> "/api/v0/runs"
 
 stripTrailingSlash :: String -> String
 stripTrailingSlash =

--- a/test/Proxy/Antithesis/ApplicationSpec.hs
+++ b/test/Proxy/Antithesis/ApplicationSpec.hs
@@ -72,14 +72,14 @@ spec =
             simpleStatus response `shouldBe` status404
             simpleBody response `shouldBe` "not found"
 
-        it "protects and routes GET /api/v1/runs" $ do
+        it "protects and routes GET /api/v0/runs" $ do
             seenRef <- newIORef Nothing
             response <-
                 withUpstream (captureRuns seenRef) $ \baseUrl ->
                     runProxyAppWithUpstream
                         baseUrl
                         ( requestFor
-                            "/api/v1/runs"
+                            "/api/v0/runs"
                             [(hAuthorization, "Bearer gh-token")]
                         )
                             { rawQueryString = "?limit=2"
@@ -91,11 +91,11 @@ spec =
             seen
                 `shouldBe` Just
                     ( "?limit=2"
-                    , Just "Basic cHJhZ21hOnNlY3JldA=="
+                    , Just "Bearer test-api-key"
                     )
 
-        it "applies auth to GET /api/v1/runs" $ do
-            response <- runProxyApp True True (requestFor "/api/v1/runs" [])
+        it "applies auth to GET /api/v0/runs" $ do
+            response <- runProxyApp True True (requestFor "/api/v0/runs" [])
 
             simpleStatus response `shouldBe` status401
 
@@ -137,8 +137,7 @@ testApplication baseUrl antithesisReady githubReady = do
                 , proxyRunsConfig =
                     RunsConfig
                         { runsAntithesisUrl = baseUrl
-                        , runsAntithesisUser = "pragma"
-                        , runsAntithesisPassword = "secret"
+                        , runsAntithesisApiKey = "test-api-key"
                         , runsManager = manager
                         }
                 , proxyReadinessConfig =

--- a/test/Proxy/Antithesis/AuditSpec.hs
+++ b/test/Proxy/Antithesis/AuditSpec.hs
@@ -33,7 +33,7 @@ spec =
                         AuditEvent
                             { auditTimestamp = baseTime
                             , auditLogin = Just (Login "octocat")
-                            , auditPath = "/api/v1/runs"
+                            , auditPath = "/api/v0/runs"
                             , auditStatus = status200
                             , auditUpstreamStatus = Just status200
                             , auditLatencyMs = 12
@@ -44,7 +44,7 @@ spec =
             decoded rendered
                 `shouldBe` Right
                     ( "octocat"
-                    , "/api/v1/runs"
+                    , "/api/v0/runs"
                     , 200
                     , Just 200
                     , 12

--- a/test/Proxy/Antithesis/ConfigSpec.hs
+++ b/test/Proxy/Antithesis/ConfigSpec.hs
@@ -16,18 +16,17 @@ import Test.Hspec (Spec, describe, it, shouldBe)
 spec :: Spec
 spec =
     describe "Proxy.Antithesis.Config" $ do
-        it "loads documented defaults and reads the password file" $ do
+        it "loads documented defaults and reads the API key file" $ do
             settings <-
                 loadSettingsWith
                     (lookupEnvFrom [])
-                    (readFileFrom [("/run/secrets/antithesis-password", "secret\n")])
+                    (readFileFrom [("/run/secrets/antithesis-api-key", "secret\n")])
 
             settingsBindAddr settings `shouldBe` "0.0.0.0"
             settingsBindPort settings `shouldBe` 8080
             settingsAntithesisUrl settings
                 `shouldBe` "https://amaru-cardano.antithesis.com"
-            settingsAntithesisUser settings `shouldBe` "pragma"
-            settingsAntithesisPassword settings `shouldBe` "secret"
+            settingsAntithesisApiKey settings `shouldBe` "secret"
             settingsAuthorizedOrg settings `shouldBe` Org "pragma-org"
             settingsAuthorizedTeam settings `shouldBe` TeamSlug "antithesis-access"
             settingsMembershipTtlSeconds settings `shouldBe` 60
@@ -40,21 +39,19 @@ spec =
                         [ ("MOOG_PROXY_BIND_ADDR", "127.0.0.1")
                         , ("MOOG_PROXY_BIND_PORT", "19090")
                         , ("MOOG_ANTITHESIS_URL", "http://upstream")
-                        , ("MOOG_ANTITHESIS_USER", "tenant-user")
-                        , ("MOOG_ANTITHESIS_PASSWORD_FILE", "/tmp/pw")
+                        , ("MOOG_ANTITHESIS_API_KEY_FILE", "/tmp/key")
                         , ("MOOG_PROXY_AUTHORIZED_ORG", "my-org")
                         , ("MOOG_PROXY_AUTHORIZED_TEAM", "my-team")
                         , ("MOOG_PROXY_MEMBERSHIP_TTL_SEC", "5")
                         , ("MOOG_PROXY_LOG_LEVEL", "debug")
                         ]
                     )
-                    (readFileFrom [("/tmp/pw", "top-secret\n")])
+                    (readFileFrom [("/tmp/key", "top-secret\n")])
 
             settingsBindAddr settings `shouldBe` "127.0.0.1"
             settingsBindPort settings `shouldBe` 19090
             settingsAntithesisUrl settings `shouldBe` "http://upstream"
-            settingsAntithesisUser settings `shouldBe` "tenant-user"
-            settingsAntithesisPassword settings `shouldBe` "top-secret"
+            settingsAntithesisApiKey settings `shouldBe` "top-secret"
             settingsAuthorizedOrg settings `shouldBe` Org "my-org"
             settingsAuthorizedTeam settings `shouldBe` TeamSlug "my-team"
             settingsMembershipTtlSeconds settings `shouldBe` 5
@@ -67,4 +64,4 @@ readFileFrom :: [(FilePath, BC.ByteString)] -> FilePath -> IO BC.ByteString
 readFileFrom files path =
     case lookup path files of
         Just contents -> pure contents
-        Nothing -> fail $ "unexpected password file: " <> path
+        Nothing -> fail $ "unexpected secret file: " <> path

--- a/test/Proxy/Antithesis/Handler/RunsSpec.hs
+++ b/test/Proxy/Antithesis/Handler/RunsSpec.hs
@@ -37,7 +37,7 @@ import Test.Hspec (Spec, describe, it, shouldBe)
 spec :: Spec
 spec =
     describe "Proxy.Antithesis.Handler.Runs" $ do
-        it "forwards GET /api/v1/runs with query and basic auth" $ do
+        it "forwards GET /api/v0/runs with query and bearer auth" $ do
             seenRef <- newIORef Nothing
             response <-
                 withUpstream
@@ -54,7 +54,7 @@ spec =
             seen
                 `shouldBe` Just
                     ( "?limit=5&cursor=a%2Fb"
-                    , Just "Basic cHJhZ21hOnNlY3JldA=="
+                    , Just "Bearer test-api-key"
                     )
 
         it "sanitizes upstream 5xx bodies" $ do
@@ -78,8 +78,7 @@ runProxy baseUrl = do
         $ runsHandler
             RunsConfig
                 { runsAntithesisUrl = baseUrl
-                , runsAntithesisUser = "pragma"
-                , runsAntithesisPassword = "secret"
+                , runsAntithesisApiKey = "test-api-key"
                 , runsManager = manager
                 }
 


### PR DESCRIPTION
## Summary

The Antithesis read API is `GET /api/v0/runs` with `Authorization: Bearer <api-key>` — see the `antithesis-api` skill (used in production by `anti runs`, `antithesis-triage`, etc.). The proxy merged via epic #109 was wired for `/api/v1/runs` with basic-auth `pragma:<password>`, which is the shape `moog-agent` uses against `/api/v1/launch/<launcher>` and is **not** valid for the read API.

Direct verification from the deployed proxy host before this PR:

```
curl -u "pragma:$PW" https://amaru-cardano.antithesis.com/api/v1/runs → 403
curl -H "Authorization: Bearer $KEY" https://amaru-cardano.antithesis.com/api/v0/runs?limit=1 → 200 + real run data
```

## What changes

- `Proxy.Antithesis.Config` — drop `MOOG_ANTITHESIS_USER` and `MOOG_ANTITHESIS_PASSWORD_FILE`; add `MOOG_ANTITHESIS_API_KEY_FILE` (default `/run/secrets/antithesis-api-key`).
- `Proxy.Antithesis.Handler.Runs` — forward `/api/v0/runs`; attach `Authorization: Bearer <key>`.
- `Proxy.Antithesis.Application` — route `/api/v0/runs`; readiness probe uses `/api/v0/runs` with the Bearer key.
- `User.Antithesis.ProxyClient` — CLI hits `/api/v0/runs` on the proxy (kept transparent to clients other than the path bump).
- `docs/antithesis-proxy.compose.example.yaml` — env vars and secret-mount name updated.
- `docs/antithesis-proxy.md` — auth model section rewritten; secret name and acceptance curls updated; supersedes #115's runbook caveat and absorbs the deferred smoke from #116.
- `.github/workflows/docker-images.yaml` — Docker-image smoke test mounts `antithesis-api-key` instead of `antithesis-password`.
- Tests — `Proxy.Antithesis.{ConfigSpec, Handler.RunsSpec, ApplicationSpec, AuditSpec}` updated for the new shape; 209 examples pass locally.

## Why this slipped past epic #109

The epic body had this as an open question: "Does amaru-cardano.antithesis.com actually expose /api/v1/runs? Need to curl-verify before the daemon scaffold lands." It was deferred to #116's smoke and we never closed it. The `antithesis-api` skill — which documents the real shape — was in the available-skills list throughout the epic and was not loaded. The PR closes the gap and the epic together.

## Test plan

- [x] `./gate.sh` — 209/0 locally.
- [ ] Post-merge: rebuild + push `ghcr.io/cardano-foundation/moog/moog-antithesis-proxy` at the merge commit, redeploy on plutimus, swap `/secrets/moog-antithesis-proxy/new/antithesis-password` for `antithesis-api-key`, run `moog antithesis runs` end-to-end through the device flow.