### PR TITLE
fix(138): finish terminal Antithesis runs without triage reports

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+nix build --quiet --no-link .#moog-agent .#unit-tests

--- a/gate.sh
+++ b/gate.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-git diff --check
-nix build --quiet --no-link .#moog-agent .#unit-tests

--- a/specs/138-terminal-antithesis-no-report/plan.md
+++ b/specs/138-terminal-antithesis-no-report/plan.md
@@ -1,0 +1,41 @@
+# Plan — #138
+
+## Tech stack
+
+Haskell, GHC 9.12.3 via haskell.nix. No new dependencies. Change is
+confined to the pure decision layer plus its single log site.
+
+## Modules touched
+
+- `src/User/Agent/Antithesis/State.hs` — `runningDecision`: add the
+  terminal-no-report policy and a deterministic synthetic-URL builder.
+- `src/User/Agent/Process.hs` — `executeRunningAction`: surface the
+  result URL in the publish log line (FR7).
+- `test/User/Agent/Antithesis/StateSpec.hs` — regression tests
+  (RED first).
+
+Downstream (`Plan.hs`, `Process.hs` finish path, `submitDone`) already
+handle `RunningFinish` generically — no new constructors needed.
+
+## Slices
+
+Single bisect-safe slice (S1):
+
+1. **RED** — add three `StateSpec` cases: `incomplete`+no-report and
+   `cancelled`+no-report expect `RunningFinish … OutcomeFailure` with the
+   `antithesis://runs/<id>/no-triage-report` URL; `completed`+no-report
+   expects `RunningWait` (renamed to state the policy). Watch them fail.
+2. **GREEN** — in `runningDecision`, when the run is terminal and the
+   report is absent, branch on a `noReportOutcome` policy: `incomplete`/
+   `cancelled` → `RunningFinish` with the synthetic URL; everything else
+   → `RunningWait`. Add the log-line URL in `Process.hs`.
+3. Gate: `nix build .#moog-agent .#unit-tests`, `just unit`,
+   `fourmolu -m check`, `hlint`.
+
+## Risk / verification note
+
+The change is pure reconciliation logic, fully covered by `StateSpec`.
+It does not touch the Antithesis launch payload, so the
+live-boundary-before-merge rule for launch changes does not apply. A live
+reconcile of the Leios run is a natural post-merge operator check, not a
+gate blocker.

--- a/specs/138-terminal-antithesis-no-report/spec.md
+++ b/specs/138-terminal-antithesis-no-report/spec.md
@@ -1,0 +1,67 @@
+# Spec — Finish terminal Antithesis runs without triage reports (#138)
+
+## P1 User Story
+
+As a MOOG operator, I run `moog-agent` against Antithesis API runs that
+reached a terminal off-chain state without a triage-report link, and I
+observe the on-chain test-run leave `accepted`/`running` state with an
+explicit failure attestation instead of remaining stuck forever.
+
+## Problem
+
+After #128 / #133, `moog-agent` reads Antithesis run state from
+`/api/v0/runs` but treats terminal API runs without `links.triage_report`
+as if they were still running. `runningDecision`
+(`src/User/Agent/Antithesis/State.hs`) only returns `RunningFinish` when
+*both* a terminal outcome *and* a report URL are present; every other case
+falls through to `RunningWait`, so a terminal-but-report-less run logs
+"still running according to Antithesis API" forever.
+
+Live evidence (2026-05-30): Antithesis run `4720e2cc…-54-7`,
+`status: incomplete`, `completed_at: 2026-05-27T17:08:46Z`, `links: {}`,
+on-chain test-run `42030238…` still `accepted`.
+
+## User Stories
+
+- **US1** — A terminal failure-class run (`incomplete`, `cancelled`)
+  without a report finishes on-chain as a failure, with a deterministic,
+  audit-friendly synthetic URL.
+- **US2** — A `completed` run without a report stays conservative (keeps
+  waiting); success is never attested without the report link.
+- **US3** — Agent logs no longer claim "still running" for terminal
+  no-report runs.
+
+## Functional Requirements
+
+- **FR1** — `runningDecision` maps a single matching run with
+  `status ∈ {incomplete, cancelled}` and **no** `triage_report` to
+  `RunningFinish run OutcomeFailure (URL "antithesis://runs/<run_id>/no-triage-report")`.
+- **FR2** — `runningDecision` maps a single matching run with
+  `status = completed` and **no** `triage_report` to `RunningWait`
+  (unchanged; documented as the conservative success policy).
+- **FR3** — Non-terminal statuses (`starting`, `in_progress`, `unknown`)
+  without a report keep returning `RunningWait`.
+- **FR4** — The with-report behaviour from #133 is preserved unchanged.
+- **FR5** — Duplicate-match runs keep returning `RunningDuplicate`
+  (fail-closed) regardless of report presence.
+- **FR6** — The synthetic URL is deterministic and depends only on the
+  Antithesis `run_id`.
+- **FR7** — The publish log line surfaces the result URL so terminal
+  no-report finishes are distinguishable from report-backed finishes and
+  from genuinely running runs.
+
+## Success Criteria
+
+- Regression test: `incomplete` + no report → `RunningFinish … OutcomeFailure …/no-triage-report`.
+- Regression test: `cancelled` + no report → `RunningFinish … OutcomeFailure …/no-triage-report`.
+- Regression test: `completed` + no report → `RunningWait` (named to state the policy).
+- `just unit`, `fourmolu -m check`, `hlint`, and `nix build .#moog-agent .#unit-tests` all green.
+- The Leios live case would reconcile from `accepted` to a terminal
+  on-chain failure without an email.
+
+## Non-goals
+
+- No Antithesis stop/cancel/delete support.
+- No email parsing for result synchronization.
+- No finishing of non-terminal API states.
+- No change to duplicate-run handling.

--- a/specs/138-terminal-antithesis-no-report/tasks.md
+++ b/specs/138-terminal-antithesis-no-report/tasks.md
@@ -1,0 +1,14 @@
+# Tasks — #138
+
+## Slice 1 — finish terminal no-report runs
+
+- [ ] T138-S1 RED: add StateSpec cases for `incomplete`+no-report and
+  `cancelled`+no-report → `RunningFinish … OutcomeFailure`
+  `antithesis://runs/<id>/no-triage-report`; rename the
+  `completed`+no-report case to state the conservative policy and assert
+  `RunningWait`.
+- [ ] T138-S1 GREEN: `runningDecision` terminal-no-report policy +
+  deterministic synthetic-URL builder in `State.hs`.
+- [ ] T138-S1 surface result URL in `Process.hs` publish log (FR7).
+- [ ] T138-S1 gate green: `nix build .#moog-agent .#unit-tests`,
+  `just unit`, `fourmolu -m check`, `hlint`.

--- a/specs/138-terminal-antithesis-no-report/tasks.md
+++ b/specs/138-terminal-antithesis-no-report/tasks.md
@@ -2,13 +2,13 @@
 
 ## Slice 1 — finish terminal no-report runs
 
-- [ ] T138-S1 RED: add StateSpec cases for `incomplete`+no-report and
+- [X] T138-S1 RED: add StateSpec cases for `incomplete`+no-report and
   `cancelled`+no-report → `RunningFinish … OutcomeFailure`
   `antithesis://runs/<id>/no-triage-report`; rename the
   `completed`+no-report case to state the conservative policy and assert
   `RunningWait`.
-- [ ] T138-S1 GREEN: `runningDecision` terminal-no-report policy +
+- [X] T138-S1 GREEN: `runningDecision` terminal-no-report policy +
   deterministic synthetic-URL builder in `State.hs`.
-- [ ] T138-S1 surface result URL in `Process.hs` publish log (FR7).
-- [ ] T138-S1 gate green: `nix build .#moog-agent .#unit-tests`,
+- [X] T138-S1 surface result URL in `Process.hs` publish log (FR7).
+- [X] T138-S1 gate green: `nix build .#moog-agent .#unit-tests`,
   `just unit`, `fourmolu -m check`, `hlint`.

--- a/specs/138-terminal-antithesis-no-report/tasks.md
+++ b/specs/138-terminal-antithesis-no-report/tasks.md
@@ -12,3 +12,12 @@
 - [X] T138-S1 surface result URL in `Process.hs` publish log (FR7).
 - [X] T138-S1 gate green: `nix build .#moog-agent .#unit-tests`,
   `just unit`, `fourmolu -m check`, `hlint`.
+
+## Slice 2 — live-derived regression (verification)
+
+- [X] T138-S2 capture real /api/v0/runs payload for the stuck Leios run
+  (incomplete, no `links` key) as `test/data/138-leios-incomplete-no-report.json`.
+- [X] T138-S2 StateSpec test drives the live fixture through `parseRunsPage` +
+  `runningDecision`, asserting `RunningFinish OutcomeFailure
+  antithesis://runs/4720e2cc…-54-7/no-triage-report`; also proves the
+  reconstructed TestRun hashes to the on-chain testRunId 42030238….

--- a/src/User/Agent/Antithesis/State.hs
+++ b/src/User/Agent/Antithesis/State.hs
@@ -114,11 +114,22 @@ runningDecision testRun runs =
     case matchingRuns testRun runs of
         [] -> RunningWait
         [run] ->
-            case (terminalOutcome $ antithesisRunStatus run, antithesisRunTriageReport run) of
-                (Just outcome, Just reportUrl) ->
-                    RunningFinish run outcome (URL $ T.unpack reportUrl)
-                _ ->
-                    RunningWait
+            case antithesisRunTriageReport run of
+                Just reportUrl ->
+                    case terminalOutcome $ antithesisRunStatus run of
+                        Just outcome ->
+                            RunningFinish run outcome (URL $ T.unpack reportUrl)
+                        Nothing -> RunningWait
+                Nothing ->
+                    -- Terminal API state with no triage-report link. Finish
+                    -- failure-class runs (incomplete, cancelled) on-chain with a
+                    -- deterministic synthetic URL so they do not stay accepted
+                    -- forever; stay conservative for completed (success is never
+                    -- attested without the report link) and for non-terminal.
+                    case terminalNoReportOutcome $ antithesisRunStatus run of
+                        Just outcome ->
+                            RunningFinish run outcome (noTriageReportUrl run)
+                        Nothing -> RunningWait
         matches -> RunningDuplicate matches
 
 terminalOutcome :: AntithesisRunStatus -> Maybe Outcome
@@ -129,6 +140,29 @@ terminalOutcome = \case
     RunStarting -> Nothing
     RunInProgress -> Nothing
     RunUnknown -> Nothing
+
+-- | Outcome for a terminal API run that has no triage-report link.
+-- Failure-class terminal states (incomplete, cancelled) are attested as
+-- failures so the on-chain run leaves accepted/running; completed stays
+-- conservative (success must not be attested without the report link), as do
+-- the non-terminal states.
+terminalNoReportOutcome :: AntithesisRunStatus -> Maybe Outcome
+terminalNoReportOutcome = \case
+    RunIncomplete -> Just OutcomeFailure
+    RunCancelled -> Just OutcomeFailure
+    RunCompleted -> Nothing
+    RunStarting -> Nothing
+    RunInProgress -> Nothing
+    RunUnknown -> Nothing
+
+-- | Deterministic, audit-friendly result URL for a run that reached a terminal
+-- API state without a triage report. Depends only on the run id.
+noTriageReportUrl :: AntithesisRun -> URL
+noTriageReportUrl run =
+    URL $
+        "antithesis://runs/"
+            <> T.unpack (antithesisRunId run)
+            <> "/no-triage-report"
 
 parseObjectTextField :: Text -> Maybe Value -> Parser (Maybe Text)
 parseObjectTextField _ Nothing = pure Nothing

--- a/src/User/Agent/Process.hs
+++ b/src/User/Agent/Process.hs
@@ -427,11 +427,14 @@ executeRunningAction opts = \case
                 ++ " is still running according to Antithesis API."
     RunningFinishObserved (Fact testRun testState _) run outcome url -> do
         let testId@(TestRunId trId) = mkTestRunId testRun
+            URL urlStr = url
         loggin
             $ "Publishing result for test-run "
                 ++ trId
                 ++ " from Antithesis API run "
                 ++ T.unpack (antithesisRunId run)
+                ++ " with result URL "
+                ++ urlStr
                 ++ "."
         eres <- submitDone opts testId (testRunDuration testState) outcome url
         case eres of

--- a/test/User/Agent/Antithesis/StateSpec.hs
+++ b/test/User/Agent/Antithesis/StateSpec.hs
@@ -8,7 +8,7 @@ where
 import Data.Aeson qualified as Aeson
 import Data.Text (Text)
 import Data.Text qualified as T
-import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe)
 import User.Agent.Antithesis.State
     ( AntithesisRun (..)
     , AntithesisRunStatus (..)
@@ -206,6 +206,42 @@ spec =
 
             runningDecision testRun [runA, runB]
                 `shouldBe` RunningDuplicate [runA, runB]
+
+        -- Live-derived regression: the real /api/v0/runs payload captured on
+        -- 2026-05-30 for the stuck Leios run (#138). The fixture has status
+        -- "incomplete" and NO "links" key at all (not even "links": {}). This
+        -- also exercises the real matching path: leiosTestRun must hash to the
+        -- on-chain testRunId 42030238… and render to the run's description.
+        it "finishes the live Leios incomplete run with no triage report" $ do
+            decoded <-
+                Aeson.eitherDecodeFileStrict
+                    "test/data/138-leios-incomplete-no-report.json"
+            value <- either (fail . ("fixture JSON: " <>)) pure decoded
+            page <- either (fail . ("parseRunsPage: " <>)) pure (parseRunsPage value)
+            case runsPageRuns page of
+                [observed] ->
+                    runningDecision leiosTestRun [observed]
+                        `shouldBe` RunningFinish
+                            observed
+                            OutcomeFailure
+                            ( URL
+                                "antithesis://runs/4720e2cc2382cf1c8581b9da13cdd26d-54-7/no-triage-report"
+                            )
+                other -> expectationFailure $ "expected one run, got " <> show other
+
+-- | Reconstructed on-chain test-run for the live Leios fixture (#138). Its
+-- fields must hash (via mkTestRunId) to testRunId 42030238… so matchingRuns
+-- pairs it with the captured Antithesis run.
+leiosTestRun :: TestRun
+leiosTestRun =
+    TestRun
+        { platform = Platform "github"
+        , repository = GithubRepository "input-output-hk" "ouroboros-leios"
+        , directory = Directory "antithesis/testnets/leios-devnet"
+        , commitId = Commit "76f3a47d8c236b8dd208c92593be54d9fe347b1e"
+        , tryIndex = Try 1
+        , requester = GithubUsername "wolf31o2"
+        }
 
 testRun :: TestRun
 testRun =

--- a/test/User/Agent/Antithesis/StateSpec.hs
+++ b/test/User/Agent/Antithesis/StateSpec.hs
@@ -140,11 +140,51 @@ spec =
                     OutcomeFailure
                     (URL "https://report.example/run-1")
 
-        it "waits instead of finishing when the report URL is absent" $ do
+        it "stays conservative on completed runs without a report URL" $ do
+            -- Success is never attested without the report link: a terminal
+            -- `completed` run missing `links.triage_report` keeps waiting.
             let observed =
                     run
                         "run-1"
                         RunCompleted
+                        (Just matchingDescription)
+                        Nothing
+
+            runningDecision testRun [observed] `shouldBe` RunningWait
+
+        it "finishes incomplete runs without a report as failure" $ do
+            let observed =
+                    run
+                        "run-1"
+                        RunIncomplete
+                        (Just matchingDescription)
+                        Nothing
+
+            runningDecision testRun [observed]
+                `shouldBe` RunningFinish
+                    observed
+                    OutcomeFailure
+                    (URL "antithesis://runs/run-1/no-triage-report")
+
+        it "finishes cancelled runs without a report as failure" $ do
+            let observed =
+                    run
+                        "run-1"
+                        RunCancelled
+                        (Just matchingDescription)
+                        Nothing
+
+            runningDecision testRun [observed]
+                `shouldBe` RunningFinish
+                    observed
+                    OutcomeFailure
+                    (URL "antithesis://runs/run-1/no-triage-report")
+
+        it "keeps waiting on non-terminal runs without a report" $ do
+            let observed =
+                    run
+                        "run-1"
+                        RunInProgress
                         (Just matchingDescription)
                         Nothing
 

--- a/test/data/138-leios-incomplete-no-report.json
+++ b/test/data/138-leios-incomplete-no-report.json
@@ -1,0 +1,14 @@
+{
+  "data": [
+    {
+      "run_id": "4720e2cc2382cf1c8581b9da13cdd26d-54-7",
+      "status": "incomplete",
+      "created_at": "2026-05-27T14:24:14Z",
+      "completed_at": "2026-05-27T17:08:46.310Z",
+      "parameters": {
+        "antithesis.description": "{\"testRun\":{\"commitId\":\"76f3a47d8c236b8dd208c92593be54d9fe347b1e\",\"directory\":\"antithesis/testnets/leios-devnet\",\"platform\":\"github\",\"repository\":{\"organization\":\"input-output-hk\",\"repo\":\"ouroboros-leios\"},\"requester\":\"wolf31o2\",\"try\":1,\"type\":\"test-run\"},\"testRunId\":\"42030238f291462e0853fb4a63d386601dee02b6aba27c47c3ffe54873aa06a0\"}"
+      }
+    }
+  ],
+  "next_cursor": null
+}


### PR DESCRIPTION
Resolves #138.

## Problem

After #128 / #133, `moog-agent` reads Antithesis run state from `/api/v0/runs`, but `runningDecision` (`src/User/Agent/Antithesis/State.hs`) only finishes a running on-chain test when the matching API run has **both** a terminal outcome **and** a `links.triage_report`. Any terminal run missing the report link falls through to `RunningWait`, so the agent logs *"still running according to Antithesis API"* forever and the on-chain state stays `accepted`.

Live case: Antithesis run `4720e2cc…-54-7` (`status: incomplete`, no `links` key) left on-chain test-run `42030238…` stuck in `accepted`.

## Fix

`runningDecision` now applies a terminal-no-report policy:

- `incomplete` / `cancelled` without report → finish on-chain as **failure** with a deterministic synthetic URL `antithesis://runs/<run_id>/no-triage-report`.
- `completed` without report → **stays conservative** (`RunningWait`): success is never attested without the report link. Documented in code + test name.
- Non-terminal states and the with-report behaviour from #133 are unchanged; duplicate handling stays fail-closed.

`executeRunningAction` now surfaces the result URL in the publish log so terminal no-report finishes are distinguishable from report-backed finishes and from genuinely running runs.

## Acceptance criteria

- [x] Regression test: `incomplete` + no report → finish as failure (not wait).
- [x] Regression test: `cancelled` + no report → finish as failure (not wait).
- [x] `completed` + no report stays conservative (documented).
- [x] Deterministic, audit-friendly URL `antithesis://runs/<run_id>/no-triage-report`.
- [x] Logs no longer say "still running" for `incomplete`/`cancelled`.
- [x] The Leios live case reconciles `accepted` → terminal failure (verified below).

## Live verification

Captured the **real** `/api/v0/runs` payload for `4720e2cc…-54-7` (status `incomplete`, no `links` key) as `test/data/138-leios-incomplete-no-report.json` and drove it through the production `parseRunsPage` + `runningDecision`:

- Decision = `RunningFinish … OutcomeFailure (URL "antithesis://runs/4720e2cc2382cf1c8581b9da13cdd26d-54-7/no-triage-report")`.
- The reconstructed `TestRun` hashes (via `mkTestRunId`) to the on-chain `testRunId 42030238…`, so `matchingRuns` pairs them — i.e. the live run would be reconciled.

No on-chain transaction was submitted: the actual failure-attestation submit is a production action under the agent wallet and is left for the operator to run the agent.

## Tests

`User.Agent.Antithesis.State`: 13/13 green (incl. the live-derived fixture). `nix build .#moog-agent .#unit-tests` green.

Spec / plan / tasks under `specs/138-terminal-antithesis-no-report/`.