### PR TITLE
fix: remove broken oracle boot/end token commands + v2 migration banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog for moog-cli
 
+### v0.5.1.3 - 2026-06-01
+
+#### Fixed
+
+- **Removed the broken oracle `token boot` / `token end` commands.**
+  These were migrated to the new facts-only MPFS endpoints (`GET
+  /status`, `POST /facts/boot`, `POST /facts/end`), which the production
+  MPFS server (`https://mpfs.plutimus.com`) does not serve — every
+  invocation returned 404. The operator CLI no longer exposes them, so
+  the release advertises only operations that work against the
+  production server. The existing moog token and all other oracle,
+  requester, and agent operations are unaffected. The facts-only cutover
+  for the whole API continues on a dedicated `moog-v2` branch. (#144)
+
 ### v0.5.1.2 - 2026-05-30
 
 #### Fixed

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@
 [![Build docker images](https://github.com/cardano-foundation/moog/actions/workflows/docker-images.yaml/badge.svg)](https://github.com/cardano-foundation/moog/actions/workflows/docker-images.yaml)
 # Moog
 
+> **⚠️ Project state — MPFS v2 migration in progress.**
+> moog is migrating from the legacy MPFS HTTP API to the new facts-only MPFS
+> service ([cardano-mpfs-offchain](https://github.com/lambdasistemi/cardano-mpfs-offchain)),
+> where the server returns indexed *facts* and the client builds, signs, and
+> submits transactions. The current release (**v0.5.1.3**) runs against the
+> **legacy** MPFS server in production; the oracle `token boot` / `token end`
+> commands were removed because they already targeted the new API, which
+> production does not yet serve. The full client-side facts cutover is happening
+> on a long-lived **`moog-v2`** branch and will land as a single coordinated
+> release. **`main` is frozen during the migration** — see
+> [#144](https://github.com/cardano-foundation/moog/issues/144).
+
 Moog is for Cardano network components testing with Antithesis.
 
 ## Overview

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,17 @@
 !!! warning
     Moog is still at an early stage and experimental. Contributions and ideas are [most welcome](https://github.com/cardano-foundation/moog/).
 
+!!! info "MPFS v2 migration in progress"
+    moog is migrating from the legacy MPFS HTTP API to the new facts-only MPFS
+    service ([cardano-mpfs-offchain](https://github.com/lambdasistemi/cardano-mpfs-offchain)),
+    where the server returns indexed *facts* and the client builds, signs, and
+    submits transactions. The current release (**v0.5.1.3**) runs against the
+    **legacy** MPFS server in production; the oracle `token boot` / `token end`
+    commands were removed because they already targeted the new API, which
+    production does not yet serve. The full client-side facts cutover happens on
+    a long-lived **`moog-v2`** branch and will land as a single coordinated
+    release. **`main` is frozen during the migration.**
+
 # Moog
 
 **Testing Cardano on Cardano with Antithesis**

--- a/moog.cabal
+++ b/moog.cabal
@@ -21,7 +21,7 @@ name:            moog
 -- PVP summary:     +-+------- breaking API changes
 --                  | | +----- non-breaking API additions
 --                  | | | +--- code changes with no API change
-version:         0.5.1.2
+version:         0.5.1.3
 
 -- A short (one-line) description of the package.
 synopsis:

--- a/src/Oracle/Token/Options.hs
+++ b/src/Oracle/Token/Options.hs
@@ -31,7 +31,4 @@ tokenCommandParser =
                 <$> tokenIdOption
                 <*> walletOption
                 <*> many outputReferenceParser
-        , command "boot" "Boot a new token" $ Box . BootToken <$> walletOption
-        , command "end" "End the token"
-            $ fmap Box . EndToken <$> tokenIdOption <*> walletOption
         ]


### PR DESCRIPTION
Closes #144.

## Why

The shipped moog release talks to **two incompatible MPFS API surfaces from a single client**. The oracle `token boot` / `token end` commands were migrated to the new facts-only MPFS endpoints, but the production server still speaks the legacy API. Live probe of `https://mpfs.plutimus.com` (what the oracle/agent compose files target):

| Route | Used by | Result |
|---|---|---|
| `GET /status` | boot/end facts path (first call) | **404** |
| `POST /facts/boot` | `token boot` | **404** |
| `GET /tokens` | new-API list | 200 |
| `GET /wait/1` | legacy reads | 200 |

So `token boot` and `token end` fail with 404 on the first call, while every other operation (requester insert/delete/update, oracle `update-token`, token reads, submit/await) uses legacy routes the production server **does** serve.

## What this changes

1. **Remove the `boot`/`end` subcommands** from the oracle token parser (`src/Oracle/Token/Options.hs`). After this, `moog oracle token --help` lists only `update`. The operator can no longer invoke a command that 404s against production.
2. **Project-state banner** (`README.md`, `docs/index.md`) explaining the MPFS v2 migration: the current release runs against the legacy server, why boot/end were removed, that the full cutover happens on a long-lived `moog-v2` branch, and that `main` is frozen during the migration.
3. **Release bump** `moog.cabal` 0.5.1.2 → 0.5.1.3 + CHANGELOG.

I verified the blast radius: moog consumes `GET /status` (and `/facts/boot`, `/facts/end`) **only** in the boot/end facts path and the devnet-only `moog-mpfs-v2-canary` executable. Other `"status"` references are unrelated Antithesis-API JSON fields. Once boot/end are gone from the CLI, **no operator-reachable code path calls those routes against production** — the v0.5.1.3 CLI is internally consistent against a single server.

## What this deliberately keeps

The boot/end facts machinery — `MPFS.{API,Boot,End,Canary}`, the `mpfsBootToken`/`mpfsEndToken` record fields, and the `moog-mpfs-v2-canary` evidence executable — is **retained as groundwork** for the full facts-only cutover on the `moog-v2` branch. The `BootToken`/`EndToken` `TokenCommand` constructors and handlers stay (still used by the integration-test harness, which runs against a devnet server that serves the new endpoints). Only the operator-facing CLI surface is removed.

## Verification

- `fourmolu -m check` on the changed module: clean. `hlint`: No hints.
- No imports become unused.
- GitHub CI: build docs, unit tests, x86_64 + ARM64 docker images, aarch64 eval all green (integration/E2E are skipped on PRs by repo policy). The project dev shell could not be instantiated locally in this environment (cabal-fmt requires a network build), so build/test coverage is via CI.

## Commits

- `fix: remove broken oracle boot/end token commands`
- `chore(release): v0.5.1.3`
- `docs: add MPFS v2 migration project-state banner`