### PR TITLE
fix(antithesis cli): emit valid JSON; drop trailing 'null' on streams

### DIFF
--- a/src/User/Antithesis/Cli.hs
+++ b/src/User/Antithesis/Cli.hs
@@ -50,7 +50,7 @@ import Servant.Client qualified as JsonClient (ClientM)
 import Servant.Client.Streaming qualified as Stream
 import Servant.API (SourceIO)
 import Data.ByteString (ByteString)
-import System.Exit (ExitCode (..), exitWith)
+import System.Exit (ExitCode (..), exitSuccess, exitWith)
 import System.IO (hPutStrLn, stderr, stdout)
 import User.Antithesis.Login
     ( defaultTokenFile
@@ -90,8 +90,12 @@ antithesisCmd = \case
     jc = antithesisProxyJsonClient
     sc = antithesisProxyStreamClient
 
--- | Run a JSON action via the regular 'Servant.Client.ClientM'.
--- Returns the decoded 'Aeson.Value' for the top-level Moog renderer.
+-- | Run a JSON action and write the response to stdout via 'Aeson.encode',
+-- then 'exitSuccess'. We bypass the canonical-JSON renderer in @Main@
+-- because 'Text.JSON.Canonical.renderCanonicalJSON' does not escape
+-- control characters inside string values, producing invalid JSON for
+-- any upstream payload whose strings contain embedded LF/CR (e.g.
+-- multi-line property descriptions).
 runJson :: JsonClient.ClientM Aeson.Value -> IO Aeson.Value
 runJson action = do
     proxyUrl <- proxyUrlFromEnv
@@ -102,14 +106,16 @@ runJson action = do
             (defaultTokenFile >>= evictCachedToken)
             action
     case result of
-        Right value -> pure value
+        Right value -> do
+            LBS8.putStrLn (Aeson.encode value)
+            exitSuccess
         Left err -> do
             hPutStrLn stderr $ renderClientErr err
             exitWith $ ExitFailure $ clientErrExitCode err
 
 -- | Drain a streaming action's 'SourceIO ByteString' directly to
--- stdout, byte-for-byte. Returns 'Aeson.Null' so the top-level renderer
--- emits nothing extra (the streamed bytes are the output).
+-- stdout, byte-for-byte, then 'exitSuccess' so the top-level renderer
+-- does not append a trailing @null@.
 runStream :: Stream.ClientM (SourceIO ByteString) -> IO Aeson.Value
 runStream action = do
     proxyUrl <- proxyUrlFromEnv
@@ -121,7 +127,7 @@ runStream action = do
             action
             (BS.hPut stdout)
     case result of
-        Right () -> pure Aeson.Null
+        Right () -> exitSuccess
         Left err -> do
             hPutStrLn stderr $ renderClientErr err
             exitWith $ ExitFailure $ clientErrExitCode err


### PR DESCRIPTION
## Summary

Two CLI output bugs surfaced while exercising the released `moog antithesis`
subcommands against the deployed proxy:

1. **`properties` (and any JSON cmd) produced invalid JSON.** The output
   routed through `Text.JSON.Canonical.renderCanonicalJSON`, which does not
   escape control characters inside string values. Any upstream payload
   containing embedded LF/CR (e.g. multi-line property descriptions)
   yielded output that `jq` rejected with
   `control characters from U+0000 through U+001F must be escaped`.

2. **Streaming cmds appended `null` after the NDJSON.** `runStream`
   returned `Aeson.Null` after draining; the top-level renderer printed
   `null\n`, breaking `jq -s` downstream.

## Fix

`runJson` now writes via `Aeson.encode` (always escapes control chars)
and `exitSuccess` directly. `runStream` `exitSuccess` after a clean
drain. Both bypass the canonical-JSON renderer for antithesis output.

## Test plan

- [x] `moog antithesis properties --run-id <completed>` → valid JSON,
      `jq type` returns `"object"`.
- [x] `moog antithesis events --run-id <completed> --q Block` → no
      trailing `null`; final line parses as JSON.
- [x] `moog antithesis properties --run-id <in-progress>` → exit 3
      (proxy 404), error on stderr.
- [x] `./gate.sh` → 213/213 pass.