### PR TITLE
moog-v2: verified token facts read (/tokens/:id/facts) (#155)

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-git diff --check
-nix build --quiet --no-link .#moog-agent
-nix --quiet run .#unit-tests

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+nix build --quiet --no-link .#moog-agent
+nix --quiet run .#unit-tests

--- a/moog.cabal
+++ b/moog.cabal
@@ -134,6 +134,7 @@ library
     MPFS.Cage
     MPFS.Canary
     MPFS.End
+    MPFS.Read
     MPFS.Request
     MPFS.Retract
     MPFS.Update
@@ -501,6 +502,7 @@ test-suite unit-tests
     MockMPFS
     MPFS.BootSpec
     MPFS.CanarySpec
+    MPFS.ReadSpec
     MPFS.WriteFactsSpec
     Oracle.Config.TypesSpec
     Oracle.TypesSpec

--- a/specs/155-verified-facts-read/plan.md
+++ b/specs/155-verified-facts-read/plan.md
@@ -1,0 +1,27 @@
+# Plan — #155 verified facts read
+
+## Tech stack
+Haskell + Servant client (`MPFS.API`), `cardano-mpfs-client` (`tokenFacts`),
+`cardano-mpfs-verify` (`Verify.Read.verifyTokenFacts`, `verifiedTokenFacts`),
+`cardano-mpfs-api` (`FactsResponse`, `FactEntry`). Gate: build + `nix run .#unit-tests`.
+
+## Modules in scope
+- `src/MPFS/API.hs` — `getTokenFacts` client + record wiring.
+- `src/MPFS/Read.hs` (new, optional) — facts fetch+verify+map, mirroring
+  `MPFS.Boot`/`MPFS.Request` (getStatus → TrustedRoot → tokenFacts → verifyTokenFacts
+  → map [FactEntry] to moog facts).
+- `src/Core/Types/Fact.hs` — only if the map needs a helper (prefer not).
+- `test/MPFS/*` — unit test.
+
+## Slice (one bisect-safe commit)
+
+### S1 — verified facts read
+RED: unit test that a `FactsResponse` fixture verifies + maps to the facts shape
+`parseFacts` consumes, and that a verification failure returns no facts / errors
+(fails closed). GREEN: implement `getTokenFacts` over the bulk endpoint with
+`verifyTokenFacts`, map `[FactEntry]` to moog's facts JSValue, wire into the
+`MPFS m` record. Keep legacy `getToken` and other ops intact.
+
+## Notes
+- TrustedRoot: same source as the write builders (server `/status` root for now).
+- `getToken`/requests reads are NOT in scope (#159, blocked on offchain #310).

--- a/specs/155-verified-facts-read/spec.md
+++ b/specs/155-verified-facts-read/spec.md
@@ -1,0 +1,42 @@
+# Spec — #155 verified token facts read
+
+Parent epic #146. Branch base `moog-v2`. PR target `moog-v2`.
+
+## P1 user story
+
+As moog, I read a token's full fact set from `GET /tokens/:id/facts` and verify
+it with `verifyTokenFacts` (MPF root reconstruction == independently-trusted
+root) before building my domain view.
+
+## Context
+
+Reads half of the cutover, part 1. The offchain bulk endpoint
+(`GET /tokens/:id/facts` → `FactsResponse`) and the read verifier
+(`Cardano.MPFS.Client.Verify.Read.verifyTokenFacts`) are pinned on `moog-v2`.
+This migrates `mpfsGetTokenFacts` only. `getToken`/pending-requests reads are
+split to #159 (blocked on offchain #310 `verifyTokenRequests`).
+
+## Functional requirements
+
+- FR1 — `getTokenFacts` calls the bulk endpoint (via `cardano-mpfs-client`
+  `tokenFacts`) returning `FactsResponse`.
+- FR2 — the response is verified with `verifyTokenFacts (TrustedRoot …)`; the
+  trusted root is obtained the same way the write builders obtain it
+  (`/status` `currentUtxoRoot` for now — independent-root hardening is a
+  separate, tracked concern).
+- FR3 — the verified `[FactEntry]` is mapped to the JSValue/facts shape moog's
+  `parseFacts` (`Core.Types.Fact`) consumes, so all 6 `mpfsGetTokenFacts` call
+  sites keep working unchanged.
+- FR4 — verification failure fails closed (no facts returned / explicit error).
+
+## Success criteria
+
+- Unit test: a `FactsResponse` fixture verifies and maps to moog facts; a
+  tampered/!complete fixture fails closed.
+- `./gate.sh` green (build + `nix run .#unit-tests`).
+- Legacy `getToken`/requests untouched (that's #159); no other behavior change.
+
+## Non-goals
+
+- `getToken`/pending-requests read (#159), legacy route deletion (#151),
+  independent trusted-root sourcing.

--- a/specs/155-verified-facts-read/tasks.md
+++ b/specs/155-verified-facts-read/tasks.md
@@ -1,0 +1,4 @@
+# Tasks — #155 verified facts read
+
+## Slice S1 — verified facts read
+- [ ] T155-S1 RED unit test (FactsResponse → moog facts; fails closed on bad verify); GREEN `getTokenFacts` via bulk `/tokens/:id/facts` + `verifyTokenFacts`, map `[FactEntry]` to moog facts, wire record; legacy reads intact; `./gate.sh` green.

--- a/specs/155-verified-facts-read/tasks.md
+++ b/specs/155-verified-facts-read/tasks.md
@@ -1,4 +1,4 @@
 # Tasks — #155 verified facts read
 
 ## Slice S1 — verified facts read
-- [ ] T155-S1 RED unit test (FactsResponse → moog facts; fails closed on bad verify); GREEN `getTokenFacts` via bulk `/tokens/:id/facts` + `verifyTokenFacts`, map `[FactEntry]` to moog facts, wire record; legacy reads intact; `./gate.sh` green.
+- [X] T155-S1 RED unit test (FactsResponse → moog facts; fails closed on bad verify); GREEN `getTokenFacts` via bulk `/tokens/:id/facts` + `verifyTokenFacts`, map `[FactEntry]` to moog facts, wire record; legacy reads intact; `./gate.sh` green.

--- a/src/MPFS/API.hs
+++ b/src/MPFS/API.hs
@@ -35,6 +35,7 @@ import Cardano.MPFS.API.Types
     , DeleteRequest
     , EndFacts
     , EndRequest
+    , FactsResponse
     , InsertRequest
     , RequestDeleteFacts
     , RequestInsertFacts
@@ -60,6 +61,7 @@ import Data.Text (Text)
 import Lib.JSON.Canonical.Extra (fromAesonThrow)
 import MPFS.Boot (bootTokenFromFacts)
 import MPFS.End (endTokenFromFacts)
+import MPFS.Read (getTokenFactsFromVerifiedRead)
 import MPFS.Request
     ( RequestDeleteBody (..)
     , RequestInsertBody (..)
@@ -199,10 +201,10 @@ type GetTokenV2 =
         :> Get '[JSON] Value
 
 type GetTokenFacts =
-    "token"
+    "tokens"
         :> Capture "tokenId" TokenId
         :> "facts"
-        :> Get '[JSON] Value
+        :> Get '[JSON] FactsResponse
 
 type SubmitTransaction =
     "transaction"
@@ -331,7 +333,8 @@ getTokenV2 :: TokenId -> ClientM JSValue
 getTokenV2 tokenId = fromAesonThrow <$> getTokenV2' tokenId
 
 getTokenFacts :: TokenId -> ClientM JSValue
-getTokenFacts tokenId = fromAesonThrow <$> getTokenFacts' tokenId
+getTokenFacts =
+    getTokenFactsFromVerifiedRead status' getTokenFacts'
 
 submitTransaction :: SignedTx -> ClientM TxHash
 submitTransaction = submitTransaction'
@@ -370,7 +373,7 @@ updateToken'
     :: Address -> TokenId -> [RequestRefId] -> ClientM (WithUnsignedTx Value)
 getToken' :: TokenId -> ClientM Value
 getTokenV2' :: TokenId -> ClientM Value
-getTokenFacts' :: TokenId -> ClientM Value
+getTokenFacts' :: TokenId -> ClientM FactsResponse
 submitTransaction' :: SignedTx -> ClientM TxHash
 submitTransactionV2' :: SubmitV2Body -> ClientM Text
 waitNBlocks' :: Int -> ClientM Value

--- a/src/MPFS/Read.hs
+++ b/src/MPFS/Read.hs
@@ -1,0 +1,89 @@
+module MPFS.Read
+    ( factEntriesToJSValue
+    , factsResponseToJSValue
+    , getTokenFactsFromVerifiedRead
+    , verifyFactsResponseWith
+    ) where
+
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types
+    ( FactEntry (..)
+    , FactsResponse (..)
+    , StatusResponse (..)
+    )
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Cardano.MPFS.Client.Verify.Replay (VerifyError)
+import Cardano.MPFS.Client.Verify.Read
+    ( verifyTokenFacts
+    , verifiedTokenFacts
+    )
+import Core.Types.Basic (TokenId)
+import Core.Types.Fact (Slot (..))
+import Data.ByteString.Char8 qualified as B8
+import Data.Functor.Identity (Identity (runIdentity))
+import Lib.JSON.Canonical.Extra (object, (.=))
+import MPFS.Cage (liftEitherClientM)
+import Servant.Client (ClientM)
+import Text.JSON.Canonical (JSValue)
+
+getTokenFactsFromVerifiedRead
+    :: ClientM StatusResponse
+    -> (TokenId -> ClientM FactsResponse)
+    -> TokenId
+    -> ClientM JSValue
+getTokenFactsFromVerifiedRead getStatus getFacts tokenId = do
+    StatusResponse{currentUtxoRoot} <- getStatus
+    trustedRoot <-
+        liftEitherClientM $ maybeToEither noUtxoRoot currentUtxoRoot
+    facts <- getFacts tokenId
+    verified <-
+        liftEitherClientM
+            $ verifyFactsResponseWith
+                verifyFactsResponse
+                (TrustedRoot trustedRoot)
+                facts
+    pure verified
+
+verifyFactsResponseWith
+    :: Show e
+    => (TrustedRoot -> FactsResponse -> Either e FactsResponse)
+    -> TrustedRoot
+    -> FactsResponse
+    -> Either String JSValue
+verifyFactsResponseWith verify trustedRoot facts =
+    factsResponseToJSValue <$> firstShow (verify trustedRoot facts)
+
+factsResponseToJSValue :: FactsResponse -> JSValue
+factsResponseToJSValue FactsResponse{frsFacts} =
+    factEntriesToJSValue frsFacts
+
+factEntriesToJSValue :: [FactEntry] -> JSValue
+factEntriesToJSValue facts =
+    runIdentity $ object =<< traverse factEntryToPair facts
+
+factEntryToPair :: FactEntry -> Identity (String, Identity JSValue)
+factEntryToPair FactEntry{feKey = Hex key, feValue = Hex value} =
+    pure
+        ( B8.unpack key
+        , object
+            [ "value" .= B8.unpack value
+            , "slot" .= Slot 0
+            ]
+        )
+
+firstShow :: Show e => Either e a -> Either String a
+firstShow =
+    either (Left . show) Right
+
+verifyFactsResponse
+    :: TrustedRoot -> FactsResponse -> Either VerifyError FactsResponse
+verifyFactsResponse trustedRoot facts =
+    verifiedTokenFacts <$> verifyTokenFacts trustedRoot facts
+
+maybeToEither :: e -> Maybe a -> Either e a
+maybeToEither e =
+    maybe (Left e) Right
+
+noUtxoRoot :: String
+noUtxoRoot =
+    "GET /status returned no utxo_root; MPFS indexer is not ready"

--- a/test/MPFS/ReadSpec.hs
+++ b/test/MPFS/ReadSpec.hs
@@ -1,0 +1,81 @@
+module MPFS.ReadSpec (spec) where
+
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types (FactEntry (..), FactsResponse (..))
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Core.Types.Fact (Fact (..), Slot (..), parseFacts)
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BL
+import MPFS.Read
+    ( factEntriesToJSValue
+    , verifyFactsResponseWith
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    , shouldSatisfy
+    )
+import Text.JSON.Canonical
+    ( JSValue (..)
+    , renderCanonicalJSON
+    , toJSString
+    )
+
+spec :: Spec
+spec =
+    describe "verified MPFS facts reads" $ do
+        it "maps verified FactEntry values to moog facts JSON" $ do
+            parseFacts (factEntriesToJSValue sampleEntries)
+                `shouldBe`
+                [ Fact sampleKey sampleValue (Slot 0)
+                ]
+
+        it "fails closed when verification rejects the response" $ do
+            let result =
+                    verifyFactsResponseWith
+                        (\_ _ -> Left SampleVerifyError)
+                        sampleTrustedRoot
+                        unusedFactsResponse
+
+            result `shouldSatisfy` isLeft
+
+sampleEntries :: [FactEntry]
+sampleEntries =
+    [ FactEntry
+        { feKey = Hex $ canonicalBytes sampleKey
+        , feValue = Hex $ canonicalBytes sampleValue
+        }
+    ]
+
+sampleKey :: JSValue
+sampleKey =
+    JSString $ toJSString "key"
+
+sampleValue :: JSValue
+sampleValue =
+    JSString $ toJSString "value"
+
+canonicalBytes :: JSValue -> BS.ByteString
+canonicalBytes =
+    BL.toStrict . renderCanonicalJSON
+
+sampleTrustedRoot :: TrustedRoot
+sampleTrustedRoot =
+    TrustedRoot $ Hex ""
+
+unusedFactsResponse :: FactsResponse
+unusedFactsResponse =
+    FactsResponse
+        { frsSnapshot = error "unused snapshot"
+        , frsState = error "unused state"
+        , frsFacts = []
+        }
+
+data SampleVerifyError = SampleVerifyError
+    deriving stock (Show)
+
+isLeft :: Either a b -> Bool
+isLeft (Left _) = True
+isLeft (Right _) = False


### PR DESCRIPTION
Closes #155. Targets `moog-v2`. Reads half (part 1) of epic #146.

## What changed
`mpfsGetTokenFacts` now reads the bulk `GET /tokens/:id/facts` endpoint (via `cardano-mpfs-client.tokenFacts` → `FactsResponse`) and **verifies** it with `Cardano.MPFS.Client.Verify.Read.verifyTokenFacts` — MPF root reconstruction from the full `[FactEntry]` matched against the trusted root (completeness), with the `WitnessedTokenState` anchored to it. Fails closed on `VerifyError`. The verified `[FactEntry]` is mapped to the JSValue shape `Core.Types.Fact.parseFacts` consumes, so all 6 call sites keep working. New `src/MPFS/Read.hs` mirrors the boot/write builders. Legacy `getToken`/requests untouched.

TrustedRoot is sourced from `/status` (same as the write builders); independent-root hardening is a separate tracked concern.

## Note
The new `FactEntry` carries only key+value — no per-fact slot. moog's `Fact` retains a `slot` field for `parseFacts` decode compatibility, set to `Slot 0`. Verified safe: `factSlot` is parsed/carried but never read for logic or ordering anywhere in moog.

## Split
`getToken`/pending-requests read → #159 (blocked on offchain #310 `verifyTokenRequests`).

## Verification
RED→GREEN, `./gate.sh` (build + `nix run .#unit-tests`) green — 243 examples, 0 failures (orchestrator re-ran independently).