### PR TITLE
chore(release): v0.5.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog for moog-cli
 
+### v0.5.1.2 - 2026-05-30
+
+#### Fixed
+
+- **Terminal Antithesis runs without a triage report now finish
+  on-chain instead of waiting forever.** `moog-agent` treated any API
+  run missing `links.triage_report` as still running, so a terminal
+  `incomplete`/`cancelled` run left its on-chain test-run stuck in
+  `accepted` indefinitely. The agent now finishes such failure-class
+  runs as `OutcomeFailure` with a deterministic synthetic URL
+  `antithesis://runs/<run_id>/no-triage-report`; `completed` without a
+  report stays conservative (it keeps waiting, since success must not be
+  attested without the report link). Agent logs no longer claim "still
+  running" for terminal runs. (#138)
+
 ### v0.5.1.1 - 2026-05-30
 
 #### Fixed

--- a/moog.cabal
+++ b/moog.cabal
@@ -21,7 +21,7 @@ name:            moog
 -- PVP summary:     +-+------- breaking API changes
 --                  | | +----- non-breaking API additions
 --                  | | | +--- code changes with no API change
-version:         0.5.1.1
+version:         0.5.1.2
 
 -- A short (one-line) description of the package.
 synopsis:


### PR DESCRIPTION
Release v0.5.1.2.

Bumps moog.cabal to 0.5.1.2 and adds the CHANGELOG section for the #138 fix (terminal Antithesis runs without a triage report now finish on-chain instead of waiting forever). The fix is already merged (#139) and deployed to the agent host; this cuts the formal release.

Merging this PR does not publish — pushing the v0.5.1.2 tag afterwards triggers release-tag.yaml.