### PR TITLE
moog-v2: agent flows on the facts API (#150)

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-git diff --check
-nix build --quiet --no-link .#moog-agent
-nix --quiet run .#unit-tests

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+git diff --check
+nix build --quiet --no-link .#moog-agent
+nix --quiet run .#unit-tests

--- a/specs/150-agent-facts-flows/tasks.md
+++ b/specs/150-agent-facts-flows/tasks.md
@@ -1,4 +1,4 @@
 # Tasks — #150 agent flows on the facts API
 
 ## Slice S1 — migrate src/User/Agent writes to *FromFacts
-- [ ] T150-S1 Repoint legacy mpfs write ops in `src/User/Agent/*` to their `*FromFacts` variants (record fields from #147); flows still validate; `./gate.sh` green.
+- [X] T150-S1 Repoint legacy mpfs write ops in `src/User/Agent/*` to their `*FromFacts` variants (record fields from #147); flows still validate; `./gate.sh` green.

--- a/specs/150-agent-facts-flows/tasks.md
+++ b/specs/150-agent-facts-flows/tasks.md
@@ -1,0 +1,4 @@
+# Tasks — #150 agent flows on the facts API
+
+## Slice S1 — migrate src/User/Agent writes to *FromFacts
+- [ ] T150-S1 Repoint legacy mpfs write ops in `src/User/Agent/*` to their `*FromFacts` variants (record fields from #147); flows still validate; `./gate.sh` green.

--- a/src/User/Agent/Cli.hs
+++ b/src/User/Agent/Cli.hs
@@ -421,7 +421,7 @@ whiteList tokenId wallet platform repo = do
         void $ validateAddWhiteListed validation requester configAgent change
         wtx <- lift $ submit $ \address -> do
             jkey <- toJSON key
-            mpfsRequestInsert mpfs address tokenId
+            mpfsRequestInsertFromFacts mpfs address tokenId
                 $ RequestInsertBody{key = jkey, value = JSNull}
         pure $ setWithTxHashValue wtx Success
 
@@ -451,7 +451,7 @@ blackList tokenId wallet platform repo = do
             $ validateRemoveWhiteListed validation requester configAgent change
         wtx <- lift $ submit $ \address -> do
             jkey <- toJSON key
-            mpfsRequestDelete mpfs address tokenId
+            mpfsRequestDeleteFromFacts mpfs address tokenId
                 $ RequestDeleteBody{key = jkey, value = JSNull}
         pure $ setWithTxHashValue wtx Success
 
@@ -510,7 +510,7 @@ signAndSubmitAnUpdate validate tokenId wallet (Fact testRun oldState _) newState
         key <- toJSON testRun
         oldValue <- toJSON oldState
         newValue <- toJSON newState
-        mpfsRequestUpdate mpfs address tokenId
+        mpfsRequestUpdateFromFacts mpfs address tokenId
             $ RequestUpdateBody{key, oldValue, newValue}
     pure $ setWithTxHashValue wtx newState
 


### PR DESCRIPTION
Draft for #150 (epic #146). Migrate src/User/Agent/* role flows to the facts-based write ops (mpfs*FromFacts, from #147); reads already verified (#155/#159). Targets moog-v2. Closes #150.