### PR TITLE
moog-v2: oracle update-token via facts (subset + validation) (#166)

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-git diff --check
-nix build --quiet --no-link .#moog-agent
-nix --quiet run .#unit-tests

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+git diff --check
+nix build --quiet --no-link .#moog-agent
+nix --quiet run .#unit-tests

--- a/specs/166-oracle-update-facts/tasks.md
+++ b/specs/166-oracle-update-facts/tasks.md
@@ -1,0 +1,4 @@
+# Tasks — #166 oracle update-token via facts (subset + validation)
+
+## Slice S1 — thread request subset + rewire oracle
+- [ ] T166-S1 Make updateTokenFromFacts/updateTokenFactsRequest carry [RequestRefId] (-> urRequests, stop hardcoding []); widen mpfsUpdateTokenFromFacts record op; rewire Oracle/Token/Cli.hs UpdateToken to mpfsUpdateTokenFromFacts (subset), keeping oracle-side validation; `./gate.sh` green.

--- a/specs/166-oracle-update-facts/tasks.md
+++ b/specs/166-oracle-update-facts/tasks.md
@@ -1,4 +1,4 @@
 # Tasks — #166 oracle update-token via facts (subset + validation)
 
 ## Slice S1 — thread request subset + rewire oracle
-- [ ] T166-S1 Make updateTokenFromFacts/updateTokenFactsRequest carry [RequestRefId] (-> urRequests, stop hardcoding []); widen mpfsUpdateTokenFromFacts record op; rewire Oracle/Token/Cli.hs UpdateToken to mpfsUpdateTokenFromFacts (subset), keeping oracle-side validation; `./gate.sh` green.
+- [X] T166-S1 Make updateTokenFromFacts/updateTokenFactsRequest carry [RequestRefId] (-> urRequests, stop hardcoding []); widen mpfsUpdateTokenFromFacts record op; rewire Oracle/Token/Cli.hs UpdateToken to mpfsUpdateTokenFromFacts (subset), keeping oracle-side validation; `./gate.sh` green.

--- a/src/MPFS/API.hs
+++ b/src/MPFS/API.hs
@@ -333,6 +333,7 @@ requestUpdateFromFacts =
 updateTokenFromFacts
     :: Address
     -> TokenId
+    -> [RequestRefId]
     -> ClientM (WithUnsignedTx JSValue)
 updateTokenFromFacts =
     Update.updateTokenFromFacts status' updateFacts'
@@ -531,6 +532,7 @@ data MPFS m = MPFS
     , mpfsUpdateTokenFromFacts
         :: Address
         -> TokenId
+        -> [RequestRefId]
         -> m (WithUnsignedTx JSValue)
     , mpfsGetToken :: TokenId -> m JSValue
     , mpfsGetTokenFacts :: TokenId -> m JSValue

--- a/src/MPFS/Update.hs
+++ b/src/MPFS/Update.hs
@@ -15,6 +15,7 @@ import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
 import Control.Monad.IO.Class (liftIO)
 import Core.Types.Basic
     ( Address
+    , RequestRefId (requestId)
     , TokenId
     )
 import Core.Types.Tx
@@ -38,9 +39,10 @@ updateTokenFromFacts
     -> (UpdateRequest -> ClientM UpdateFacts)
     -> Address
     -> TokenId
+    -> [RequestRefId]
     -> ClientM (WithUnsignedTx JSValue)
-updateTokenFromFacts getStatus postFacts address tokenId = do
-    request <- liftEitherClientM $ updateTokenFactsRequest address tokenId
+updateTokenFromFacts getStatus postFacts address tokenId requests = do
+    request <- liftEitherClientM $ updateTokenFactsRequest address tokenId requests
     StatusResponse{currentUtxoRoot} <- getStatus
     trustedRoot <-
         liftEitherClientM $ maybeToEither noUtxoRoot currentUtxoRoot
@@ -59,12 +61,12 @@ updateTokenFromFacts getStatus postFacts address tokenId = do
     pure $ WithUnsignedTx (UnsignedTx $ txHex tx) Nothing
 
 updateTokenFactsRequest
-    :: Address -> TokenId -> Either String UpdateRequest
-updateTokenFactsRequest address tokenId =
+    :: Address -> TokenId -> [RequestRefId] -> Either String UpdateRequest
+updateTokenFactsRequest address tokenId requests =
     UpdateRequest
         <$> tokenIdJSONFromTokenId tokenId
         <*> (Hex <$> addressBytesForCage address)
-        <*> pure []
+        <*> pure (requestId <$> requests)
 
 firstShow :: Show e => Either e a -> Either String a
 firstShow =

--- a/src/Oracle/Token/Cli.hs
+++ b/src/Oracle/Token/Cli.hs
@@ -176,7 +176,7 @@ tokenCmdCore command = do
                             $ validateRequest oracle mconfig validation tokenRequest
                 WithTxHash txHash _ <- lift
                     $ submit
-                    $ \address -> mpfsUpdateToken mpfs address tk wanted
+                    $ \address -> mpfsUpdateTokenFromFacts mpfs address tk wanted
                 pure txHash
         BootToken wallet -> do
             Submission submit <- askSubmit wallet

--- a/test/MPFS/WriteFactsSpec.hs
+++ b/test/MPFS/WriteFactsSpec.hs
@@ -88,12 +88,15 @@ spec =
                     uvrAddr `shouldBe` Hex sampleAddressBytes
 
         it "builds POST /facts/update request bodies" $
-            case updateTokenFactsRequest sampleAddress sampleToken of
+            case updateTokenFactsRequest
+                sampleAddress
+                sampleToken
+                [sampleRequestRef] of
                 Left err -> error err
                 Right UpdateRequest{..} -> do
                     urToken `shouldBe` sampleTokenJSON
                     urAddr `shouldBe` Hex sampleAddressBytes
-                    urRequests `shouldBe` []
+                    urRequests `shouldBe` [requestId sampleRequestRef]
 
         it "builds POST /facts/retract request bodies" $
             case retractFactsRequest sampleAddress sampleRequestRef of
@@ -122,7 +125,7 @@ spec =
                         , mpfsRequestUpdateFromFacts =
                             \_ _ _ -> Identity tx
                         , mpfsUpdateTokenFromFacts =
-                            \_ _ -> Identity tx
+                            \_ _ _ -> Identity tx
                         , mpfsRetractChangeFromFacts =
                             \_ _ -> Identity tx
                         }
@@ -132,6 +135,7 @@ spec =
                     mpfs
                     sampleAddress
                     sampleToken
+                    [sampleRequestRef]
                 )
                 `shouldBe` tx
 

--- a/test/MockMPFS.hs
+++ b/test/MockMPFS.hs
@@ -42,7 +42,7 @@ mockMPFS =
         , mpfsRetractChangeFromFacts =
             \_ _ -> error "retract change facts not implemented"
         , mpfsUpdateTokenFromFacts =
-            \_ _ -> error "update token facts not implemented"
+            \_ _ _ -> error "update token facts not implemented"
         , mpfsGetToken = \_ -> toJSON $ mockToken []
         , mpfsGetTokenFacts = \_ -> toJSON ([] :: [JSFact])
         , mpfsSubmitTransaction = \_ -> error "submit transaction not implemented"


### PR DESCRIPTION
Thread the oracle's request subset through to /facts/update (offchain e483c50 already supports urRequests subset + readExactRequestSubset + validation). moog-only: stop hardcoding urRequests=[], widen mpfsUpdateTokenFromFacts, rewire Oracle/Token/Cli.hs off legacy mpfsUpdateToken. Unblocks full legacy retire (#151). Targets moog-v2. Closes #166.