### PR TITLE
moog-v2: re-pin offchain main (677ec55) + adapt cage builders to *WithEval/eval-context

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,8 +11,8 @@ packages:
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-mpfs-offchain.git
-  tag: 677ec552659f42893035bcb9c372be20584eb79e
-  --sha256: 0pscwxca8w8q05g78kbism5mnigrjm0firr0v1axa4rzsrwlk4zq
+  tag: e483c500195e77646ed9e2f11c0b090ec96d382e
+  --sha256: 1z6lhdw80bq3lc9azk0z09frdnh4y8bhx2lp3ywcvgr9i8xxkxwz
   subdir:
     cardano-mpfs-api
     cardano-mpfs-cage-tx

--- a/cabal.project
+++ b/cabal.project
@@ -11,8 +11,8 @@ packages:
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-mpfs-offchain.git
-  tag: 1b91a1f66b26cb868fa1685442fdba56d084d972
-  --sha256: 0k5ka5pi915336vxf4wm3drvk0y8g4p6qg5gpwf75wnqc19nkvv7
+  tag: 677ec552659f42893035bcb9c372be20584eb79e
+  --sha256: 0pscwxca8w8q05g78kbism5mnigrjm0firr0v1axa4rzsrwlk4zq
   subdir:
     cardano-mpfs-api
     cardano-mpfs-cage-tx
@@ -51,8 +51,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/haskell-mts
-  tag: 2893775286801e91afe10e14775507a36e97e169
-  --sha256: 1ipwx1xgbyp0fwyq90zp7j6habvl0164d08s4mfbixg40w15sd8w
+  tag: f2e9f584f2ed9dff3990300f1b646090f122585b
+  --sha256: 015gzc7f419qhm4d893v9h3a6pzk66vjcbmjs37dlg6ypxwc3sry
 
 source-repository-package
   type: git
@@ -83,8 +83,14 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-tx-tools
-  tag: 97374ffb611d08d2e0e7c17dfdac5699ac2b3ed8
-  --sha256: 0jsnq3hbay8y12jc0sz3jqdd99rrhkiqc0qkppf37hc3qv46p5fx
+  tag: 631f1341fde6e4a11e94b058cf5f2925ffeb9eac
+  --sha256: 0asp3sx7hd8hip739kbz65986jlv8qx9342m9gqpqcxih6pxfgjj
+
+source-repository-package
+  type: git
+  location: https://github.com/lambdasistemi/cardano-utxo-csmt
+  tag: f4772f73dde0a84dff9608d6ac2b168c4315b05f
+  --sha256: 129sv2ayp7y2s5mhapx3720pr005dnfybz02nwibgyhsjqp292vz
 
 source-repository-package
   type: git

--- a/gate.sh
+++ b/gate.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-git diff --check
-nix build --quiet --no-link .#moog-agent
-nix --quiet run .#unit-tests

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+git diff --check
+nix build --quiet --no-link .#moog-agent
+nix --quiet run .#unit-tests

--- a/specs/162-cage-witheval/tasks.md
+++ b/specs/162-cage-witheval/tasks.md
@@ -1,4 +1,4 @@
 # Tasks — #162 adapt cage builders to offchain *WithEval (eval-context)
 
 ## Slice S1 — *WithEval migration
-- [ ] T162-S1 Add eval-context fetch+decode (mirror offchain Workflow.resolveEvalContext, in ClientM: GET /eval-context -> decodeEvalContext -> DecodedEvalContext); migrate src/MPFS/{Boot,End,Retract,Update}.hs to *WithEval (thread DecodedEvalContext as first arg); imports updated; `./gate.sh` green.
+- [X] T162-S1 Add eval-context fetch+decode (mirror offchain Workflow.resolveEvalContext, in ClientM: GET /eval-context -> decodeEvalContext -> DecodedEvalContext); migrate src/MPFS/{Boot,End,Retract,Update}.hs to *WithEval (thread DecodedEvalContext as first arg); imports updated; `./gate.sh` green.

--- a/specs/162-cage-witheval/tasks.md
+++ b/specs/162-cage-witheval/tasks.md
@@ -1,0 +1,4 @@
+# Tasks — #162 adapt cage builders to offchain *WithEval (eval-context)
+
+## Slice S1 — *WithEval migration
+- [ ] T162-S1 Add eval-context fetch+decode (mirror offchain Workflow.resolveEvalContext, in ClientM: GET /eval-context -> decodeEvalContext -> DecodedEvalContext); migrate src/MPFS/{Boot,End,Retract,Update}.hs to *WithEval (thread DecodedEvalContext as first arg); imports updated; `./gate.sh` green.

--- a/src/MPFS/Boot.hs
+++ b/src/MPFS/Boot.hs
@@ -13,7 +13,7 @@ import Cardano.MPFS.API.Types
     , BootRequest (..)
     , StatusResponse (..)
     )
-import Cardano.MPFS.Client.Cage.Boot (bootCageTx)
+import Cardano.MPFS.Client.Cage.Boot (bootCageTxWithEval)
 import Cardano.MPFS.Client.Cage.Config
     ( CageConfig (..)
     , cagePolicyIdFromCfg
@@ -43,6 +43,7 @@ import MPFS.Cage
     ( addressBytesForCage
     , liftEitherClientM
     , loadCageConfig
+    , resolveEvalContext
     , txHex
     , walletPolicy
     )
@@ -67,8 +68,11 @@ bootTokenFromFacts getStatus postBootFacts address = do
             $ firstShow
             $ verifyBootFacts (TrustedRoot trustedRoot) facts
     cfg <- liftIO $ loadCageConfig rawAddress
+    evalCtx <- resolveEvalContext
     tx <-
-        liftEitherClientM $ firstShow $ bootCageTx cfg walletPolicy verified
+        liftEitherClientM
+            $ firstShow
+            $ bootCageTxWithEval evalCtx cfg walletPolicy verified
     tokenId <- liftEitherClientM $ extractTokenId cfg tx
     pure
         $ WithUnsignedTx

--- a/src/MPFS/Cage.hs
+++ b/src/MPFS/Cage.hs
@@ -4,6 +4,7 @@ module MPFS.Cage
     ( addressBytesForCage
     , liftEitherClientM
     , loadCageConfig
+    , resolveEvalContext
     , txHex
     , walletPolicy
     ) where
@@ -12,6 +13,8 @@ import Cardano.Ledger.BaseTypes (Network (..))
 import Cardano.Ledger.Binary (natVersion, serialize')
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Plutus.ExUnits (Prices (..))
+import Cardano.MPFS.API (EvalContextAPI)
+import Cardano.MPFS.API.Types (EvalContext)
 import Cardano.MPFS.Cage.Blueprint
     ( Blueprint
     , extractCompiledCode
@@ -20,6 +23,10 @@ import Cardano.MPFS.Cage.Blueprint
 import Cardano.MPFS.Client.Cage.Config
     ( CageConfig (..)
     , computeScriptHash
+    )
+import Cardano.MPFS.Client
+    ( DecodedEvalContext
+    , decodeEvalContext
     )
 import Cardano.MPFS.Client.Cage.Policy (WalletPolicy (..))
 import Cardano.Slotting.Slot (SlotNo (..))
@@ -33,9 +40,10 @@ import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as Base16
 import Data.ByteString.Short qualified as SBS
+import Data.Proxy (Proxy (..))
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
-import Servant.Client (ClientM)
+import Servant.Client (ClientM, client)
 import System.Environment (lookupEnv)
 
 import Cardano.Tx.Ledger (ConwayTx)
@@ -70,6 +78,15 @@ loadCageConfig rawAddress = do
             , defaultTip = Coin 1_000_000
             , network = networkFromAddressBytes rawAddress
             }
+
+resolveEvalContext :: ClientM DecodedEvalContext
+resolveEvalContext = do
+    wire <- evalContextClient
+    liftEitherClientM $ firstShow $ decodeEvalContext wire
+  where
+    evalContextClient :: ClientM EvalContext
+    evalContextClient =
+        client (Proxy @EvalContextAPI)
 
 walletPolicy :: WalletPolicy
 walletPolicy =

--- a/src/MPFS/End.hs
+++ b/src/MPFS/End.hs
@@ -10,7 +10,7 @@ import Cardano.MPFS.API.Types
     , StatusResponse (..)
     )
 import Cardano.MPFS.API.Types.Common (TokenIdJSON (..))
-import Cardano.MPFS.Client.Cage.End (endCageTx)
+import Cardano.MPFS.Client.Cage.End (endCageTxWithEval)
 import Cardano.MPFS.Client.Facts (verifyEndFacts)
 import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
 import Control.Monad.IO.Class (liftIO)
@@ -28,6 +28,7 @@ import MPFS.Cage
     ( addressBytesForCage
     , liftEitherClientM
     , loadCageConfig
+    , resolveEvalContext
     , txHex
     , walletPolicy
     )
@@ -52,8 +53,11 @@ endTokenFromFacts getStatus postEndFacts address tokenId = do
         liftEitherClientM
             $ firstShow
             $ verifyEndFacts cfg (TrustedRoot trustedRoot) facts
+    evalCtx <- resolveEvalContext
     tx <-
-        liftEitherClientM $ firstShow $ endCageTx cfg walletPolicy verified
+        liftEitherClientM
+            $ firstShow
+            $ endCageTxWithEval evalCtx cfg walletPolicy verified
     pure
         $ WithUnsignedTx
             (UnsignedTx $ txHex tx)

--- a/src/MPFS/Retract.hs
+++ b/src/MPFS/Retract.hs
@@ -8,7 +8,7 @@ import Cardano.MPFS.API.Types
     ( RetractRequest (..)
     , StatusResponse (..)
     )
-import Cardano.MPFS.Client.Cage.Retract (retractCageTx)
+import Cardano.MPFS.Client.Cage.Retract (retractCageTxWithEval)
 import Cardano.MPFS.Client.Facts
     ( RetractFacts
     , verifyRetractFacts
@@ -27,6 +27,7 @@ import MPFS.Cage
     ( addressBytesForCage
     , liftEitherClientM
     , loadCageConfig
+    , resolveEvalContext
     , txHex
     , walletPolicy
     )
@@ -51,8 +52,11 @@ retractChangeFromFacts getStatus postFacts address requestRef = do
             $ verifyRetractFacts (TrustedRoot trustedRoot) facts
     rawAddress <- liftEitherClientM $ addressBytesForCage address
     cfg <- liftIO $ loadCageConfig rawAddress
+    evalCtx <- resolveEvalContext
     tx <-
-        liftEitherClientM $ firstShow $ retractCageTx cfg walletPolicy verified
+        liftEitherClientM
+            $ firstShow
+            $ retractCageTxWithEval evalCtx cfg walletPolicy verified
     pure $ WithUnsignedTx (UnsignedTx $ txHex tx) Nothing
 
 retractFactsRequest

--- a/src/MPFS/Update.hs
+++ b/src/MPFS/Update.hs
@@ -9,7 +9,7 @@ import Cardano.MPFS.API.Types
     , UpdateRequest (..)
     )
 import Cardano.MPFS.API.Types.Facts (UpdateFacts)
-import Cardano.MPFS.Client.Cage.Update (updateCageTx)
+import Cardano.MPFS.Client.Cage.Update (updateCageTxWithEval)
 import Cardano.MPFS.Client.Facts (verifyUpdateFacts)
 import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
 import Control.Monad.IO.Class (liftIO)
@@ -25,6 +25,7 @@ import MPFS.Cage
     ( addressBytesForCage
     , liftEitherClientM
     , loadCageConfig
+    , resolveEvalContext
     , txHex
     , walletPolicy
     )
@@ -50,8 +51,11 @@ updateTokenFromFacts getStatus postFacts address tokenId = do
             $ verifyUpdateFacts (TrustedRoot trustedRoot) facts
     rawAddress <- liftEitherClientM $ addressBytesForCage address
     cfg <- liftIO $ loadCageConfig rawAddress
+    evalCtx <- resolveEvalContext
     tx <-
-        liftEitherClientM $ firstShow $ updateCageTx cfg walletPolicy verified
+        liftEitherClientM
+            $ firstShow
+            $ updateCageTxWithEval evalCtx cfg walletPolicy verified
     pure $ WithUnsignedTx (UnsignedTx $ txHex tx) Nothing
 
 updateTokenFactsRequest
@@ -60,6 +64,7 @@ updateTokenFactsRequest address tokenId =
     UpdateRequest
         <$> tokenIdJSONFromTokenId tokenId
         <*> (Hex <$> addressBytesForCage address)
+        <*> pure []
 
 firstShow :: Show e => Either e a -> Either String a
 firstShow =

--- a/test/MPFS/WriteFactsSpec.hs
+++ b/test/MPFS/WriteFactsSpec.hs
@@ -93,6 +93,7 @@ spec =
                 Right UpdateRequest{..} -> do
                     urToken `shouldBe` sampleTokenJSON
                     urAddr `shouldBe` Hex sampleAddressBytes
+                    urRequests `shouldBe` []
 
         it "builds POST /facts/retract request bodies" $
             case retractFactsRequest sampleAddress sampleRequestRef of


### PR DESCRIPTION
Re-pin offchain to latest `main` (`677ec55`). Aligns the shared deps the offchain bumped/added so its packages resolve in moog's closure: `haskell-mts`→`f2e9f58`, `cardano-tx-tools`→`631f134` (provides the `tx-build` lib `cardano-mpfs-cage-tx` now needs), and adds `cardano-utxo-csmt`→`f4772f7` (new offchain dep). Targets `moog-v2`.