### PR TITLE
moog-v2: retire all legacy MPFS surface (#151)

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-git diff --check
-nix build --quiet --no-link .#moog-agent
-nix --quiet run .#unit-tests

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+git diff --check
+nix build --quiet --no-link .#moog-agent
+nix --quiet run .#unit-tests

--- a/specs/151-retire-legacy/tasks.md
+++ b/specs/151-retire-legacy/tasks.md
@@ -1,4 +1,4 @@
 # Tasks — #151 retire ALL legacy MPFS surface
 
 ## Slice S1 — remove all legacy ops/routes (all now 0-consumer)
-- [ ] T151-S1 Remove ALL legacy MPFS record ops + Servant routes + client fns: requestInsert/Delete/Update, retractChange, updateToken, submitTransaction(legacy), waitNBlocks, getTransaction(legacy), and legacy token/:id + token/:id/facts read routes. KEEP *FromFacts, v2 submit/await, /tokens/* read clients (MPFS.Read), boot/end, and RequestInsert/Delete/UpdateBody (used by *FromFacts). `./gate.sh` green.
+- [X] T151-S1 Remove ALL legacy MPFS record ops + Servant routes + client fns: requestInsert/Delete/Update, retractChange, updateToken, submitTransaction(legacy), waitNBlocks, getTransaction(legacy), and legacy token/:id + token/:id/facts read routes. KEEP *FromFacts, v2 submit/await, /tokens/* read clients (MPFS.Read), boot/end, and RequestInsert/Delete/UpdateBody (used by *FromFacts). `./gate.sh` green.

--- a/specs/151-retire-legacy/tasks.md
+++ b/specs/151-retire-legacy/tasks.md
@@ -1,0 +1,4 @@
+# Tasks — #151 retire ALL legacy MPFS surface
+
+## Slice S1 — remove all legacy ops/routes (all now 0-consumer)
+- [ ] T151-S1 Remove ALL legacy MPFS record ops + Servant routes + client fns: requestInsert/Delete/Update, retractChange, updateToken, submitTransaction(legacy), waitNBlocks, getTransaction(legacy), and legacy token/:id + token/:id/facts read routes. KEEP *FromFacts, v2 submit/await, /tokens/* read clients (MPFS.Read), boot/end, and RequestInsert/Delete/UpdateBody (used by *FromFacts). `./gate.sh` green.

--- a/src/Cli.hs
+++ b/src/Cli.hs
@@ -26,7 +26,7 @@ import Lib.SSH.Private
 import MPFS.API
     ( MPFS (..)
     , mpfsClient
-    , retractChange
+    , retractChangeFromFacts
     )
 import Oracle.Cli (OracleCommand (..), oracleCmd)
 import Oracle.Config.Types (ProtocolFailure)
@@ -130,7 +130,7 @@ cmd = \case
                 $ fmap txHash
                 $ submit
                 $ \address ->
-                    retractChange address refId
+                    retractChangeFromFacts address refId
     GetFacts MPFSClient{runMPFS} tokenId factsCommand -> do
         let validation =
                 mkEffects

--- a/src/MPFS/API.hs
+++ b/src/MPFS/API.hs
@@ -1,27 +1,17 @@
 module MPFS.API
-    ( tokenApi
-    , TokenAPI
-    , SubmitV2Body (..)
-    , requestInsert
+    ( SubmitV2Body (..)
     , requestInsertFromFacts
-    , requestDelete
     , requestDeleteFromFacts
-    , requestUpdate
     , requestUpdateFromFacts
-    , retractChange
     , retractChangeFromFacts
-    , updateToken
     , updateTokenFromFacts
     , getToken
     , getTokenV2
     , getTokenFacts
-    , submitTransaction
     , submitTransactionV2
-    , waitNBlocks
     , RequestInsertBody (..)
     , RequestDeleteBody (..)
     , RequestUpdateBody (..)
-    , getTransaction
     , awaitTransactionV2
     , bootToken
     , endToken
@@ -82,11 +72,7 @@ import Servant.API
     , NoContent
     , Post
     , QueryParam
-    , QueryParam'
-    , QueryParams
     , ReqBody
-    , Required
-    , (:<|>) (..)
     , type (:>)
     )
 import Servant.Client (ClientM, client)
@@ -149,63 +135,12 @@ type RetractFactsEndpoint =
         :> ReqBody '[JSON] RetractRequest
         :> Post '[JSON] RetractFacts
 
-type EndToken =
-    "transaction"
-        :> Capture "address" Address
-        :> "end-token"
-        :> Capture "tokenId" TokenId
-        :> Get '[JSON] (WithUnsignedTx Value)
-
-type RequestInsert =
-    "transaction"
-        :> Capture "address" Address
-        :> "request-insert"
-        :> Capture "tokenId" TokenId
-        :> ReqBody '[JSON] RequestInsertBody
-        :> Post '[JSON] (WithUnsignedTx Value)
-
-type RequestDelete =
-    "transaction"
-        :> Capture "address" Address
-        :> "request-delete"
-        :> Capture "tokenId" TokenId
-        :> ReqBody '[JSON] RequestDeleteBody
-        :> Post '[JSON] (WithUnsignedTx Value)
-
-type RequestUpdate =
-    "transaction"
-        :> Capture "address" Address
-        :> "request-update"
-        :> Capture "tokenId" TokenId
-        :> ReqBody '[JSON] RequestUpdateBody
-        :> Post '[JSON] (WithUnsignedTx Value)
-
-type RetractChange =
-    "transaction"
-        :> Capture "address" Address
-        :> "retract-change"
-        :> Capture "requestId" RequestRefId
-        :> Get '[JSON] (WithUnsignedTx Value)
-
-type UpdateToken =
-    "transaction"
-        :> Capture "address" Address
-        :> "update-token"
-        :> Capture "tokenId" TokenId
-        :> QueryParams "request" RequestRefId
-        :> Get '[JSON] (WithUnsignedTx Value)
-
-type GetToken =
-    "token"
-        :> Capture "tokenId" TokenId
-        :> Get '[JSON] Value
-
 type GetTokenV2 =
     "tokens"
         :> Capture "tokenId" TokenId
         :> Get '[JSON] Value
 
-type GetTokenFacts =
+type GetTokenFactsRead =
     "tokens"
         :> Capture "tokenId" TokenId
         :> "facts"
@@ -222,48 +157,17 @@ type GetTokenRequests =
         :> "requests"
         :> Get '[JSON] RequestsResponse
 
-type SubmitTransaction =
-    "transaction"
-        :> ReqBody '[JSON] SignedTx
-        :> Post '[JSON] TxHash
-
 type SubmitTransactionV2 =
     "tx"
         :> "submit"
         :> ReqBody '[JSON] SubmitV2Body
         :> Post '[JSON] Text
 
-type WaitNBlocks =
-    "wait"
-        :> Capture "n" Int
-        :> Get '[JSON] Value
-
-type GetTransaction =
-    "transaction"
-        :> QueryParam' '[Required] "txHash" TxHash
-        :> Get '[JSON] Value
-
 type AwaitTransactionV2 =
     "tx"
         :> Capture "txId" TxHash
         :> QueryParam "timeout" Int
         :> Get '[JSON] NoContent
-
-type TokenAPI =
-    EndToken
-        :<|> RequestInsert
-        :<|> RequestDelete
-        :<|> RequestUpdate
-        :<|> RetractChange
-        :<|> UpdateToken
-        :<|> GetToken
-        :<|> GetTokenFacts
-        :<|> SubmitTransaction
-        :<|> WaitNBlocks
-        :<|> GetTransaction
-
-tokenApi :: Proxy TokenAPI
-tokenApi = Proxy
 
 bootToken
     :: Address -> ClientM (WithUnsignedTx JSValue)
@@ -273,38 +177,6 @@ endToken
     :: Address -> TokenId -> ClientM (WithUnsignedTx JSValue)
 endToken =
     endTokenFromFacts status' endFacts'
-requestInsert
-    :: Address
-    -> TokenId
-    -> RequestInsertBody
-    -> ClientM (WithUnsignedTx JSValue)
-requestInsert address tokenId body =
-    fmap fromAesonThrow <$> requestInsert' address tokenId body
-requestDelete
-    :: Address
-    -> TokenId
-    -> RequestDeleteBody
-    -> ClientM (WithUnsignedTx JSValue)
-requestDelete address tokenId body =
-    fmap fromAesonThrow <$> requestDelete' address tokenId body
-requestUpdate
-    :: Address
-    -> TokenId
-    -> RequestUpdateBody
-    -> ClientM (WithUnsignedTx JSValue)
-requestUpdate address tokenId body =
-    fmap fromAesonThrow <$> requestUpdate' address tokenId body
-retractChange
-    :: Address -> RequestRefId -> ClientM (WithUnsignedTx JSValue)
-retractChange address requestId =
-    fmap fromAesonThrow <$> retractChange' address requestId
-updateToken
-    :: Address
-    -> TokenId
-    -> [RequestRefId]
-    -> ClientM (WithUnsignedTx JSValue)
-updateToken address tokenId requests =
-    fmap fromAesonThrow <$> updateToken' address tokenId requests
 
 requestInsertFromFacts
     :: Address
@@ -354,65 +226,20 @@ getTokenFacts :: TokenId -> ClientM JSValue
 getTokenFacts =
     getTokenFactsFromVerifiedRead status' getTokenFacts'
 
-submitTransaction :: SignedTx -> ClientM TxHash
-submitTransaction = submitTransaction'
-
 submitTransactionV2 :: SignedTx -> ClientM TxHash
 submitTransactionV2 signed =
     TxHash <$> submitTransactionV2' (SubmitV2Body signed)
-
-waitNBlocks :: Int -> ClientM JSValue
-waitNBlocks n = fromAesonThrow <$> waitNBlocks' n
-getTransaction :: TxHash -> ClientM JSValue
-getTransaction txHash = fromAesonThrow <$> getTransaction' txHash
 
 awaitTransactionV2 :: TxHash -> ClientM ()
 awaitTransactionV2 txHash =
     void $ awaitTransactionV2' txHash (Just 1)
 
-requestInsert'
-    :: Address
-    -> TokenId
-    -> RequestInsertBody
-    -> ClientM (WithUnsignedTx Value)
-requestDelete'
-    :: Address
-    -> TokenId
-    -> RequestDeleteBody
-    -> ClientM (WithUnsignedTx Value)
-requestUpdate'
-    :: Address
-    -> TokenId
-    -> RequestUpdateBody
-    -> ClientM (WithUnsignedTx Value)
-retractChange'
-    :: Address -> RequestRefId -> ClientM (WithUnsignedTx Value)
-updateToken'
-    :: Address -> TokenId -> [RequestRefId] -> ClientM (WithUnsignedTx Value)
-_getToken' :: TokenId -> ClientM Value
 getTokenV2' :: TokenId -> ClientM Value
 getTokenRead' :: TokenId -> ClientM TokenResponse
 getTokenFacts' :: TokenId -> ClientM FactsResponse
 getTokenRequests' :: TokenId -> ClientM RequestsResponse
-submitTransaction' :: SignedTx -> ClientM TxHash
 submitTransactionV2' :: SubmitV2Body -> ClientM Text
-waitNBlocks' :: Int -> ClientM Value
-getTransaction' :: TxHash -> ClientM Value
 awaitTransactionV2' :: TxHash -> Maybe Int -> ClientM NoContent
-_endToken'
-    :: Address -> TokenId -> ClientM (WithUnsignedTx Value)
-_endToken'
-    :<|> requestInsert'
-    :<|> requestDelete'
-    :<|> requestUpdate'
-    :<|> retractChange'
-    :<|> updateToken'
-    :<|> _getToken'
-    :<|> getTokenFacts'
-    :<|> submitTransaction'
-    :<|> waitNBlocks'
-    :<|> getTransaction' =
-        client tokenApi
 
 status' :: ClientM StatusResponse
 status' =
@@ -452,6 +279,9 @@ getTokenV2' =
 getTokenRead' =
     client (Proxy :: Proxy GetTokenRead)
 
+getTokenFacts' =
+    client (Proxy :: Proxy GetTokenFactsRead)
+
 getTokenRequests' =
     client (Proxy :: Proxy GetTokenRequests)
 
@@ -466,11 +296,6 @@ mpfsClient =
     MPFS
         { mpfsBootToken = bootToken
         , mpfsEndToken = endToken
-        , mpfsRequestInsert = requestInsert
-        , mpfsRequestDelete = requestDelete
-        , mpfsRequestUpdate = requestUpdate
-        , mpfsRetractChange = retractChange
-        , mpfsUpdateToken = updateToken
         , mpfsRequestInsertFromFacts = requestInsertFromFacts
         , mpfsRequestDeleteFromFacts = requestDeleteFromFacts
         , mpfsRequestUpdateFromFacts = requestUpdateFromFacts
@@ -478,38 +303,11 @@ mpfsClient =
         , mpfsUpdateTokenFromFacts = updateTokenFromFacts
         , mpfsGetToken = getToken
         , mpfsGetTokenFacts = getTokenFacts
-        , mpfsSubmitTransaction = submitTransaction
-        , mpfsWaitNBlocks = waitNBlocks
-        , mpfsGetTransaction = getTransaction
         }
 
 data MPFS m = MPFS
     { mpfsBootToken :: Address -> m (WithUnsignedTx JSValue)
     , mpfsEndToken :: Address -> TokenId -> m (WithUnsignedTx JSValue)
-    , mpfsRequestInsert
-        :: Address
-        -> TokenId
-        -> RequestInsertBody
-        -> m (WithUnsignedTx JSValue)
-    , mpfsRequestDelete
-        :: Address
-        -> TokenId
-        -> RequestDeleteBody
-        -> m (WithUnsignedTx JSValue)
-    , mpfsRequestUpdate
-        :: Address
-        -> TokenId
-        -> RequestUpdateBody
-        -> m (WithUnsignedTx JSValue)
-    , mpfsRetractChange
-        :: Address
-        -> RequestRefId
-        -> m (WithUnsignedTx JSValue)
-    , mpfsUpdateToken
-        :: Address
-        -> TokenId
-        -> [RequestRefId]
-        -> m (WithUnsignedTx JSValue)
     , mpfsRequestInsertFromFacts
         :: Address
         -> TokenId
@@ -536,7 +334,4 @@ data MPFS m = MPFS
         -> m (WithUnsignedTx JSValue)
     , mpfsGetToken :: TokenId -> m JSValue
     , mpfsGetTokenFacts :: TokenId -> m JSValue
-    , mpfsSubmitTransaction :: SignedTx -> m TxHash
-    , mpfsWaitNBlocks :: Int -> m JSValue
-    , mpfsGetTransaction :: TxHash -> m JSValue
     }

--- a/src/Submitting.hs
+++ b/src/Submitting.hs
@@ -72,7 +72,6 @@ import Cardano.Tx.Ledger (ConwayTx)
 import Control.Concurrent (threadDelay)
 import Control.Exception (Exception, SomeException, throwIO)
 import Control.Lens ((%~))
-import Control.Monad (void)
 import Control.Monad.Catch (MonadCatch (..))
 import Control.Monad.IO.Class (MonadIO (..))
 import Core.Encryption (encryptText)
@@ -113,10 +112,9 @@ import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
-import MPFS.API (getTransaction, submitTransaction)
+import MPFS.API (awaitTransactionV2, submitTransactionV2)
 import Servant.Client (ClientM)
 import System.Directory (doesFileExist)
-import Text.JSON.Canonical (JSValue (..))
 
 data IfToWait = Wait Int | NoWait
     deriving (Show, Eq)
@@ -134,12 +132,12 @@ newtype Submission m = Submission
     }
 
 waitTx :: Submitting -> TxHash -> IO ()
-waitTx (Submitting (Wait maxCycles) runClient) txHash = void $ go maxCycles
+waitTx (Submitting (Wait maxCycles) runClient) txHash = go maxCycles
   where
-    go :: Int -> IO JSValue
-    go 0 = pure JSNull
+    go :: Int -> IO ()
+    go 0 = pure ()
     go n =
-        runClient (getTransaction txHash)
+        runClient (awaitTransactionV2 txHash)
             `catch` \(_ :: SomeException) -> do
                 liftIO $ threadDelay 1000000
                 go (n - 1)
@@ -153,7 +151,7 @@ signAndSubmitMPFS sbmt Wallet{address, sign} = Submission $ \action -> do
     WithUnsignedTx unsignedTx value <- action address
     case sign unsignedTx of
         Right (SignedTx signedTx) -> do
-            txHash <- submitTransaction $ SignedTx signedTx
+            txHash <- submitTransactionV2 $ SignedTx signedTx
             liftIO $ waitTx sbmt txHash
             return $ WithTxHash txHash value
         Left e -> liftIO $ throwIO e

--- a/test/MockMPFS.hs
+++ b/test/MockMPFS.hs
@@ -1,11 +1,9 @@
-module MockMPFS (mockMPFS, withRequestInsert, withFacts, withRequests)
+module MockMPFS (mockMPFS, withFacts, withRequests)
 where
 
 import Core.Types.Basic
-    ( Address
-    , Owner (..)
+    ( Owner (..)
     , RequestRefId (..)
-    , TokenId
     )
 import Core.Types.Fact (JSFact, renderFacts)
 import Core.Types.Tx
@@ -16,25 +14,19 @@ import Core.Types.Tx
 import Data.Functor.Identity (Identity (..))
 import MPFS.API (MPFS (..), RequestInsertBody (..))
 import Oracle.Types (RequestZoo, Token (..), TokenState (..))
-import Text.JSON.Canonical (JSValue, ToJSON (..))
+import Text.JSON.Canonical (ToJSON (..))
 
 mockMPFS :: Monad m => MPFS m
 mockMPFS =
     MPFS
         { mpfsBootToken = \_ -> error "boot token not implemented"
         , mpfsEndToken = \_ _ -> error "end token not implemented"
-        , mpfsRequestInsert = \_ _ RequestInsertBody{value = body} ->
+        , mpfsRequestInsertFromFacts = \_ _ RequestInsertBody{value = body} ->
             pure
                 $ WithUnsignedTx
                     { unsignedTransaction = UnsignedTx "mock-tx-hash"
                     , value = Just body
                     }
-        , mpfsRequestDelete = \_ _ _ -> error "request delete not implemented"
-        , mpfsRequestUpdate = \_ _ _ -> error "request update not implemented"
-        , mpfsRetractChange = \_ _ -> error "retract change not implemented"
-        , mpfsUpdateToken = \_ _ _ -> error "update token not implemented"
-        , mpfsRequestInsertFromFacts =
-            \_ _ _ -> error "request insert facts not implemented"
         , mpfsRequestDeleteFromFacts =
             \_ _ _ -> error "request delete facts not implemented"
         , mpfsRequestUpdateFromFacts =
@@ -45,20 +37,7 @@ mockMPFS =
             \_ _ _ -> error "update token facts not implemented"
         , mpfsGetToken = \_ -> toJSON $ mockToken []
         , mpfsGetTokenFacts = \_ -> toJSON ([] :: [JSFact])
-        , mpfsSubmitTransaction = \_ -> error "submit transaction not implemented"
-        , mpfsWaitNBlocks = \_ -> error "wait n blocks not implemented"
-        , mpfsGetTransaction = \_ -> error "get transaction not implemented"
         }
-
-withRequestInsert
-    :: ( Address
-         -> TokenId
-         -> RequestInsertBody
-         -> Identity (WithUnsignedTx JSValue)
-       )
-    -> MPFS Identity
-    -> MPFS Identity
-withRequestInsert f mpfs = mpfs{mpfsRequestInsert = f}
 
 withFacts :: Monad m => [JSFact] -> MPFS m -> MPFS m
 withFacts fs mpfs = mpfs{mpfsGetTokenFacts = \_ -> pure $ renderFacts fs}

--- a/test/Oracle/Config/CliSpec.hs
+++ b/test/Oracle/Config/CliSpec.hs
@@ -74,9 +74,7 @@ runConfig mpfs =
 markedMPFS :: MPFS Identity
 markedMPFS =
     mockMPFS
-        { mpfsRequestInsert = \_ _ _ -> pure (marker "legacy-insert")
-        , mpfsRequestUpdate = \_ _ _ -> pure (marker "legacy-update")
-        , mpfsRequestInsertFromFacts =
+        { mpfsRequestInsertFromFacts =
             \_ _ _ -> pure (marker "facts-insert")
         , mpfsRequestUpdateFromFacts =
             \_ _ _ -> pure (marker "facts-update")

--- a/test/User/Requester/CliSpec.hs
+++ b/test/User/Requester/CliSpec.hs
@@ -226,15 +226,9 @@ spec = describe "User.Requester.Cli" $ do
 
         withContext
             -- Expect the facts-based write path: the requester must route
-            -- inserts through mpfsRequestInsertFromFacts. The legacy field is
-            -- wired to fail closed so a stale call site is caught here.
+            -- inserts through mpfsRequestInsertFromFacts.
             mockMPFS
                 { mpfsGetTokenFacts = const . pure $ renderFacts facts
-                , mpfsRequestInsertFromFacts = mpfsRequestInsert mockMPFS
-                , mpfsRequestInsert =
-                    \_ _ _ ->
-                        error
-                            "requester must use mpfsRequestInsertFromFacts"
                 }
             ( \_ _ ->
                 mkEffects


### PR DESCRIPTION
All legacy server-build MPFS ops now have zero consumers (flows on facts after #148-#150, update-token after #166). Remove every legacy op/route/client; keep *FromFacts, v2 submit/await, /tokens/* reads, boot/end, and the request-body types used by *FromFacts. Targets moog-v2. Closes #151.