### PR TITLE
ci: run x86_64 Linux release builds on builder-new self-hosted runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,9 @@ concurrency:
 jobs:
   linux-bundles:
     name: Build Linux ${{ matrix.executable.name }} (${{ matrix.arch.id }})
-    runs-on: ${{ matrix.arch.runner }}
+    # x86_64 non-fork builds run on the self-hosted builder-new fleet (label: moog);
+    # fork PRs and aarch64 fall back to the matrix runner (GitHub-hosted).
+    runs-on: ${{ (matrix.arch.id == 'x86_64' && !github.event.pull_request.head.repo.fork) && fromJSON('["self-hosted","moog"]') || matrix.arch.runner }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Routes the x86_64 `linux-bundles` builds to the dedicated self-hosted runners on builder-new (label `moog`, 64 cores / 125 GB / 1.5 TB), ending the ~3h cold build on `ubuntu-latest`. Fork PRs and aarch64 fall back to GitHub-hosted runners (fork-guarded `runs-on`). 6 runners provisioned.