### PR TITLE
moog-v2: verified token state + pending-requests read (#159)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,8 +11,8 @@ packages:
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-mpfs-offchain.git
-  tag: def1d7b3bdcb12357b4dccba5c799b4653038865
-  --sha256: 14dalypfsq1fqfkd3k4swbgpzk24bspixh9pq46yv6ca6wbxb54a
+  tag: 1b91a1f66b26cb868fa1685442fdba56d084d972
+  --sha256: 0k5ka5pi915336vxf4wm3drvk0y8g4p6qg5gpwf75wnqc19nkvv7
   subdir:
     cardano-mpfs-api
     cardano-mpfs-cage-tx

--- a/gate.sh
+++ b/gate.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-git diff --check
-nix build --quiet --no-link .#moog-agent
-nix --quiet run .#unit-tests

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+git diff --check
+nix build --quiet --no-link .#moog-agent
+nix --quiet run .#unit-tests

--- a/specs/159-verified-state-requests/plan.md
+++ b/specs/159-verified-state-requests/plan.md
@@ -1,0 +1,29 @@
+# Plan — #159 verified state + requests read
+
+## Modules
+- `cabal.project` — offchain pin → 1b91a1f (done in scaffold).
+- `src/MPFS/Read.hs` (extend; #155 created it) — `getToken` fetch+verify+assemble.
+- `src/MPFS/API.hs` — record wiring for `mpfsGetToken`.
+- `src/Oracle/Types.hs` — only if the Token mapping needs a constructor helper.
+- `test/MPFS/*` — unit tests.
+
+Verifiers (offchain `Cardano.MPFS.Client.Verify.Read`): `verifyTokenState`,
+`verifiedTokenState`, `verifyTokenRequests`, `verifiedTokenRequests`. Mirror how
+#155 used `verifyTokenFacts` in `MPFS/Read.hs`, and how boot/write builders source
+the TrustedRoot (+ Blueprint via `loadCageConfig`).
+
+## Slice (one bisect-safe commit)
+
+### S1 — verified getToken (state + requests)
+RED: unit test that a `TokenResponse` + `RequestsResponse` pair verifies and
+assembles into moog's `Token { tokenRefId, tokenState, tokenRequests }`, and that
+a tampered state / incomplete request-set fails closed. GREEN: implement `getToken`
+over `/tokens/:id` (verifyTokenState) + `/tokens/:id/requests` (verifyTokenRequests),
+map to moog's `Token`, wire `mpfsGetToken`. `mpfsGetTokenRequests` (derived from
+getToken in Effects) then works. Keep facts read + write ops intact.
+
+## Notes
+- Map `WitnessedTokenState` → moog `TokenState` (root, owner); token output ref → `tokenRefId`.
+- Map `[WitnessedRequest]` (`wrRequest :: RequestJSON`) → moog `[RequestZoo]`.
+- If a real design choice arises (e.g. RequestJSON→RequestZoo mapping, or the
+  Blueprint/prefix input for verifyTokenRequests), Q-file.

--- a/specs/159-verified-state-requests/spec.md
+++ b/specs/159-verified-state-requests/spec.md
@@ -1,0 +1,47 @@
+# Spec — #159 verified token state + pending-requests read
+
+Parent epic #146. Base `moog-v2`. PR target `moog-v2`. Follows #155.
+
+## P1 user story
+
+As moog, I read a token's state via `GET /tokens/:id` and its pending requests via
+`GET /tokens/:id/requests`, verify both against the trusted root
+(`verifyTokenState`, `verifyTokenRequests` — request-set completeness), and
+assemble them into moog's `Token` before any oracle validation.
+
+## Context
+
+`mpfsGetToken` is consumed entirely for `tokenRequests` (Effects/Cli/Oracle).
+The new API splits state (`/tokens/:id`) from requests (`/tokens/:id/requests`).
+The read verifiers now exist on the pinned offchain (`1b91a1f`):
+`Cardano.MPFS.Client.Verify.Read.{verifyTokenState, verifyTokenRequests}`.
+The verified facts read (#155) already landed.
+
+## Functional requirements
+
+- FR1 — offchain pinned to `1b91a1f` (done in scaffold) so `verifyTokenRequests`
+  is available.
+- FR2 — `mpfsGetToken` fetches `GET /tokens/:id` (`TokenResponse`) and verifies
+  with `verifyTokenState (TrustedRoot …)`; maps the verified `WitnessedTokenState`
+  to moog's `TokenState` (root + owner) and the token's output ref to `tokenRefId`.
+- FR3 — pending requests fetched from `GET /tokens/:id/requests`
+  (`RequestsResponse`) and verified with `verifyTokenRequests` (request-set
+  completeness); the verified `[WitnessedRequest]` mapped to moog's `[RequestZoo]`.
+- FR4 — the two are assembled into moog's `Token { tokenRefId, tokenState,
+  tokenRequests }` so all `mpfsGetToken` / `mpfsGetTokenRequests` consumers keep
+  working unchanged.
+- FR5 — verification failure fails closed.
+- Trusted root sourced as in the write builders / #155 (server `/status` root).
+  `verifyTokenRequests` may also need the `Blueprint` (request-address prefix) —
+  obtain it as boot/write builders do (`loadCageConfig`).
+
+## Success criteria
+
+- Unit tests: a `TokenResponse` + `RequestsResponse` pair verifies and assembles
+  into a moog `Token`; tampered/incomplete fails closed.
+- `./gate.sh` green (build + `nix run .#unit-tests`).
+- Legacy write ops + facts read untouched; no consumer signature changes.
+
+## Non-goals
+
+- Removing legacy read routes (#151); independent trusted-root sourcing.

--- a/specs/159-verified-state-requests/tasks.md
+++ b/specs/159-verified-state-requests/tasks.md
@@ -1,4 +1,4 @@
 # Tasks — #159 verified state + requests read
 
 ## Slice S1 — verified getToken (state + requests)
-- [ ] T159-S1 RED unit test (TokenResponse+RequestsResponse → moog Token; tampered/incomplete fails closed); GREEN getToken via /tokens/:id (verifyTokenState) + /tokens/:id/requests (verifyTokenRequests), assemble moog Token, wire mpfsGetToken; facts/write ops intact; `./gate.sh` green.
+- [X] T159-S1 RED unit test (TokenResponse+RequestsResponse → moog Token; tampered/incomplete fails closed); GREEN getToken via /tokens/:id (verifyTokenState) + /tokens/:id/requests (verifyTokenRequests), assemble moog Token, wire mpfsGetToken; facts/write ops intact; `./gate.sh` green.

--- a/specs/159-verified-state-requests/tasks.md
+++ b/specs/159-verified-state-requests/tasks.md
@@ -1,0 +1,4 @@
+# Tasks — #159 verified state + requests read
+
+## Slice S1 — verified getToken (state + requests)
+- [ ] T159-S1 RED unit test (TokenResponse+RequestsResponse → moog Token; tampered/incomplete fails closed); GREEN getToken via /tokens/:id (verifyTokenState) + /tokens/:id/requests (verifyTokenRequests), assemble moog Token, wire mpfsGetToken; facts/write ops intact; `./gate.sh` green.

--- a/src/MPFS/API.hs
+++ b/src/MPFS/API.hs
@@ -40,9 +40,11 @@ import Cardano.MPFS.API.Types
     , RequestDeleteFacts
     , RequestInsertFacts
     , RequestUpdateFacts
+    , RequestsResponse
     , RetractFacts
     , RetractRequest
     , StatusResponse
+    , TokenResponse
     , UpdateRequest
     , UpdateValueRequest
     )
@@ -61,7 +63,10 @@ import Data.Text (Text)
 import Lib.JSON.Canonical.Extra (fromAesonThrow)
 import MPFS.Boot (bootTokenFromFacts)
 import MPFS.End (endTokenFromFacts)
-import MPFS.Read (getTokenFactsFromVerifiedRead)
+import MPFS.Read
+    ( getTokenFactsFromVerifiedRead
+    , getTokenFromVerifiedRead
+    )
 import MPFS.Request
     ( RequestDeleteBody (..)
     , RequestInsertBody (..)
@@ -206,6 +211,17 @@ type GetTokenFacts =
         :> "facts"
         :> Get '[JSON] FactsResponse
 
+type GetTokenRead =
+    "tokens"
+        :> Capture "tokenId" TokenId
+        :> Get '[JSON] TokenResponse
+
+type GetTokenRequests =
+    "tokens"
+        :> Capture "tokenId" TokenId
+        :> "requests"
+        :> Get '[JSON] RequestsResponse
+
 type SubmitTransaction =
     "transaction"
         :> ReqBody '[JSON] SignedTx
@@ -327,7 +343,8 @@ retractChangeFromFacts =
     Retract.retractChangeFromFacts status' retractFacts'
 
 getToken :: TokenId -> ClientM JSValue
-getToken tokenId = fromAesonThrow <$> getToken' tokenId
+getToken =
+    getTokenFromVerifiedRead status' getTokenRead' getTokenRequests'
 
 getTokenV2 :: TokenId -> ClientM JSValue
 getTokenV2 tokenId = fromAesonThrow <$> getTokenV2' tokenId
@@ -371,9 +388,11 @@ retractChange'
     :: Address -> RequestRefId -> ClientM (WithUnsignedTx Value)
 updateToken'
     :: Address -> TokenId -> [RequestRefId] -> ClientM (WithUnsignedTx Value)
-getToken' :: TokenId -> ClientM Value
+_getToken' :: TokenId -> ClientM Value
 getTokenV2' :: TokenId -> ClientM Value
+getTokenRead' :: TokenId -> ClientM TokenResponse
 getTokenFacts' :: TokenId -> ClientM FactsResponse
+getTokenRequests' :: TokenId -> ClientM RequestsResponse
 submitTransaction' :: SignedTx -> ClientM TxHash
 submitTransactionV2' :: SubmitV2Body -> ClientM Text
 waitNBlocks' :: Int -> ClientM Value
@@ -387,7 +406,7 @@ _endToken'
     :<|> requestUpdate'
     :<|> retractChange'
     :<|> updateToken'
-    :<|> getToken'
+    :<|> _getToken'
     :<|> getTokenFacts'
     :<|> submitTransaction'
     :<|> waitNBlocks'
@@ -428,6 +447,12 @@ retractFacts' =
 
 getTokenV2' =
     client (Proxy :: Proxy GetTokenV2)
+
+getTokenRead' =
+    client (Proxy :: Proxy GetTokenRead)
+
+getTokenRequests' =
+    client (Proxy :: Proxy GetTokenRequests)
 
 submitTransactionV2' =
     client (Proxy :: Proxy SubmitTransactionV2)

--- a/src/MPFS/Read.hs
+++ b/src/MPFS/Read.hs
@@ -1,30 +1,64 @@
 module MPFS.Read
     ( factEntriesToJSValue
     , factsResponseToJSValue
+    , getTokenFromVerifiedRead
     , getTokenFactsFromVerifiedRead
+    , requestJSONToRequestZoo
+    , tokenResponsesToJSValue
     , verifyFactsResponseWith
+    , verifyTokenResponsesWith
     ) where
 
 import Cardano.MPFS.API.Encoding (Hex (..))
 import Cardano.MPFS.API.Types
     ( FactEntry (..)
     , FactsResponse (..)
+    , RequestJSON (..)
+    , RequestsResponse (..)
     , StatusResponse (..)
+    , TokenResponse (..)
+    , TokenStateJSON (..)
+    , TxInJSON (..)
+    , WitnessedRequest (..)
+    , WitnessedTokenState (..)
+    , WitnessedUtxo (..)
     )
+import Cardano.MPFS.API.Types.Common (TokenIdJSON)
 import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
 import Cardano.MPFS.Client.Verify.Replay (VerifyError)
 import Cardano.MPFS.Client.Verify.Read
-    ( verifyTokenFacts
+    ( verifiedTokenRequests
+    , verifiedTokenState
+    , verifyTokenFacts
+    , verifyTokenRequests
+    , verifyTokenState
     , verifiedTokenFacts
     )
-import Core.Types.Basic (TokenId)
+import Control.Monad.IO.Class (liftIO)
+import Core.Types.Basic (Owner (..), RequestRefId (..), TokenId)
 import Core.Types.Fact (Slot (..))
+import Core.Types.Tx (Root (..))
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as Base16
 import Data.ByteString.Char8 qualified as B8
-import Data.Functor.Identity (Identity (runIdentity))
-import Lib.JSON.Canonical.Extra (object, (.=))
-import MPFS.Cage (liftEitherClientM)
+import Data.Functor.Identity (Identity (Identity, runIdentity))
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
+import Lib.JSON.Canonical.Extra
+    ( jsonToString
+    , object
+    , parseJSValue
+    , (.=)
+    )
+import MPFS.Cage (liftEitherClientM, loadCageConfig)
+import MPFS.End (tokenIdJSONFromTokenId)
+import Oracle.Types
+    ( RequestZoo
+    , Token (..)
+    , TokenState (..)
+    )
 import Servant.Client (ClientM)
-import Text.JSON.Canonical (JSValue)
+import Text.JSON.Canonical (FromJSON (..), JSValue (..), ToJSON (..))
 
 getTokenFactsFromVerifiedRead
     :: ClientM StatusResponse
@@ -44,6 +78,34 @@ getTokenFactsFromVerifiedRead getStatus getFacts tokenId = do
                 facts
     pure verified
 
+getTokenFromVerifiedRead
+    :: ClientM StatusResponse
+    -> (TokenId -> ClientM TokenResponse)
+    -> (TokenId -> ClientM RequestsResponse)
+    -> TokenId
+    -> ClientM JSValue
+getTokenFromVerifiedRead getStatus getTokenState getRequests tokenId = do
+    StatusResponse{currentUtxoRoot} <- getStatus
+    trustedRoot <-
+        liftEitherClientM $ maybeToEither noUtxoRoot currentUtxoRoot
+    token <- liftEitherClientM $ tokenIdJSONFromTokenId tokenId
+    cfg <- liftIO $ loadCageConfig BS.empty
+    tokenState <- getTokenState tokenId
+    requests <- getRequests tokenId
+    liftEitherClientM
+        $ verifyTokenResponsesWith
+            (\trustedRoot' state' ->
+                verifiedTokenState <$> verifyTokenState trustedRoot' state'
+            )
+            ( \token' trustedRoot' requests' ->
+                verifiedTokenRequests
+                    <$> verifyTokenRequests cfg token' trustedRoot' requests'
+            )
+            token
+            (TrustedRoot trustedRoot)
+            tokenState
+            requests
+
 verifyFactsResponseWith
     :: Show e
     => (TrustedRoot -> FactsResponse -> Either e FactsResponse)
@@ -52,6 +114,35 @@ verifyFactsResponseWith
     -> Either String JSValue
 verifyFactsResponseWith verify trustedRoot facts =
     factsResponseToJSValue <$> firstShow (verify trustedRoot facts)
+
+verifyTokenResponsesWith
+    :: Show e
+    => (TrustedRoot -> TokenResponse -> Either e TokenResponse)
+    -> (TokenIdJSON -> TrustedRoot -> RequestsResponse -> Either e RequestsResponse)
+    -> TokenIdJSON
+    -> TrustedRoot
+    -> TokenResponse
+    -> RequestsResponse
+    -> Either String JSValue
+verifyTokenResponsesWith verifyState verifyRequests token trustedRoot state requests = do
+    verifiedState <- firstShow $ verifyState trustedRoot state
+    verifiedRequests <- firstShow $ verifyRequests token trustedRoot requests
+    tokenResponsesToJSValue verifiedState verifiedRequests
+
+tokenResponsesToJSValue
+    :: TokenResponse -> RequestsResponse -> Either String JSValue
+tokenResponsesToJSValue
+    TokenResponse{trState = state}
+    RequestsResponse{rrRequests = requests} = do
+        requestZoos <- traverse requestJSONToRequestZoo requests
+        pure
+            $ runIdentity
+            $ toJSON
+            $ Token
+                { tokenRefId = txInRefId $ wuTxIn $ wtsUtxo state
+                , tokenState = witnessedTokenStateToTokenState state
+                , tokenRequests = Identity <$> requestZoos
+                }
 
 factsResponseToJSValue :: FactsResponse -> JSValue
 factsResponseToJSValue FactsResponse{frsFacts} =
@@ -79,6 +170,97 @@ verifyFactsResponse
     :: TrustedRoot -> FactsResponse -> Either VerifyError FactsResponse
 verifyFactsResponse trustedRoot facts =
     verifiedTokenFacts <$> verifyTokenFacts trustedRoot facts
+
+requestJSONToRequestZoo :: WitnessedRequest -> Either String RequestZoo
+requestJSONToRequestZoo WitnessedRequest{wrUtxo, wrRequest} =
+    let refId = txInRefId $ wuTxIn wrUtxo
+    in  requestJSONToJSValue refId wrRequest >>= parseRequestZoo
+
+requestJSONToJSValue
+    :: RequestRefId -> RequestJSON -> Either String JSValue
+requestJSONToJSValue
+    refId
+    RequestJSON{rjOwner, rjKey = Hex key, rjOperation, rjValue} = do
+        keyValue <- canonicalBytesToJSValue "request.key" (Hex key)
+        operationFields <- requestOperationFields rjOperation rjValue
+        pure
+            $ runIdentity
+            $ object
+                [ "outputRefId" .= refId
+                , "owner" .= Owner (T.unpack rjOwner)
+                ,
+                    ( "change"
+                    , object
+                        $ ("key" .= jsonToString keyValue)
+                            : operationFields
+                    )
+                ]
+
+requestOperationFields
+    :: T.Text -> Maybe Hex -> Either String [(String, Identity JSValue)]
+requestOperationFields "insert" maybeValue = do
+    value <- requiredValue "insert" maybeValue
+    pure
+        [ "type" .= ("insert" :: String)
+        , "newValue" .= jsonToString value
+        ]
+requestOperationFields "delete" maybeValue = do
+    value <- optionalValue maybeValue
+    pure
+        [ "type" .= ("delete" :: String)
+        , "oldValue" .= jsonToString value
+        ]
+requestOperationFields "update" maybeValue = do
+    value <- optionalValue maybeValue
+    pure
+        [ "type" .= ("update" :: String)
+        , "oldValue" .= jsonToString JSNull
+        , "newValue" .= jsonToString value
+        ]
+requestOperationFields operation _ =
+    Left $ "unknown request operation: " <> T.unpack operation
+
+requiredValue :: String -> Maybe Hex -> Either String JSValue
+requiredValue operation =
+    maybe
+        (Left $ operation <> " request is missing value")
+        (canonicalBytesToJSValue $ "request." <> operation <> ".value")
+
+optionalValue :: Maybe Hex -> Either String JSValue
+optionalValue Nothing = Right JSNull
+optionalValue (Just hexValue) =
+    canonicalBytesToJSValue "request.value" hexValue
+
+canonicalBytesToJSValue :: String -> Hex -> Either String JSValue
+canonicalBytesToJSValue field (Hex bytes) =
+    maybeToEither
+        (field <> " is not canonical JSON")
+        (parseJSValue bytes :: Maybe JSValue)
+
+parseRequestZoo :: JSValue -> Either String RequestZoo
+parseRequestZoo value =
+    maybeToEither
+        "verified request JSON did not match moog RequestZoo"
+        (fromJSON value)
+
+witnessedTokenStateToTokenState :: WitnessedTokenState -> TokenState
+witnessedTokenStateToTokenState
+    WitnessedTokenState{wtsState = TokenStateJSON{owner, root = Hex root}} =
+        TokenState
+            { tokenRoot = Root $ hexString root
+            , tokenOwner = Owner $ T.unpack owner
+            }
+
+txInRefId :: TxInJSON -> RequestRefId
+txInRefId TxInJSON{tjTxId = Hex txId, tjTxIx} =
+    RequestRefId
+        $ T.decodeUtf8 (Base16.encode txId)
+            <> "#"
+            <> T.pack (show tjTxIx)
+
+hexString :: BS.ByteString -> String
+hexString =
+    B8.unpack . Base16.encode
 
 maybeToEither :: e -> Maybe a -> Either e a
 maybeToEither e =

--- a/test/MPFS/ReadSpec.hs
+++ b/test/MPFS/ReadSpec.hs
@@ -1,14 +1,44 @@
 module MPFS.ReadSpec (spec) where
 
 import Cardano.MPFS.API.Encoding (Hex (..))
-import Cardano.MPFS.API.Types (FactEntry (..), FactsResponse (..))
+import Cardano.MPFS.API.Types
+    ( FactEntry (..)
+    , FactsResponse (..)
+    , RequestJSON (..)
+    , RequestsResponse (..)
+    , TokenResponse (..)
+    , TokenStateJSON (..)
+    , TxInJSON (..)
+    , WitnessedRequest (..)
+    , WitnessedTokenState (..)
+    , WitnessedUtxo (..)
+    )
+import Cardano.MPFS.API.Types.Common
+    ( ChainPointJSON (..)
+    , TokenIdJSON (..)
+    , UtxoSetWitness (..)
+    , VerificationSnapshot (..)
+    )
+import Core.Types.Change qualified as Change
+import Core.Types.Operation qualified as Operation
 import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Core.Types.Basic (Owner (..), RequestRefId (..))
 import Core.Types.Fact (Fact (..), Slot (..), parseFacts)
+import Core.Types.Tx (Root (..))
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
+import Data.Functor.Identity (Identity (..))
+import Data.Text qualified as T
 import MPFS.Read
     ( factEntriesToJSValue
     , verifyFactsResponseWith
+    , verifyTokenResponsesWith
+    )
+import Oracle.Types
+    ( Request (..)
+    , RequestZoo (..)
+    , Token (..)
+    , TokenState (..)
     )
 import Test.Hspec
     ( Spec
@@ -18,7 +48,8 @@ import Test.Hspec
     , shouldSatisfy
     )
 import Text.JSON.Canonical
-    ( JSValue (..)
+    ( FromJSON (..)
+    , JSValue (..)
     , renderCanonicalJSON
     , toJSString
     )
@@ -40,6 +71,39 @@ spec =
                         unusedFactsResponse
 
             result `shouldSatisfy` isLeft
+
+        it "maps verified token state and requests to moog Token JSON" $ do
+            let result =
+                    verifyTokenResponsesWith
+                        acceptTokenResponse
+                        acceptRequestsResponse
+                        sampleTokenId
+                        sampleTrustedRoot
+                        sampleTokenResponse
+                        sampleRequestsResponse
+
+            (result >>= parseToken) `shouldBe` Right sampleToken
+
+        it "fails closed when state or request verification rejects" $ do
+            let stateFailure =
+                    verifyTokenResponsesWith
+                        rejectTokenResponse
+                        acceptRequestsResponse
+                        sampleTokenId
+                        sampleTrustedRoot
+                        sampleTokenResponse
+                        sampleRequestsResponse
+                requestFailure =
+                    verifyTokenResponsesWith
+                        acceptTokenResponse
+                        rejectRequestsResponse
+                        sampleTokenId
+                        sampleTrustedRoot
+                        sampleTokenResponse
+                        sampleRequestsResponse
+
+            stateFailure `shouldSatisfy` isLeft
+            requestFailure `shouldSatisfy` isLeft
 
 sampleEntries :: [FactEntry]
 sampleEntries =
@@ -73,8 +137,173 @@ unusedFactsResponse =
         , frsFacts = []
         }
 
+sampleTokenId :: TokenIdJSON
+sampleTokenId =
+    TokenIdJSON "token-id"
+
+sampleTokenResponse :: TokenResponse
+sampleTokenResponse =
+    TokenResponse
+        { trSnapshot = unusedSnapshot
+        , trState =
+            WitnessedTokenState
+                { wtsUtxo =
+                    WitnessedUtxo
+                        { wuTxIn = sampleStateTxIn
+                        , wuTxOut = Hex ""
+                        , wuProof = Hex ""
+                        }
+                , wtsState =
+                    TokenStateJSON
+                        { owner = "owner"
+                        , root = Hex sampleRoot
+                        , tip = 1000000
+                        , processTime = 60000
+                        , retractTime = 30000
+                        }
+                }
+        }
+
+sampleRequestsResponse :: RequestsResponse
+sampleRequestsResponse =
+    RequestsResponse
+        { rrSnapshot = unusedSnapshot
+        , rrRequestSet = unusedRequestSet
+        , rrRequests = [sampleWitnessedRequest]
+        }
+
+sampleWitnessedRequest :: WitnessedRequest
+sampleWitnessedRequest =
+    WitnessedRequest
+        { wrUtxo =
+            WitnessedUtxo
+                { wuTxIn = sampleRequestTxIn
+                , wuTxOut = Hex ""
+                , wuProof = Hex ""
+                }
+        , wrRequest =
+            RequestJSON
+                { rjToken = sampleTokenId
+                , rjOwner = "request-owner"
+                , rjKey = Hex $ canonicalBytes sampleKey
+                , rjOperation = "insert"
+                , rjValue = Just $ Hex $ canonicalBytes sampleValue
+                , rjFee = 1000000
+                , rjSubmittedAt = 42
+                }
+        }
+
+sampleToken :: Token Identity
+sampleToken =
+    Token
+        { tokenRefId = txInRef sampleStateTxIn
+        , tokenState =
+            TokenState
+                { tokenRoot = Root $ hexString sampleRoot
+                , tokenOwner = Owner "owner"
+                }
+        , tokenRequests =
+            [ Identity
+                $ UnknownInsertRequest
+                $ Request
+                    { outputRefId = txInRef sampleRequestTxIn
+                    , owner = Owner "request-owner"
+                    , change =
+                        Change.Change
+                            (Change.Key sampleKey)
+                            (Operation.Insert sampleValue)
+                    }
+            ]
+        }
+
+sampleStateTxIn :: TxInJSON
+sampleStateTxIn =
+    TxInJSON
+        { tjTxId = Hex $ BS.replicate 32 0x01
+        , tjTxIx = 0
+        }
+
+sampleRequestTxIn :: TxInJSON
+sampleRequestTxIn =
+    TxInJSON
+        { tjTxId = Hex $ BS.replicate 32 0x02
+        , tjTxIx = 1
+        }
+
+sampleRoot :: BS.ByteString
+sampleRoot =
+    BS.pack [0x00 .. 0x1f]
+
+parseToken :: JSValue -> Either String (Token Identity)
+parseToken value =
+    case fromJSON value of
+        Just token -> Right token
+        Nothing -> Left "Token JSON did not parse"
+
+txInRef :: TxInJSON -> RequestRefId
+txInRef TxInJSON{tjTxId = Hex txId, tjTxIx} =
+    RequestRefId
+        $ T.pack (hexString txId)
+            <> "#"
+            <> T.pack (show tjTxIx)
+
+hexString :: BS.ByteString -> String
+hexString =
+    concatMap (flip showHexByte "")
+        . BS.unpack
+  where
+    showHexByte byte =
+        showString [hexDigit $ byte `div` 16, hexDigit $ byte `mod` 16]
+    hexDigit n
+        | n < 10 = toEnum $ fromEnum '0' + fromIntegral n
+        | otherwise = toEnum $ fromEnum 'a' + fromIntegral n - 10
+
+unusedSnapshot :: VerificationSnapshot
+unusedSnapshot =
+    VerificationSnapshot
+        { vsUtxoRoot = Hex sampleRoot
+        , vsChainPoint =
+            ChainPointJSON
+                { cpSlot = 42
+                , cpBlockId = Hex $ BS.replicate 32 0x03
+                }
+        }
+
+unusedRequestSet :: UtxoSetWitness
+unusedRequestSet =
+    UtxoSetWitness
+        { uswEntries = []
+        , uswCompletenessProof = Hex ""
+        }
+
 data SampleVerifyError = SampleVerifyError
     deriving stock (Show)
+
+acceptTokenResponse
+    :: TrustedRoot -> TokenResponse -> Either SampleVerifyError TokenResponse
+acceptTokenResponse _ =
+    Right
+
+rejectTokenResponse
+    :: TrustedRoot -> TokenResponse -> Either SampleVerifyError TokenResponse
+rejectTokenResponse _ _ =
+    Left SampleVerifyError
+
+acceptRequestsResponse
+    :: TokenIdJSON
+    -> TrustedRoot
+    -> RequestsResponse
+    -> Either SampleVerifyError RequestsResponse
+acceptRequestsResponse _ _ =
+    Right
+
+rejectRequestsResponse
+    :: TokenIdJSON
+    -> TrustedRoot
+    -> RequestsResponse
+    -> Either SampleVerifyError RequestsResponse
+rejectRequestsResponse _ _ _ =
+    Left SampleVerifyError
 
 isLeft :: Either a b -> Bool
 isLeft (Left _) = True


### PR DESCRIPTION
Draft for #159 (epic #146). Re-pins offchain to 1b91a1f (read verifiers) and migrates `getToken` to `GET /tokens/:id` + `verifyTokenState` and `GET /tokens/:id/requests` + `verifyTokenRequests` (request-set completeness), assembling moog's `Token`. Unblocked by offchain #310. Targets `moog-v2`. Closes #159.