### PR TITLE
moog-v2: moog builds & submits its token facts client-side (#147)

### DIFF
--- a/.github/workflows/E2E-test.yaml
+++ b/.github/workflows/E2E-test.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+      - moog-v2
 
 jobs:
   integration-tests:

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - moog-v2
 
 jobs:
   docs:

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+      - moog-v2
 
 jobs:
   build:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+      - moog-v2
 
 jobs:
   integration-tests:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+      - moog-v2
 
 jobs:
 

--- a/cabal.project
+++ b/cabal.project
@@ -11,11 +11,13 @@ packages:
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-mpfs-offchain.git
-  tag: c33c1bdd658b725965c9f404ec0477dabea70de3
-  --sha256: 1almz2il76d4q3r5wby8lp5716xy3kz994n2idarqxm4z5qizih9
+  tag: c9eb9ea9acc6b928ec30d4fd6d88180811876147
+  --sha256: 156p4gl8lc8chgwr8arns12f109fafpan31l5dcyhbcyiy8nw499
   subdir:
     cardano-mpfs-api
+    cardano-mpfs-cage-tx
     cardano-mpfs-client
+    cardano-mpfs-verify
 
 repository cardano-haskell-packages
   url: https://chap.intersectmbo.org/

--- a/gate.sh
+++ b/gate.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-git diff --check
-nix build --quiet --no-link .#moog-agent
-nix --quiet run .#unit-tests

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+nix build --quiet --no-link .#moog-agent .#unit-tests

--- a/gate.sh
+++ b/gate.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-git diff --check
-nix build --quiet --no-link .#moog-agent .#unit-tests

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+nix build --quiet --no-link .#moog-agent
+nix --quiet run .#unit-tests

--- a/moog.cabal
+++ b/moog.cabal
@@ -134,6 +134,9 @@ library
     MPFS.Cage
     MPFS.Canary
     MPFS.End
+    MPFS.Request
+    MPFS.Retract
+    MPFS.Update
     Options
     Oracle.Cli
     Oracle.Config.Cli
@@ -498,6 +501,7 @@ test-suite unit-tests
     MockMPFS
     MPFS.BootSpec
     MPFS.CanarySpec
+    MPFS.WriteFactsSpec
     Oracle.Config.TypesSpec
     Oracle.TypesSpec
     Oracle.Validate.Requests.ConfigSpec

--- a/specs/147-mpfs-facts-foundation/plan.md
+++ b/specs/147-mpfs-facts-foundation/plan.md
@@ -1,0 +1,42 @@
+# Plan — #147 facts-only foundation
+
+## Tech stack
+
+Haskell + Servant client (`MPFS.API`), haskell.nix, `cardano-mpfs-offchain`
+(`cardano-mpfs-api`, `cardano-mpfs-client`, new `cage-tx`) pinned via
+`cabal.project` source-repository-package. Unit tests under `test/`.
+Gate: `nix build --quiet --no-link .#moog-agent .#unit-tests`.
+
+## Modules in scope
+
+- `cabal.project` — offchain pin.
+- `src/MPFS/API.hs` — facts endpoints + record.
+- `src/MPFS/*.hs` — client-side cage builders (new `Request.hs`/`Update.hs`/
+  `Retract.hs` mirroring `Boot.hs`/`End.hs`).
+- `src/Core/Types/MPFS.hs` — only if client wiring needs it.
+- `test/MPFS/*` — unit tests.
+
+## Slices (one bisect-safe commit each)
+
+### Slice S1 — pin cardano-mpfs-offchain to latest main
+Bump `cabal.project` tag → `c9eb9ea9acc6b928ec30d4fd6d88180811876147`,
+recompute `--sha256:` (nix32, via `nix flake prefetch` +
+`nix hash convert --to nix32`), add the new `cage-tx` subdir if the tip
+carves it. Proof: `./gate.sh` green. No unit test (dependency pin —
+RED-skip; proof is the build).
+
+### Slice S2 — token reads on /tokens/*
+RED: unit test decoding a `/tokens/:id` `TokenResponse` into moog's token
+view, and per-key `/tokens/:id/facts/:key`. GREEN: switch `getToken`/
+`getTokenFacts` clients to the new endpoints; adapt decode.
+
+### Slice S3 — client-side cage builders from facts + record wiring
+RED: unit tests asserting facts → unsigned tx for request insert/delete/
+update, update, retract. GREEN: implement the builders (mirroring
+boot/end), expose them on the `MPFS m` record. Legacy ops remain.
+
+## Order rationale
+
+S1 first — the new facts types must exist to build against. S2 before S3 —
+builders and validation read token state. S3 settles the record the flow
+children consume.

--- a/specs/147-mpfs-facts-foundation/spec.md
+++ b/specs/147-mpfs-facts-foundation/spec.md
@@ -1,0 +1,48 @@
+# Spec — #147 moog builds & submits its token facts client-side
+
+Parent epic: #146. Branch base: `moog-v2`. PR target: `moog-v2`.
+
+## P1 user story
+
+As a moog operator, when I run any token-mutating command, moog fetches
+MPFS *facts* and builds, signs, and submits the transaction client-side,
+reading token state from the new `/tokens/*` endpoints.
+
+## Context
+
+This is the foundation child of the moog-v2 cutover. It does not switch
+any requester/oracle/agent flow yet; it lays the reusable mechanism the
+flow children (#148–#150) build on, generalizing the boot/end facts
+pattern already present in `MPFS.{API,Boot,End}`.
+
+## Functional requirements
+
+- FR1 — `cabal.project` pins `cardano-mpfs-offchain` (subdirs incl. any
+  new `cage-tx` package) to the latest `main`
+  (`c9eb9ea9acc6b928ec30d4fd6d88180811876147`) with an updated nix32
+  `--sha256:`. The project builds against it.
+- FR2 — moog reads token state via `GET /tokens/:id` (replacing legacy
+  `token/:id`) and per-key facts via `GET /tokens/:id/facts/:key`.
+- FR3 — client-side cage tx builders exist for request insert/delete/
+  update, update, and retract, each producing an unsigned tx from
+  server-returned facts (mirroring `bootTokenFromFacts`/`endTokenFromFacts`).
+- FR4 — the `MPFS m` record exposes these facts-based operations; legacy
+  operations remain (deleted later in #151).
+
+## Success criteria
+
+- Unit tests prove facts → unsigned tx for each new builder, and decode
+  of `/tokens/:id` `TokenResponse`.
+- `./gate.sh` green at HEAD (`nix build .#moog-agent .#unit-tests`).
+- No requester/oracle/agent flow behavior changed; boot/end pattern
+  generalized, not duplicated.
+
+## Non-goals
+
+- Switching role flows (#148–#150) or deleting legacy routes (#151).
+- `/facts/reject`, `/tx/sweep` (out of epic scope).
+
+## Inherited invariants (from #146)
+
+- Facts-only, client-side tx construction; external-signing model.
+- Do not reshape concerns owned elsewhere; PR targets `moog-v2`.

--- a/specs/147-mpfs-facts-foundation/spec.md
+++ b/specs/147-mpfs-facts-foundation/spec.md
@@ -21,7 +21,7 @@ pattern already present in `MPFS.{API,Boot,End}`.
   new `cage-tx` package) to the latest `main`
   (`c9eb9ea9acc6b928ec30d4fd6d88180811876147`) with an updated nix32
   `--sha256:`. The project builds against it.
-- FR2 — moog reads token state via `GET /tokens/:id` (replacing legacy
+- FR2 — (SPLIT to #155) moog reads token state via `GET /tokens/:id` (replacing legacy
   `token/:id`) and per-key facts via `GET /tokens/:id/facts/:key`.
 - FR3 — client-side cage tx builders exist for request insert/delete/
   update, update, and retract, each producing an unsigned tx from

--- a/specs/147-mpfs-facts-foundation/tasks.md
+++ b/specs/147-mpfs-facts-foundation/tasks.md
@@ -3,8 +3,7 @@
 ## Slice S1 — pin cardano-mpfs-offchain to latest main
 - [X] T147-S1 Bump `cabal.project` offchain tag to `c9eb9ea` + nix32 `--sha256:`; add new `cage-tx` subdir if present; `./gate.sh` green.
 
-## Slice S2 — token reads on /tokens/* (BLOCKED on offchain #305 + #243 read-side verification; writes-first per epic decision)
-- [ ] T147-S2 RED unit test for `/tokens/:id` (`TokenResponse`) + `/tokens/:id/facts/:key` decode; GREEN switch `getToken`/`getTokenFacts` to the new endpoints; `./gate.sh` green.
+## Slice S2 — token reads on /tokens/* — SPLIT OUT to #155 (blocked on offchain #305 + #243); not part of this PR
 
 ## Slice S3 — client-side cage builders from facts + record wiring
 - [X] T147-S3 RED unit tests facts→unsigned-tx for request insert/delete/update, update, retract; GREEN implement builders + expose on `MPFS m` record (legacy retained); `./gate.sh` green.

--- a/specs/147-mpfs-facts-foundation/tasks.md
+++ b/specs/147-mpfs-facts-foundation/tasks.md
@@ -3,8 +3,8 @@
 ## Slice S1 — pin cardano-mpfs-offchain to latest main
 - [X] T147-S1 Bump `cabal.project` offchain tag to `c9eb9ea` + nix32 `--sha256:`; add new `cage-tx` subdir if present; `./gate.sh` green.
 
-## Slice S2 — token reads on /tokens/*
+## Slice S2 — token reads on /tokens/* (BLOCKED on offchain #305 + #243 read-side verification; writes-first per epic decision)
 - [ ] T147-S2 RED unit test for `/tokens/:id` (`TokenResponse`) + `/tokens/:id/facts/:key` decode; GREEN switch `getToken`/`getTokenFacts` to the new endpoints; `./gate.sh` green.
 
 ## Slice S3 — client-side cage builders from facts + record wiring
-- [ ] T147-S3 RED unit tests facts→unsigned-tx for request insert/delete/update, update, retract; GREEN implement builders + expose on `MPFS m` record (legacy retained); `./gate.sh` green.
+- [X] T147-S3 RED unit tests facts→unsigned-tx for request insert/delete/update, update, retract; GREEN implement builders + expose on `MPFS m` record (legacy retained); `./gate.sh` green.

--- a/specs/147-mpfs-facts-foundation/tasks.md
+++ b/specs/147-mpfs-facts-foundation/tasks.md
@@ -1,0 +1,10 @@
+# Tasks — #147 facts-only foundation
+
+## Slice S1 — pin cardano-mpfs-offchain to latest main
+- [ ] T147-S1 Bump `cabal.project` offchain tag to `c9eb9ea` + nix32 `--sha256:`; add new `cage-tx` subdir if present; `./gate.sh` green.
+
+## Slice S2 — token reads on /tokens/*
+- [ ] T147-S2 RED unit test for `/tokens/:id` (`TokenResponse`) + `/tokens/:id/facts/:key` decode; GREEN switch `getToken`/`getTokenFacts` to the new endpoints; `./gate.sh` green.
+
+## Slice S3 — client-side cage builders from facts + record wiring
+- [ ] T147-S3 RED unit tests facts→unsigned-tx for request insert/delete/update, update, retract; GREEN implement builders + expose on `MPFS m` record (legacy retained); `./gate.sh` green.

--- a/specs/147-mpfs-facts-foundation/tasks.md
+++ b/specs/147-mpfs-facts-foundation/tasks.md
@@ -1,7 +1,7 @@
 # Tasks — #147 facts-only foundation
 
 ## Slice S1 — pin cardano-mpfs-offchain to latest main
-- [ ] T147-S1 Bump `cabal.project` offchain tag to `c9eb9ea` + nix32 `--sha256:`; add new `cage-tx` subdir if present; `./gate.sh` green.
+- [X] T147-S1 Bump `cabal.project` offchain tag to `c9eb9ea` + nix32 `--sha256:`; add new `cage-tx` subdir if present; `./gate.sh` green.
 
 ## Slice S2 — token reads on /tokens/*
 - [ ] T147-S2 RED unit test for `/tokens/:id` (`TokenResponse`) + `/tokens/:id/facts/:key` decode; GREEN switch `getToken`/`getTokenFacts` to the new endpoints; `./gate.sh` green.

--- a/src/MPFS/API.hs
+++ b/src/MPFS/API.hs
@@ -3,10 +3,15 @@ module MPFS.API
     , TokenAPI
     , SubmitV2Body (..)
     , requestInsert
+    , requestInsertFromFacts
     , requestDelete
+    , requestDeleteFromFacts
     , requestUpdate
+    , requestUpdateFromFacts
     , retractChange
+    , retractChangeFromFacts
     , updateToken
+    , updateTokenFromFacts
     , getToken
     , getTokenV2
     , getTokenFacts
@@ -27,31 +32,42 @@ module MPFS.API
 import Cardano.MPFS.API.Types
     ( BootFacts
     , BootRequest
+    , DeleteRequest
     , EndFacts
     , EndRequest
+    , InsertRequest
+    , RequestDeleteFacts
+    , RequestInsertFacts
+    , RequestUpdateFacts
+    , RetractFacts
+    , RetractRequest
     , StatusResponse
+    , UpdateRequest
+    , UpdateValueRequest
     )
+import Cardano.MPFS.API.Types.Facts (UpdateFacts)
 import Control.Monad (void)
 import Core.Types.Basic (Address, RequestRefId, TokenId)
 import Core.Types.Tx (SignedTx (..), TxHash (..), WithUnsignedTx)
 import Data.Aeson
-    ( FromJSON (..)
-    , ToJSON (..)
+    ( ToJSON (..)
     , Value (..)
     , object
-    , withObject
-    , (.:)
     , (.=)
     )
 import Data.Data (Proxy (..))
 import Data.Text (Text)
-import Lib.JSON.Canonical.Extra
-    ( fromAesonString
-    , fromAesonThrow
-    , toAesonString
-    )
+import Lib.JSON.Canonical.Extra (fromAesonThrow)
 import MPFS.Boot (bootTokenFromFacts)
 import MPFS.End (endTokenFromFacts)
+import MPFS.Request
+    ( RequestDeleteBody (..)
+    , RequestInsertBody (..)
+    , RequestUpdateBody (..)
+    )
+import MPFS.Request qualified as Request
+import MPFS.Retract qualified as Retract
+import MPFS.Update qualified as Update
 import Servant.API
     ( Capture
     , Get
@@ -70,63 +86,6 @@ import Servant.Client (ClientM, client)
 import Text.JSON.Canonical
     ( JSValue (..)
     )
-
-data RequestInsertBody = RequestInsertBody
-    { key :: JSValue
-    , value :: JSValue
-    }
-
-instance ToJSON RequestInsertBody where
-    toJSON (RequestInsertBody k v) =
-        object
-            [ "key" .= toAesonString k
-            , "newValue" .= toAesonString v
-            ]
-
-instance FromJSON RequestInsertBody where
-    parseJSON = withObject "RequestInsertBody" $ \o ->
-        RequestInsertBody
-            <$> (o .: "key" >>= fromAesonString)
-            <*> (o .: "newValue" >>= fromAesonString)
-
-data RequestDeleteBody = RequestDeleteBody
-    { key :: JSValue
-    , value :: JSValue
-    }
-
-instance ToJSON RequestDeleteBody where
-    toJSON (RequestDeleteBody k v) =
-        object
-            [ "key" .= toAesonString k
-            , "oldValue" .= toAesonString v
-            ]
-
-instance FromJSON RequestDeleteBody where
-    parseJSON = withObject "RequestDeleteBody" $ \o ->
-        RequestDeleteBody
-            <$> (o .: "key" >>= fromAesonString)
-            <*> (o .: "oldValue" >>= fromAesonString)
-
-data RequestUpdateBody = RequestUpdateBody
-    { key :: JSValue
-    , oldValue :: JSValue
-    , newValue :: JSValue
-    }
-
-instance ToJSON RequestUpdateBody where
-    toJSON (RequestUpdateBody k old new) =
-        object
-            [ "key" .= toAesonString k
-            , "oldValue" .= toAesonString old
-            , "newValue" .= toAesonString new
-            ]
-
-instance FromJSON RequestUpdateBody where
-    parseJSON = withObject "RequestUpdateBody" $ \o ->
-        RequestUpdateBody
-            <$> (o .: "key" >>= fromAesonString)
-            <*> (o .: "oldValue" >>= fromAesonString)
-            <*> (o .: "newValue" >>= fromAesonString)
 
 newtype SubmitV2Body = SubmitV2Body SignedTx
 
@@ -149,6 +108,39 @@ type EndFactsEndpoint =
         :> "end"
         :> ReqBody '[JSON] EndRequest
         :> Post '[JSON] EndFacts
+
+type RequestInsertFactsEndpoint =
+    "facts"
+        :> "request"
+        :> "insert"
+        :> ReqBody '[JSON] InsertRequest
+        :> Post '[JSON] RequestInsertFacts
+
+type RequestDeleteFactsEndpoint =
+    "facts"
+        :> "request"
+        :> "delete"
+        :> ReqBody '[JSON] DeleteRequest
+        :> Post '[JSON] RequestDeleteFacts
+
+type RequestUpdateFactsEndpoint =
+    "facts"
+        :> "request"
+        :> "update"
+        :> ReqBody '[JSON] UpdateValueRequest
+        :> Post '[JSON] RequestUpdateFacts
+
+type UpdateFactsEndpoint =
+    "facts"
+        :> "update"
+        :> ReqBody '[JSON] UpdateRequest
+        :> Post '[JSON] UpdateFacts
+
+type RetractFactsEndpoint =
+    "facts"
+        :> "retract"
+        :> ReqBody '[JSON] RetractRequest
+        :> Post '[JSON] RetractFacts
 
 type EndToken =
     "transaction"
@@ -296,6 +288,42 @@ updateToken
 updateToken address tokenId requests =
     fmap fromAesonThrow <$> updateToken' address tokenId requests
 
+requestInsertFromFacts
+    :: Address
+    -> TokenId
+    -> RequestInsertBody
+    -> ClientM (WithUnsignedTx JSValue)
+requestInsertFromFacts =
+    Request.requestInsertFromFacts status' requestInsertFacts'
+
+requestDeleteFromFacts
+    :: Address
+    -> TokenId
+    -> RequestDeleteBody
+    -> ClientM (WithUnsignedTx JSValue)
+requestDeleteFromFacts =
+    Request.requestDeleteFromFacts status' requestDeleteFacts'
+
+requestUpdateFromFacts
+    :: Address
+    -> TokenId
+    -> RequestUpdateBody
+    -> ClientM (WithUnsignedTx JSValue)
+requestUpdateFromFacts =
+    Request.requestUpdateFromFacts status' requestUpdateFacts'
+
+updateTokenFromFacts
+    :: Address
+    -> TokenId
+    -> ClientM (WithUnsignedTx JSValue)
+updateTokenFromFacts =
+    Update.updateTokenFromFacts status' updateFacts'
+
+retractChangeFromFacts
+    :: Address -> RequestRefId -> ClientM (WithUnsignedTx JSValue)
+retractChangeFromFacts =
+    Retract.retractChangeFromFacts status' retractFacts'
+
 getToken :: TokenId -> ClientM JSValue
 getToken tokenId = fromAesonThrow <$> getToken' tokenId
 
@@ -375,6 +403,26 @@ endFacts' :: EndRequest -> ClientM EndFacts
 endFacts' =
     client (Proxy :: Proxy EndFactsEndpoint)
 
+requestInsertFacts' :: InsertRequest -> ClientM RequestInsertFacts
+requestInsertFacts' =
+    client (Proxy :: Proxy RequestInsertFactsEndpoint)
+
+requestDeleteFacts' :: DeleteRequest -> ClientM RequestDeleteFacts
+requestDeleteFacts' =
+    client (Proxy :: Proxy RequestDeleteFactsEndpoint)
+
+requestUpdateFacts' :: UpdateValueRequest -> ClientM RequestUpdateFacts
+requestUpdateFacts' =
+    client (Proxy :: Proxy RequestUpdateFactsEndpoint)
+
+updateFacts' :: UpdateRequest -> ClientM UpdateFacts
+updateFacts' =
+    client (Proxy :: Proxy UpdateFactsEndpoint)
+
+retractFacts' :: RetractRequest -> ClientM RetractFacts
+retractFacts' =
+    client (Proxy :: Proxy RetractFactsEndpoint)
+
 getTokenV2' =
     client (Proxy :: Proxy GetTokenV2)
 
@@ -394,6 +442,11 @@ mpfsClient =
         , mpfsRequestUpdate = requestUpdate
         , mpfsRetractChange = retractChange
         , mpfsUpdateToken = updateToken
+        , mpfsRequestInsertFromFacts = requestInsertFromFacts
+        , mpfsRequestDeleteFromFacts = requestDeleteFromFacts
+        , mpfsRequestUpdateFromFacts = requestUpdateFromFacts
+        , mpfsRetractChangeFromFacts = retractChangeFromFacts
+        , mpfsUpdateTokenFromFacts = updateTokenFromFacts
         , mpfsGetToken = getToken
         , mpfsGetTokenFacts = getTokenFacts
         , mpfsSubmitTransaction = submitTransaction
@@ -427,6 +480,29 @@ data MPFS m = MPFS
         :: Address
         -> TokenId
         -> [RequestRefId]
+        -> m (WithUnsignedTx JSValue)
+    , mpfsRequestInsertFromFacts
+        :: Address
+        -> TokenId
+        -> RequestInsertBody
+        -> m (WithUnsignedTx JSValue)
+    , mpfsRequestDeleteFromFacts
+        :: Address
+        -> TokenId
+        -> RequestDeleteBody
+        -> m (WithUnsignedTx JSValue)
+    , mpfsRequestUpdateFromFacts
+        :: Address
+        -> TokenId
+        -> RequestUpdateBody
+        -> m (WithUnsignedTx JSValue)
+    , mpfsRetractChangeFromFacts
+        :: Address
+        -> RequestRefId
+        -> m (WithUnsignedTx JSValue)
+    , mpfsUpdateTokenFromFacts
+        :: Address
+        -> TokenId
         -> m (WithUnsignedTx JSValue)
     , mpfsGetToken :: TokenId -> m JSValue
     , mpfsGetTokenFacts :: TokenId -> m JSValue

--- a/src/MPFS/Request.hs
+++ b/src/MPFS/Request.hs
@@ -1,0 +1,261 @@
+module MPFS.Request
+    ( RequestInsertBody (..)
+    , RequestDeleteBody (..)
+    , RequestUpdateBody (..)
+    , requestInsertFromFacts
+    , requestDeleteFromFacts
+    , requestUpdateFromFacts
+    , requestInsertFactsRequest
+    , requestDeleteFactsRequest
+    , requestUpdateFactsRequest
+    ) where
+
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types
+    ( DeleteRequest (..)
+    , InsertRequest (..)
+    , RequestDeleteFacts
+    , RequestInsertFacts
+    , RequestUpdateFacts
+    , StatusResponse (..)
+    , UpdateValueRequest (..)
+    )
+import Cardano.MPFS.API.Types.Common (TokenIdJSON)
+import Cardano.MPFS.Client.Cage.Request
+    ( requestDeleteCageTx
+    , requestInsertCageTx
+    , requestUpdateCageTx
+    )
+import Cardano.MPFS.Client.Facts
+    ( verifyRequestDeleteFacts
+    , verifyRequestInsertFacts
+    , verifyRequestUpdateFacts
+    )
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Control.Monad.IO.Class (liftIO)
+import Core.Types.Basic
+    ( Address
+    , TokenId
+    )
+import Core.Types.Tx
+    ( UnsignedTx (..)
+    , WithUnsignedTx (..)
+    )
+import Data.Aeson
+    ( FromJSON (..)
+    , ToJSON (..)
+    , object
+    , withObject
+    , (.:)
+    , (.=)
+    )
+import Data.ByteString.Lazy qualified as BL
+import Lib.JSON.Canonical.Extra
+    ( fromAesonString
+    , toAesonString
+    )
+import MPFS.Cage
+    ( addressBytesForCage
+    , liftEitherClientM
+    , loadCageConfig
+    , txHex
+    , walletPolicy
+    )
+import MPFS.End (tokenIdJSONFromTokenId)
+import Servant.Client (ClientM)
+import Text.JSON.Canonical
+    ( JSValue
+    , renderCanonicalJSON
+    )
+
+data RequestInsertBody = RequestInsertBody
+    { key :: JSValue
+    , value :: JSValue
+    }
+
+instance ToJSON RequestInsertBody where
+    toJSON (RequestInsertBody k v) =
+        object
+            [ "key" .= toAesonString k
+            , "newValue" .= toAesonString v
+            ]
+
+instance FromJSON RequestInsertBody where
+    parseJSON = withObject "RequestInsertBody" $ \o ->
+        RequestInsertBody
+            <$> (o .: "key" >>= fromAesonString)
+            <*> (o .: "newValue" >>= fromAesonString)
+
+data RequestDeleteBody = RequestDeleteBody
+    { key :: JSValue
+    , value :: JSValue
+    }
+
+instance ToJSON RequestDeleteBody where
+    toJSON (RequestDeleteBody k v) =
+        object
+            [ "key" .= toAesonString k
+            , "oldValue" .= toAesonString v
+            ]
+
+instance FromJSON RequestDeleteBody where
+    parseJSON = withObject "RequestDeleteBody" $ \o ->
+        RequestDeleteBody
+            <$> (o .: "key" >>= fromAesonString)
+            <*> (o .: "oldValue" >>= fromAesonString)
+
+data RequestUpdateBody = RequestUpdateBody
+    { key :: JSValue
+    , oldValue :: JSValue
+    , newValue :: JSValue
+    }
+
+instance ToJSON RequestUpdateBody where
+    toJSON (RequestUpdateBody k old new) =
+        object
+            [ "key" .= toAesonString k
+            , "oldValue" .= toAesonString old
+            , "newValue" .= toAesonString new
+            ]
+
+instance FromJSON RequestUpdateBody where
+    parseJSON = withObject "RequestUpdateBody" $ \o ->
+        RequestUpdateBody
+            <$> (o .: "key" >>= fromAesonString)
+            <*> (o .: "oldValue" >>= fromAesonString)
+            <*> (o .: "newValue" >>= fromAesonString)
+
+requestInsertFromFacts
+    :: ClientM StatusResponse
+    -> (InsertRequest -> ClientM RequestInsertFacts)
+    -> Address
+    -> TokenId
+    -> RequestInsertBody
+    -> ClientM (WithUnsignedTx JSValue)
+requestInsertFromFacts getStatus postFacts address tokenId body = do
+    request <-
+        liftEitherClientM
+            $ requestInsertFactsRequest address tokenId body
+    StatusResponse{currentUtxoRoot} <- getStatus
+    trustedRoot <-
+        liftEitherClientM $ maybeToEither noUtxoRoot currentUtxoRoot
+    facts <- postFacts request
+    verified <-
+        liftEitherClientM
+            $ firstShow
+            $ verifyRequestInsertFacts (TrustedRoot trustedRoot) facts
+    rawAddress <- liftEitherClientM $ addressBytesForCage address
+    cfg <- liftIO $ loadCageConfig rawAddress
+    tx <-
+        liftEitherClientM
+            $ firstShow
+            $ requestInsertCageTx cfg walletPolicy verified
+    pure $ WithUnsignedTx (UnsignedTx $ txHex tx) Nothing
+
+requestDeleteFromFacts
+    :: ClientM StatusResponse
+    -> (DeleteRequest -> ClientM RequestDeleteFacts)
+    -> Address
+    -> TokenId
+    -> RequestDeleteBody
+    -> ClientM (WithUnsignedTx JSValue)
+requestDeleteFromFacts getStatus postFacts address tokenId body = do
+    request <-
+        liftEitherClientM
+            $ requestDeleteFactsRequest address tokenId body
+    StatusResponse{currentUtxoRoot} <- getStatus
+    trustedRoot <-
+        liftEitherClientM $ maybeToEither noUtxoRoot currentUtxoRoot
+    facts <- postFacts request
+    verified <-
+        liftEitherClientM
+            $ firstShow
+            $ verifyRequestDeleteFacts (TrustedRoot trustedRoot) facts
+    rawAddress <- liftEitherClientM $ addressBytesForCage address
+    cfg <- liftIO $ loadCageConfig rawAddress
+    tx <-
+        liftEitherClientM
+            $ firstShow
+            $ requestDeleteCageTx cfg walletPolicy verified
+    pure $ WithUnsignedTx (UnsignedTx $ txHex tx) Nothing
+
+requestUpdateFromFacts
+    :: ClientM StatusResponse
+    -> (UpdateValueRequest -> ClientM RequestUpdateFacts)
+    -> Address
+    -> TokenId
+    -> RequestUpdateBody
+    -> ClientM (WithUnsignedTx JSValue)
+requestUpdateFromFacts getStatus postFacts address tokenId body = do
+    request <-
+        liftEitherClientM
+            $ requestUpdateFactsRequest address tokenId body
+    StatusResponse{currentUtxoRoot} <- getStatus
+    trustedRoot <-
+        liftEitherClientM $ maybeToEither noUtxoRoot currentUtxoRoot
+    facts <- postFacts request
+    verified <-
+        liftEitherClientM
+            $ firstShow
+            $ verifyRequestUpdateFacts (TrustedRoot trustedRoot) facts
+    rawAddress <- liftEitherClientM $ addressBytesForCage address
+    cfg <- liftIO $ loadCageConfig rawAddress
+    tx <-
+        liftEitherClientM
+            $ firstShow
+            $ requestUpdateCageTx cfg walletPolicy verified
+    pure $ WithUnsignedTx (UnsignedTx $ txHex tx) Nothing
+
+requestInsertFactsRequest
+    :: Address -> TokenId -> RequestInsertBody -> Either String InsertRequest
+requestInsertFactsRequest address tokenId RequestInsertBody{..} =
+    InsertRequest
+        <$> tokenIdJSONFromTokenId' tokenId
+        <*> pure (canonicalHex key)
+        <*> pure (canonicalHex value)
+        <*> addressHex address
+
+requestDeleteFactsRequest
+    :: Address -> TokenId -> RequestDeleteBody -> Either String DeleteRequest
+requestDeleteFactsRequest address tokenId RequestDeleteBody{..} =
+    DeleteRequest
+        <$> tokenIdJSONFromTokenId' tokenId
+        <*> pure (canonicalHex key)
+        <*> pure (canonicalHex value)
+        <*> addressHex address
+
+requestUpdateFactsRequest
+    :: Address -> TokenId -> RequestUpdateBody -> Either String UpdateValueRequest
+requestUpdateFactsRequest address tokenId RequestUpdateBody{..} =
+    UpdateValueRequest
+        <$> tokenIdJSONFromTokenId' tokenId
+        <*> pure (canonicalHex key)
+        <*> pure (canonicalHex oldValue)
+        <*> pure (canonicalHex newValue)
+        <*> addressHex address
+
+addressHex :: Address -> Either String Hex
+addressHex =
+    fmap Hex . addressBytesForCage
+
+canonicalHex :: JSValue -> Hex
+canonicalHex =
+    Hex . BL.toStrict . renderCanonicalJSON
+
+tokenIdJSONFromTokenId' :: TokenId -> Either String TokenIdJSON
+tokenIdJSONFromTokenId' tokenId =
+    case tokenIdJSONFromTokenId tokenId of
+        Right token -> Right token
+        Left err -> Left $ "invalid token id hex: " <> err
+
+firstShow :: Show e => Either e a -> Either String a
+firstShow =
+    either (Left . show) Right
+
+maybeToEither :: e -> Maybe a -> Either e a
+maybeToEither e =
+    maybe (Left e) Right
+
+noUtxoRoot :: String
+noUtxoRoot =
+    "GET /status returned no utxo_root; MPFS indexer is not ready"

--- a/src/MPFS/Retract.hs
+++ b/src/MPFS/Retract.hs
@@ -1,0 +1,75 @@
+module MPFS.Retract
+    ( retractChangeFromFacts
+    , retractFactsRequest
+    ) where
+
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types
+    ( RetractRequest (..)
+    , StatusResponse (..)
+    )
+import Cardano.MPFS.Client.Cage.Retract (retractCageTx)
+import Cardano.MPFS.Client.Facts
+    ( RetractFacts
+    , verifyRetractFacts
+    )
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Control.Monad.IO.Class (liftIO)
+import Core.Types.Basic
+    ( Address
+    , RequestRefId (..)
+    )
+import Core.Types.Tx
+    ( UnsignedTx (..)
+    , WithUnsignedTx (..)
+    )
+import MPFS.Cage
+    ( addressBytesForCage
+    , liftEitherClientM
+    , loadCageConfig
+    , txHex
+    , walletPolicy
+    )
+import Servant.Client (ClientM)
+import Text.JSON.Canonical (JSValue)
+
+retractChangeFromFacts
+    :: ClientM StatusResponse
+    -> (RetractRequest -> ClientM RetractFacts)
+    -> Address
+    -> RequestRefId
+    -> ClientM (WithUnsignedTx JSValue)
+retractChangeFromFacts getStatus postFacts address requestRef = do
+    request <- liftEitherClientM $ retractFactsRequest address requestRef
+    StatusResponse{currentUtxoRoot} <- getStatus
+    trustedRoot <-
+        liftEitherClientM $ maybeToEither noUtxoRoot currentUtxoRoot
+    facts <- postFacts request
+    verified <-
+        liftEitherClientM
+            $ firstShow
+            $ verifyRetractFacts (TrustedRoot trustedRoot) facts
+    rawAddress <- liftEitherClientM $ addressBytesForCage address
+    cfg <- liftIO $ loadCageConfig rawAddress
+    tx <-
+        liftEitherClientM $ firstShow $ retractCageTx cfg walletPolicy verified
+    pure $ WithUnsignedTx (UnsignedTx $ txHex tx) Nothing
+
+retractFactsRequest
+    :: Address -> RequestRefId -> Either String RetractRequest
+retractFactsRequest address requestRef =
+    RetractRequest
+        (requestId requestRef)
+        <$> (Hex <$> addressBytesForCage address)
+
+firstShow :: Show e => Either e a -> Either String a
+firstShow =
+    either (Left . show) Right
+
+maybeToEither :: e -> Maybe a -> Either e a
+maybeToEither e =
+    maybe (Left e) Right
+
+noUtxoRoot :: String
+noUtxoRoot =
+    "GET /status returned no utxo_root; MPFS indexer is not ready"

--- a/src/MPFS/Update.hs
+++ b/src/MPFS/Update.hs
@@ -1,0 +1,74 @@
+module MPFS.Update
+    ( updateTokenFromFacts
+    , updateTokenFactsRequest
+    ) where
+
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types
+    ( StatusResponse (..)
+    , UpdateRequest (..)
+    )
+import Cardano.MPFS.API.Types.Facts (UpdateFacts)
+import Cardano.MPFS.Client.Cage.Update (updateCageTx)
+import Cardano.MPFS.Client.Facts (verifyUpdateFacts)
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Control.Monad.IO.Class (liftIO)
+import Core.Types.Basic
+    ( Address
+    , TokenId
+    )
+import Core.Types.Tx
+    ( UnsignedTx (..)
+    , WithUnsignedTx (..)
+    )
+import MPFS.Cage
+    ( addressBytesForCage
+    , liftEitherClientM
+    , loadCageConfig
+    , txHex
+    , walletPolicy
+    )
+import MPFS.End (tokenIdJSONFromTokenId)
+import Servant.Client (ClientM)
+import Text.JSON.Canonical (JSValue)
+
+updateTokenFromFacts
+    :: ClientM StatusResponse
+    -> (UpdateRequest -> ClientM UpdateFacts)
+    -> Address
+    -> TokenId
+    -> ClientM (WithUnsignedTx JSValue)
+updateTokenFromFacts getStatus postFacts address tokenId = do
+    request <- liftEitherClientM $ updateTokenFactsRequest address tokenId
+    StatusResponse{currentUtxoRoot} <- getStatus
+    trustedRoot <-
+        liftEitherClientM $ maybeToEither noUtxoRoot currentUtxoRoot
+    facts <- postFacts request
+    verified <-
+        liftEitherClientM
+            $ firstShow
+            $ verifyUpdateFacts (TrustedRoot trustedRoot) facts
+    rawAddress <- liftEitherClientM $ addressBytesForCage address
+    cfg <- liftIO $ loadCageConfig rawAddress
+    tx <-
+        liftEitherClientM $ firstShow $ updateCageTx cfg walletPolicy verified
+    pure $ WithUnsignedTx (UnsignedTx $ txHex tx) Nothing
+
+updateTokenFactsRequest
+    :: Address -> TokenId -> Either String UpdateRequest
+updateTokenFactsRequest address tokenId =
+    UpdateRequest
+        <$> tokenIdJSONFromTokenId tokenId
+        <*> (Hex <$> addressBytesForCage address)
+
+firstShow :: Show e => Either e a -> Either String a
+firstShow =
+    either (Left . show) Right
+
+maybeToEither :: e -> Maybe a -> Either e a
+maybeToEither e =
+    maybe (Left e) Right
+
+noUtxoRoot :: String
+noUtxoRoot =
+    "GET /status returned no utxo_root; MPFS indexer is not ready"

--- a/test/MPFS/WriteFactsSpec.hs
+++ b/test/MPFS/WriteFactsSpec.hs
@@ -1,0 +1,177 @@
+module MPFS.WriteFactsSpec (spec) where
+
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types
+    ( DeleteRequest (..)
+    , InsertRequest (..)
+    , RetractRequest (..)
+    , UpdateRequest (..)
+    , UpdateValueRequest (..)
+    )
+import Cardano.MPFS.API.Types.Common (TokenIdJSON (..))
+import Codec.Binary.Bech32 qualified as Bech32
+import Core.Types.Basic
+    ( Address (..)
+    , RequestRefId (..)
+    , TokenId (..)
+    )
+import Core.Types.Tx
+    ( UnsignedTx (..)
+    , WithUnsignedTx (..)
+    )
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BL
+import Data.Functor.Identity (Identity (..))
+import MPFS.API
+    ( MPFS (..)
+    , RequestDeleteBody (..)
+    , RequestInsertBody (..)
+    , RequestUpdateBody (..)
+    )
+import MPFS.Request
+    ( requestDeleteFactsRequest
+    , requestInsertFactsRequest
+    , requestUpdateFactsRequest
+    )
+import MPFS.Retract (retractFactsRequest)
+import MPFS.Update (updateTokenFactsRequest)
+import MockMPFS (mockMPFS)
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+import Text.JSON.Canonical
+    ( JSValue (..)
+    , renderCanonicalJSON
+    , toJSString
+    )
+
+spec :: Spec
+spec =
+    describe "facts-based MPFS write requests" $ do
+        it "builds POST /facts/request/insert request bodies" $ do
+            let body = RequestInsertBody sampleKey sampleNewValue
+
+            case requestInsertFactsRequest sampleAddress sampleToken body of
+                Left err -> error err
+                Right InsertRequest{..} -> do
+                    irToken `shouldBe` sampleTokenJSON
+                    irKey `shouldBe` canonicalHex sampleKey
+                    irValue `shouldBe` canonicalHex sampleNewValue
+                    irAddr `shouldBe` Hex sampleAddressBytes
+
+        it "builds POST /facts/request/delete request bodies" $ do
+            let body = RequestDeleteBody sampleKey sampleOldValue
+
+            case requestDeleteFactsRequest sampleAddress sampleToken body of
+                Left err -> error err
+                Right DeleteRequest{..} -> do
+                    drToken `shouldBe` sampleTokenJSON
+                    drKey `shouldBe` canonicalHex sampleKey
+                    drValue `shouldBe` canonicalHex sampleOldValue
+                    drAddr `shouldBe` Hex sampleAddressBytes
+
+        it "builds POST /facts/request/update request bodies" $ do
+            let body = RequestUpdateBody sampleKey sampleOldValue sampleNewValue
+
+            case requestUpdateFactsRequest sampleAddress sampleToken body of
+                Left err -> error err
+                Right UpdateValueRequest{..} -> do
+                    uvrToken `shouldBe` sampleTokenJSON
+                    uvrKey `shouldBe` canonicalHex sampleKey
+                    uvrOldValue `shouldBe` canonicalHex sampleOldValue
+                    uvrNewValue `shouldBe` canonicalHex sampleNewValue
+                    uvrAddr `shouldBe` Hex sampleAddressBytes
+
+        it "builds POST /facts/update request bodies" $
+            case updateTokenFactsRequest sampleAddress sampleToken of
+                Left err -> error err
+                Right UpdateRequest{..} -> do
+                    urToken `shouldBe` sampleTokenJSON
+                    urAddr `shouldBe` Hex sampleAddressBytes
+
+        it "builds POST /facts/retract request bodies" $
+            case retractFactsRequest sampleAddress sampleRequestRef of
+                Left err -> error err
+                Right RetractRequest{..} -> do
+                    rrUtxo `shouldBe` requestId sampleRequestRef
+                    rrAddr `shouldBe` Hex sampleAddressBytes
+
+        it "fails closed when token ids are not hex" $
+            case requestInsertFactsRequest
+                sampleAddress
+                (TokenId "not hex")
+                (RequestInsertBody sampleKey sampleNewValue) of
+                Left err ->
+                    err `shouldBe` "invalid token id hex: invalid byte 'n'"
+                Right _ -> error "expected malformed token id to fail"
+
+        it "adds facts-based write operations to the MPFS record" $ do
+            let tx = WithUnsignedTx (UnsignedTx "00") Nothing
+                mpfs =
+                    mockMPFS
+                        { mpfsRequestInsertFromFacts =
+                            \_ _ _ -> Identity tx
+                        , mpfsRequestDeleteFromFacts =
+                            \_ _ _ -> Identity tx
+                        , mpfsRequestUpdateFromFacts =
+                            \_ _ _ -> Identity tx
+                        , mpfsUpdateTokenFromFacts =
+                            \_ _ -> Identity tx
+                        , mpfsRetractChangeFromFacts =
+                            \_ _ -> Identity tx
+                        }
+
+            runIdentity
+                ( mpfsUpdateTokenFromFacts
+                    mpfs
+                    sampleAddress
+                    sampleToken
+                )
+                `shouldBe` tx
+
+sampleAddress :: Address
+sampleAddress =
+    Address
+        $ case Bech32.humanReadablePartFromText "addr_test" of
+            Left err -> error $ show err
+            Right hrp ->
+                case Bech32.encode
+                    hrp
+                    (Bech32.dataPartFromBytes sampleAddressBytes) of
+                    Left err -> error $ show err
+                    Right encoded -> encoded
+
+sampleAddressBytes :: BS.ByteString
+sampleAddressBytes =
+    BS.pack [0x00 .. 0x1c]
+
+sampleToken :: TokenId
+sampleToken =
+    TokenId "abcd"
+
+sampleTokenJSON :: TokenIdJSON
+sampleTokenJSON =
+    TokenIdJSON "\xab\xcd"
+
+sampleRequestRef :: RequestRefId
+sampleRequestRef =
+    RequestRefId "0123456789abcdef#0"
+
+sampleKey :: JSValue
+sampleKey =
+    JSString $ toJSString "key"
+
+sampleOldValue :: JSValue
+sampleOldValue =
+    JSString $ toJSString "old"
+
+sampleNewValue :: JSValue
+sampleNewValue =
+    JSString $ toJSString "new"
+
+canonicalHex :: JSValue -> Hex
+canonicalHex =
+    Hex . BL.toStrict . renderCanonicalJSON

--- a/test/MPFS/WriteFactsSpec.hs
+++ b/test/MPFS/WriteFactsSpec.hs
@@ -22,6 +22,7 @@ import Core.Types.Tx
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
 import Data.Functor.Identity (Identity (..))
+import Data.List (isPrefixOf)
 import MPFS.API
     ( MPFS (..)
     , RequestDeleteBody (..)
@@ -41,6 +42,7 @@ import Test.Hspec
     , describe
     , it
     , shouldBe
+    , shouldSatisfy
     )
 import Text.JSON.Canonical
     ( JSValue (..)
@@ -105,7 +107,7 @@ spec =
                 (TokenId "not hex")
                 (RequestInsertBody sampleKey sampleNewValue) of
                 Left err ->
-                    err `shouldBe` "invalid token id hex: invalid byte 'n'"
+                    err `shouldSatisfy` ("invalid token id hex:" `isPrefixOf`)
                 Right _ -> error "expected malformed token id to fail"
 
         it "adds facts-based write operations to the MPFS record" $ do

--- a/test/MockMPFS.hs
+++ b/test/MockMPFS.hs
@@ -33,6 +33,16 @@ mockMPFS =
         , mpfsRequestUpdate = \_ _ _ -> error "request update not implemented"
         , mpfsRetractChange = \_ _ -> error "retract change not implemented"
         , mpfsUpdateToken = \_ _ _ -> error "update token not implemented"
+        , mpfsRequestInsertFromFacts =
+            \_ _ _ -> error "request insert facts not implemented"
+        , mpfsRequestDeleteFromFacts =
+            \_ _ _ -> error "request delete facts not implemented"
+        , mpfsRequestUpdateFromFacts =
+            \_ _ _ -> error "request update facts not implemented"
+        , mpfsRetractChangeFromFacts =
+            \_ _ -> error "retract change facts not implemented"
+        , mpfsUpdateTokenFromFacts =
+            \_ _ -> error "update token facts not implemented"
         , mpfsGetToken = \_ -> toJSON $ mockToken []
         , mpfsGetTokenFacts = \_ -> toJSON ([] :: [JSFact])
         , mpfsSubmitTransaction = \_ -> error "submit transaction not implemented"


### PR DESCRIPTION
Foundation child of epic #146. Targets the long-lived `moog-v2` branch.

## State

- **S1 — pin offchain to latest `main`** ✅ `c9eb9ea`, builds green.
- **S3 — client-side cage write builders** ✅ `MPFS.Request/Update/Retract` turn `POST /facts/*` responses into unsigned txs (mirroring boot/end), exposed as `mpfs*FromFacts` on the `MPFS m` record. Legacy ops retained (removed later in #151).
- **S2 — token reads on `/tokens/*`** ⏸ **blocked** on upstream lambdasistemi/cardano-mpfs-offchain#305 (bulk `/facts` endpoint) + offchain #243 (read-side MPF verification). Per the epic "writes-first" decision, reads are deferred until upstream lands.

## Verification model (epic invariant)

moog verifies offchain responses against an independently-obtained trusted root (UTxO-CSMT `utxo_root`); fact-set completeness is established by reconstructing the MPF root from the full fact set and matching the trusted root. See epic #146 decision log.

## Plan

`specs/147-mpfs-facts-foundation/` — S1 ✅, S2 ⏸ blocked, S3 ✅.