### PR TITLE
moog-v2: requester flows on the facts API (#148)

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-git diff --check
-nix build --quiet --no-link .#moog-agent
-nix --quiet run .#unit-tests

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+git diff --check
+nix build --quiet --no-link .#moog-agent
+nix --quiet run .#unit-tests

--- a/specs/148-requester-facts-flows/tasks.md
+++ b/specs/148-requester-facts-flows/tasks.md
@@ -1,4 +1,4 @@
 # Tasks — #148 requester flows on the facts API
 
 ## Slice S1 — migrate src/User/Requester writes to *FromFacts
-- [ ] T148-S1 Repoint legacy mpfs write ops in `src/User/Requester/*` to their `*FromFacts` variants (record fields from #147); flows still validate; `./gate.sh` green.
+- [x] T148-S1 Repoint legacy mpfs write ops in `src/User/Requester/*` to their `*FromFacts` variants (record fields from #147); flows still validate; `./gate.sh` green.

--- a/specs/148-requester-facts-flows/tasks.md
+++ b/specs/148-requester-facts-flows/tasks.md
@@ -1,0 +1,4 @@
+# Tasks — #148 requester flows on the facts API
+
+## Slice S1 — migrate src/User/Requester writes to *FromFacts
+- [ ] T148-S1 Repoint legacy mpfs write ops in `src/User/Requester/*` to their `*FromFacts` variants (record fields from #147); flows still validate; `./gate.sh` green.

--- a/src/User/Requester/Cli.hs
+++ b/src/User/Requester/Cli.hs
@@ -258,7 +258,7 @@ createCommand
                 $ Change (Key testRun) (Insert newState)
             value <- toJSON newState
             wtx <- lift $ submit $ \address -> do
-                mpfsRequestInsert mpfs address tokenId
+                mpfsRequestInsertFromFacts mpfs address tokenId
                     $ RequestInsertBody{key, value}
             hash <- keyHash testRun
             pure
@@ -291,7 +291,7 @@ registerUser
                 $ \address -> do
                     key <- toJSON request
                     value <- toJSON ()
-                    mpfsRequestInsert mpfs address tokenId
+                    mpfsRequestInsertFromFacts mpfs address tokenId
                         $ RequestInsertBody{key = key, value = value}
 
 unregisterUser
@@ -317,7 +317,7 @@ unregisterUser
                 $ \address -> do
                     key <- toJSON request
                     value <- toJSON ()
-                    mpfsRequestDelete mpfs address tokenId
+                    mpfsRequestDeleteFromFacts mpfs address tokenId
                         $ RequestDeleteBody{key = key, value = value}
 
 registerRole
@@ -343,7 +343,7 @@ registerRole
                 $ \address -> do
                     key <- toJSON request
                     value <- toJSON ()
-                    mpfsRequestInsert mpfs address tokenId
+                    mpfsRequestInsertFromFacts mpfs address tokenId
                         $ RequestInsertBody{key = key, value = value}
 
 unregisterRole
@@ -369,5 +369,5 @@ unregisterRole
                 $ \address -> do
                     key <- toJSON request
                     value <- toJSON ()
-                    mpfsRequestDelete mpfs address tokenId
+                    mpfsRequestDeleteFromFacts mpfs address tokenId
                         $ RequestDeleteBody{key = key, value = value}

--- a/test/User/Requester/CliSpec.hs
+++ b/test/User/Requester/CliSpec.hs
@@ -225,7 +225,17 @@ spec = describe "User.Requester.Cli" $ do
                     hasInstrumentation
 
         withContext
-            mockMPFS{mpfsGetTokenFacts = const . pure $ renderFacts facts}
+            -- Expect the facts-based write path: the requester must route
+            -- inserts through mpfsRequestInsertFromFacts. The legacy field is
+            -- wired to fail closed so a stale call site is caught here.
+            mockMPFS
+                { mpfsGetTokenFacts = const . pure $ renderFacts facts
+                , mpfsRequestInsertFromFacts = mpfsRequestInsert mockMPFS
+                , mpfsRequestInsert =
+                    \_ _ _ ->
+                        error
+                            "requester must use mpfsRequestInsertFromFacts"
+                }
             ( \_ _ ->
                 mkEffects
                     (withFacts facts mockMPFS)


### PR DESCRIPTION
Draft for #148 (epic #146). Migrate src/User/Requester/* role flows to the facts-based write ops (mpfs*FromFacts, from #147); reads already verified (#155/#159). Targets moog-v2. Closes #148.