### PR TITLE
chore(release): v0.5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog for moog-cli
 
+### v0.5.1.1 - 2026-05-30
+
+#### Fixed
+
+- **`moog antithesis` JSON output is now valid JSON.** The JSON
+  subcommands (`runs`, `run`, `properties`) routed through the
+  canonical-JSON renderer, which did not escape control characters
+  inside string values. Any upstream payload containing embedded
+  LF/CR (e.g. multi-line property descriptions) produced output that
+  `jq` rejected. The CLI now writes responses via `Aeson.encode`
+  (which always escapes control chars). (#136)
+- **Streaming subcommands no longer append a trailing `null`.**
+  `events`, `logs`, and `build-logs` previously printed `null` after
+  the NDJSON stream, which broke `jq -s` consumers. The CLI now
+  exits cleanly after the byte stream ends. (#136)
+
 ### v0.5.1.0 - 2026-05-29
 
 #### Added

--- a/moog.cabal
+++ b/moog.cabal
@@ -21,7 +21,7 @@ name:            moog
 -- PVP summary:     +-+------- breaking API changes
 --                  | | +----- non-breaking API additions
 --                  | | | +--- code changes with no API change
-version:         0.5.1.0
+version:         0.5.1.1
 
 -- A short (one-line) description of the package.
 synopsis:


### PR DESCRIPTION
Release v0.5.1.1 — hotfix for two CLI output bugs landed via #136.

- `moog antithesis` JSON commands now emit valid JSON (control chars
  escaped).
- Streaming commands no longer append a trailing `null` after the
  NDJSON stream.

Once merged: tag `v0.5.1.1` on `main`, create the GitHub release, and
attach tarballs via `CI/release.sh v0.5.1.1 {linux64,darwin64,linux-aarch64}`.