### PR TITLE
moog-v2: oracle flows on the facts API (#149)

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-git diff --check
-nix build --quiet --no-link .#moog-agent
-nix --quiet run .#unit-tests

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+git diff --check
+nix build --quiet --no-link .#moog-agent
+nix --quiet run .#unit-tests

--- a/moog.cabal
+++ b/moog.cabal
@@ -504,6 +504,7 @@ test-suite unit-tests
     MPFS.CanarySpec
     MPFS.ReadSpec
     MPFS.WriteFactsSpec
+    Oracle.Config.CliSpec
     Oracle.Config.TypesSpec
     Oracle.TypesSpec
     Oracle.Validate.Requests.ConfigSpec

--- a/specs/149-oracle-facts-flows/tasks.md
+++ b/specs/149-oracle-facts-flows/tasks.md
@@ -1,4 +1,12 @@
 # Tasks — #149 oracle flows on the facts API
 
 ## Slice S1 — migrate src/Oracle writes to *FromFacts
-- [ ] T149-S1 Repoint legacy mpfs write ops in `src/Oracle/*` to their `*FromFacts` variants (record fields from #147); flows still validate; `./gate.sh` green.
+- [x] T149-S1 Repoint legacy mpfs write ops in `src/Oracle/*` to their `*FromFacts` variants (record fields from #147); flows still validate; `./gate.sh` green.
+  - Done: `src/Oracle/Config/Cli.hs` now uses `mpfsRequestInsertFromFacts` /
+    `mpfsRequestUpdateFromFacts` (pure swaps; identical arg shape and flow).
+  - Out of scope: `src/Oracle/Token/Cli.hs` update-token stays on legacy
+    `mpfsUpdateToken`. `mpfsUpdateTokenFromFacts` drops the `[RequestRefId]` subset
+    arg and (offchain e483c50) merges ALL pending requests while skipping the
+    owner/processability checks — a fail-open change vs the validated `wanted`
+    subset. Migrating it needs a subset-capable facts path + validation rework,
+    split to **#166**.

--- a/specs/149-oracle-facts-flows/tasks.md
+++ b/specs/149-oracle-facts-flows/tasks.md
@@ -1,0 +1,4 @@
+# Tasks — #149 oracle flows on the facts API
+
+## Slice S1 — migrate src/Oracle writes to *FromFacts
+- [ ] T149-S1 Repoint legacy mpfs write ops in `src/Oracle/*` to their `*FromFacts` variants (record fields from #147); flows still validate; `./gate.sh` green.

--- a/src/Oracle/Config/Cli.hs
+++ b/src/Oracle/Config/Cli.hs
@@ -12,7 +12,7 @@ import Core.Types.Tx (WithTxHash (..), setWithTxHashValue)
 import Core.Types.Wallet (Wallet)
 import Facts (FactsSelection (..), factsCmd)
 import MPFS.API
-    ( MPFS (mpfsRequestInsert, mpfsRequestUpdate)
+    ( MPFS (mpfsRequestInsertFromFacts, mpfsRequestUpdateFromFacts)
     , RequestInsertBody (RequestInsertBody, key, value)
     , RequestUpdateBody (RequestUpdateBody, key, newValue, oldValue)
     )
@@ -44,7 +44,7 @@ configCmd (SetConfig tokenId wallet config) = do
         [oldConfig] -> do
             oldValue <- toJSON $ factValue oldConfig
             run $ \address ->
-                mpfsRequestUpdate mpfs address tokenId
+                mpfsRequestUpdateFromFacts mpfs address tokenId
                     $ RequestUpdateBody
                         { key = jkey
                         , newValue = jvalue
@@ -52,5 +52,5 @@ configCmd (SetConfig tokenId wallet config) = do
                         }
         _ -> do
             run $ \address ->
-                mpfsRequestInsert mpfs address tokenId
+                mpfsRequestInsertFromFacts mpfs address tokenId
                     $ RequestInsertBody{key = jkey, value = jvalue}

--- a/test/Oracle/Config/CliSpec.hs
+++ b/test/Oracle/Config/CliSpec.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Tests that the oracle config flow routes its on-chain writes through
+-- the facts-based MPFS operations rather than the legacy endpoints.
+module Oracle.Config.CliSpec
+    ( spec
+    ) where
+
+import Core.Context (withContext)
+import Core.Types.Basic
+    ( Address (..)
+    , Owner (..)
+    , Success (..)
+    , TokenId (..)
+    )
+import Core.Types.Fact (JSFact, toJSFact)
+import Core.Types.Tx
+    ( TxHash (..)
+    , UnsignedTx (..)
+    , WithTxHash (..)
+    , WithUnsignedTx (..)
+    )
+import Core.Types.Wallet (Wallet)
+import Data.Functor.Identity (Identity (..))
+import Data.Text (Text)
+import MPFS.API (MPFS (..))
+import MockMPFS (mockMPFS, withFacts)
+import Oracle.Config.Cli (ConfigCmd (..), configCmd)
+import Oracle.Config.Types
+    ( Config
+    , ConfigKey (..)
+    , mkCurrentConfig
+    )
+import Oracle.Validate.Requests.TestRun.Config
+    ( TestRunValidationConfig (..)
+    )
+import Oracle.Validate.Requests.TestRun.Lib (mkEffects, noValidation)
+import Submitting (Submission (..))
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+import Text.JSON.Canonical (JSValue)
+
+spec :: Spec
+spec =
+    describe "Oracle.Config.Cli facts-based writes" $ do
+        it "routes a config insert through mpfsRequestInsertFromFacts" $ do
+            let result = runConfig markedMPFS
+            -- empty config facts -> insert branch
+            txHash result `shouldBe` TxHash "facts-insert"
+
+        it "routes a config update through mpfsRequestUpdateFromFacts" $ do
+            let result = runConfig (withFacts [configFact] markedMPFS)
+            -- one existing config fact -> update branch
+            txHash result `shouldBe` TxHash "facts-update"
+
+-- | Run the @SetConfig@ command against a mock MPFS, returning the
+-- submitted transaction wrapper. The submission surfaces which builder
+-- ran via the unsigned-tx marker promoted into the tx hash.
+runConfig :: MPFS Identity -> WithTxHash Success
+runConfig mpfs =
+    runIdentity
+        $ withContext
+            mpfs
+            (\m _ -> mkEffects m noValidation)
+            (const recordingSubmission)
+            (configCmd (SetConfig sampleToken sampleWallet sampleConfig))
+
+-- | A mock MPFS where each write op returns a distinct marker, so the
+-- test can observe which one the flow selected.
+markedMPFS :: MPFS Identity
+markedMPFS =
+    mockMPFS
+        { mpfsRequestInsert = \_ _ _ -> pure (marker "legacy-insert")
+        , mpfsRequestUpdate = \_ _ _ -> pure (marker "legacy-update")
+        , mpfsRequestInsertFromFacts =
+            \_ _ _ -> pure (marker "facts-insert")
+        , mpfsRequestUpdateFromFacts =
+            \_ _ _ -> pure (marker "facts-update")
+        }
+
+-- | Build an unsigned-tx wrapper whose transaction text is a marker
+-- identifying the builder that produced it.
+marker :: Text -> WithUnsignedTx JSValue
+marker name = WithUnsignedTx (UnsignedTx name) Nothing
+
+-- | A submission that promotes the unsigned-tx marker into the tx hash,
+-- so a test can assert which MPFS builder was invoked.
+recordingSubmission :: Submission Identity
+recordingSubmission = Submission $ \action -> do
+    WithUnsignedTx (UnsignedTx tx) value <- action (Address "addr")
+    pure (WithTxHash (TxHash tx) value)
+
+sampleToken :: TokenId
+sampleToken = TokenId "deadbeef"
+
+-- | The config flow never inspects the wallet (the mock submission
+-- ignores it), so a bottom is safe and keeps the fixture light.
+sampleWallet :: Wallet
+sampleWallet = error "wallet is not forced by the config flow"
+
+sampleConfig :: Config
+sampleConfig =
+    mkCurrentConfig
+        (Owner "agent")
+        TestRunValidationConfig{minDuration = 1, maxDuration = 2}
+
+configFact :: JSFact
+configFact = runIdentity $ toJSFact ConfigKey sampleConfig 0


### PR DESCRIPTION
Draft for #149 (epic #146). Migrate src/Oracle/* role flows to the facts-based write ops (mpfs*FromFacts, from #147); reads already verified (#155/#159). Targets moog-v2. Closes #149.