### PR TITLE
chore(deps): bump cardano-mpfs-offchain to main (bulk /tokens/:id/facts)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,8 +11,8 @@ packages:
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-mpfs-offchain.git
-  tag: c9eb9ea9acc6b928ec30d4fd6d88180811876147
-  --sha256: 156p4gl8lc8chgwr8arns12f109fafpan31l5dcyhbcyiy8nw499
+  tag: 6a015057274fe8eabc93a66aba8634850495d98c
+  --sha256: 05y4i4wrxziwbs0pddlq2gp6s7k9dqgbjaw9ynkiwdqwnrmrygwa
   subdir:
     cardano-mpfs-api
     cardano-mpfs-cage-tx


### PR DESCRIPTION
Re-pin cardano-mpfs-offchain to 6a01505 (merged #305/#306 — adds GET /tokens/:id/facts + cardano-mpfs-client.tokenFacts). Unblocks the fetch half of #155; client-side completeness verifier pending upstream #307. Targets moog-v2.