### PR TITLE
moog-v2: retire dead legacy MPFS surface (#151)

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+git diff --check
+nix build --quiet --no-link .#moog-agent
+nix --quiet run .#unit-tests

--- a/specs/151-retire-legacy/tasks.md
+++ b/specs/151-retire-legacy/tasks.md
@@ -1,0 +1,4 @@
+# Tasks — #151 retire dead legacy MPFS surface
+
+## Slice S1 — remove 0-consumer legacy ops/routes
+- [ ] T151-S1 Remove legacy MPFS ops with no live consumers (requestInsert/Delete/Update, retractChange, submitTransaction(legacy), waitNBlocks, getTransaction(legacy)) + their Servant routes + client fns + record fields, and the legacy token/:id + token/:id/facts route defs. KEEP mpfsUpdateToken (+ update-token route, pending #166), the *FromFacts ops, RequestInsert/Delete/UpdateBody (used by *FromFacts), v2 submit/await, the /tokens/* read clients, boot/end. `./gate.sh` green.


### PR DESCRIPTION
Remove legacy MPFS ops/routes/clients with no live consumers after flow migrations (#148-#150). KEEP mpfsUpdateToken + update-token route (pending #166) and all facts machinery. Targets moog-v2. Closes #151.