### PR TITLE
chore: repin dev-assets to v0.1.0 tag

### DIFF
--- a/.github/workflows/E2E-test.yaml
+++ b/.github/workflows/E2E-test.yaml
@@ -46,7 +46,7 @@ jobs:
               sleep 2
           done
 
-      - uses: paolino/dev-assets/setup-nix@b901b08ce8d2e290d84e323486f7fa216b190df9
+      - uses: paolino/dev-assets/setup-nix@v0.1.0
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: paolino/dev-assets/setup-nix@b901b08ce8d2e290d84e323486f7fa216b190df9
+      - uses: paolino/dev-assets/setup-nix@v0.1.0
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix develop github:paolino/dev-assets?dir=mkdocs -c mkdocs build --strict

--- a/.github/workflows/darwin-release.yml
+++ b/.github/workflows/darwin-release.yml
@@ -101,7 +101,7 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build, smoke-test, and optionally publish Darwin Homebrew artifacts
-        uses: paolino/dev-assets/darwin-homebrew-release@b901b08ce8d2e290d84e323486f7fa216b190df9
+        uses: paolino/dev-assets/darwin-homebrew-release@v0.1.0
         with:
           mode: ${{ env.MODE }}
           tag: ${{ env.TAG }}

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - run: sudo rm -rf /opt&
       - uses: actions/checkout@v6
-      - uses: paolino/dev-assets/setup-nix@b901b08ce8d2e290d84e323486f7fa216b190df9
+      - uses: paolino/dev-assets/setup-nix@v0.1.0
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Build oracle docker image
@@ -67,7 +67,7 @@ jobs:
     steps:
       - run: sudo rm -rf /opt&
       - uses: actions/checkout@v6
-      - uses: paolino/dev-assets/setup-nix@b901b08ce8d2e290d84e323486f7fa216b190df9
+      - uses: paolino/dev-assets/setup-nix@v0.1.0
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Build oracle docker image

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -40,7 +40,7 @@ jobs:
               sleep 2
           done
 
-      - uses: paolino/dev-assets/setup-nix@b901b08ce8d2e290d84e323486f7fa216b190df9
+      - uses: paolino/dev-assets/setup-nix@v0.1.0
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 

--- a/.github/workflows/mpfs-v2-canary.yaml
+++ b/.github/workflows/mpfs-v2-canary.yaml
@@ -29,7 +29,7 @@ jobs:
           token: ${{ secrets.MOOG_GITHUB_PAT || github.token }}
           path: cardano-mpfs-offchain
 
-      - uses: paolino/dev-assets/setup-nix@b901b08ce8d2e290d84e323486f7fa216b190df9
+      - uses: paolino/dev-assets/setup-nix@v0.1.0
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 

--- a/.github/workflows/publish-site.yaml
+++ b/.github/workflows/publish-site.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: paolino/dev-assets/setup-nix@b901b08ce8d2e290d84e323486f7fa216b190df9
+      - uses: paolino/dev-assets/setup-nix@v0.1.0
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix --quiet develop github:paolino/dev-assets?dir=mkdocs -c mkdocs-deploy --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,11 +74,11 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag || github.ref }}
 
-      - uses: paolino/dev-assets/setup-nix@b901b08ce8d2e290d84e323486f7fa216b190df9
+      - uses: paolino/dev-assets/setup-nix@v0.1.0
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - uses: paolino/dev-assets/linux-release@b901b08ce8d2e290d84e323486f7fa216b190df9
+      - uses: paolino/dev-assets/linux-release@v0.1.0
         with:
           mode: >-
             ${{

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - run: sudo rm -rf /opt&
       - uses: actions/checkout@v6
-      - uses: paolino/dev-assets/setup-nix@b901b08ce8d2e290d84e323486f7fa216b190df9
+      - uses: paolino/dev-assets/setup-nix@v0.1.0
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
-      - uses: paolino/dev-assets/setup-nix@b901b08ce8d2e290d84e323486f7fa216b190df9
+      - uses: paolino/dev-assets/setup-nix@v0.1.0
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Assert the aarch64 GHC is cached (no source build)

--- a/flake.lock
+++ b/flake.lock
@@ -376,8 +376,8 @@
       },
       "original": {
         "owner": "paolino",
+        "ref": "v0.1.0",
         "repo": "dev-assets",
-        "rev": "b901b08ce8d2e290d84e323486f7fa216b190df9",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
       url = "github:NixOS/bundlers";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    dev-assets.url = "github:paolino/dev-assets/b901b08ce8d2e290d84e323486f7fa216b190df9";
+    dev-assets.url = "github:paolino/dev-assets/v0.1.0";
     iohkNix = {
       url = "github:input-output-hk/iohk-nix";
       inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Repins the `dev-assets` flake input and all GitHub Actions action pins from the raw commit SHA to the tagged release **v0.1.0** (https://github.com/paolino/dev-assets/releases/tag/v0.1.0), which points at the same proven commit `b901b08`.

Part of the release-harmonization epic closeout: paolino/dev-assets#28 (epic paolino/dev-assets#29). No behavioral change — same dev-assets commit, tag reference instead of raw SHA.