### PR TITLE
moog-v2: full-lifecycle live-boundary canary (#152)

### DIFF
--- a/.github/workflows/mpfs-v2-canary.yaml
+++ b/.github/workflows/mpfs-v2-canary.yaml
@@ -9,9 +9,9 @@ on:
         default: "main"
 
 jobs:
-  boot-end-canary:
-    name: Run MPFS v2 boot/end boundary canary
-    runs-on: ubuntu-latest
+  full-lifecycle-canary:
+    name: Run MPFS v2 full lifecycle boundary canary
+    runs-on: [self-hosted, moog]
     env:
       MOOG_CANARY_POLLS: "240"
     steps:
@@ -38,11 +38,32 @@ jobs:
         run: |
           nix build --quiet --print-out-paths .#mpfs-devnet-server \
             > "$RUNNER_TEMP/mpfs-devnet-server"
-          nix develop --quiet -c bash -lc \
-            "printf '%s\n%s\n%s\n' \"\$MPFS_BLUEPRINT\" \"\$E2E_GENESIS_DIR\" \"\$PATH\"" \
-            | tail -n3 > "$RUNNER_TEMP/mpfs-devnet-env"
+          # Root the ENTIRE devshell closure via a profile GC root. The canary
+          # step (a later step) relies on the devshell's PATH tools (cardano-node,
+          # etc.), the blueprint and the genesis -- all transient `nix develop`
+          # store paths. Without a root, nix auto-GC under disk pressure on the
+          # self-hosted runner reaps them between steps ("blueprint/cardano-node
+          # does not exist"). A devshell profile roots the whole closure at once.
+          nix develop --quiet --profile "$RUNNER_TEMP/canary-devshell" -c true
+          # Write the env DIRECTLY to a file from inside the devshell, using a
+          # NON-LOGIN shell (`bash -c`, not `bash -lc`). On the self-hosted
+          # builder-new runner the login shell re-sources /etc/profile +
+          # ~/.bash_profile, which RESET $PATH to the ambient gha-runner profile
+          # (dropping the devshell's cardano-node -> "cardano-node: execvp: does
+          # not exist") and emitted the ESC%G escape that corrupted the blueprint
+          # path. A non-login shell preserves the devshell PATH + env vars.
+          nix develop --quiet --profile "$RUNNER_TEMP/canary-devshell" -c bash -c \
+            'printf "%s\n%s\n%s\n" "$MPFS_BLUEPRINT" "$E2E_GENESIS_DIR" "$PATH" > "$RUNNER_TEMP/mpfs-devnet-env"'
+          # Ground-truth debug: does cardano-node resolve on the captured PATH?
+          _dbg_path="$(sed -n 3p "$RUNNER_TEMP/mpfs-devnet-env")"
+          if PATH="$_dbg_path" command -v cardano-node >/dev/null 2>&1; then
+            echo "DEBUG: cardano-node found on captured MPFS_DEVNET_PATH"
+          else
+            echo "DEBUG: cardano-node MISSING on captured MPFS_DEVNET_PATH"
+            echo "DEBUG: first 200 chars of captured PATH: ${_dbg_path:0:200}"
+          fi
 
-      - name: Run MPFS v2 boot/end canary executable
+      - name: Run MPFS v2 full lifecycle canary executable
         working-directory: moog
         run: |
           mapfile -t devnet_env < "$RUNNER_TEMP/mpfs-devnet-env"

--- a/app/moog-mpfs-v2-canary.hs
+++ b/app/moog-mpfs-v2-canary.hs
@@ -36,8 +36,8 @@ import Data.Scientific (floatingOrInteger)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
 import MPFS.Canary
-    ( EndBoundaryCanaryResult (..)
-    , bootThenEndCanary
+    ( FullLifecycleCanaryResult (..)
+    , fullLifecycleCanary
     )
 import Network.HTTP.Client
     ( HttpException
@@ -106,32 +106,44 @@ main = do
     output <- toJSON result
     BL.putStrLn $ renderCanonicalJSON output
 
-runCanary :: CanaryConfig -> IO EndBoundaryCanaryResult
+runCanary :: CanaryConfig -> IO FullLifecycleCanaryResult
 runCanary cfg =
     withCanaryTempDirectory $ \tmp -> do
         wallet <- canaryWallet
         genesisDir <- fundedGenesis tmp cfg wallet
         withDevnetServer tmp cfg genesisDir $ \host -> do
             client <- newClient (host, NoWait, 120)
-            bootThenEndCanary client wallet cfg.polls
+            fullLifecycleCanary client wallet cfg.polls
 
-assertCanaryResult :: EndBoundaryCanaryResult -> IO ()
+assertCanaryResult :: FullLifecycleCanaryResult -> IO ()
 assertCanaryResult result = do
     let TokenId tokenId = result.canaryTokenId
     when (null tokenId)
-        $ failTest "end boundary canary returned an empty token id"
+        $ failTest "full lifecycle canary returned an empty token id"
     when (result.bootTransactionPolls < 0)
         $ failTest
-            "end boundary canary returned a negative boot transaction poll count"
+            "full lifecycle canary returned a negative boot transaction poll count"
+    when (result.requestInsertTransactionPolls < 0)
+        $ failTest
+            "full lifecycle canary returned a negative request insert transaction poll count"
+    when (result.requestObservedPolls < 0)
+        $ failTest
+            "full lifecycle canary returned a negative request observed poll count"
+    when (result.updateTokenTransactionPolls < 0)
+        $ failTest
+            "full lifecycle canary returned a negative update token transaction poll count"
+    when (result.factObservedPolls < 0)
+        $ failTest
+            "full lifecycle canary returned a negative fact observed poll count"
     when (result.tokenBeforeEndPolls < 0)
         $ failTest
-            "end boundary canary returned a negative token-before-end poll count"
+            "full lifecycle canary returned a negative token-before-end poll count"
     when (result.endTransactionPolls < 0)
         $ failTest
-            "end boundary canary returned a negative end transaction poll count"
+            "full lifecycle canary returned a negative end transaction poll count"
     when (result.tokenGonePolls < 0)
         $ failTest
-            "end boundary canary returned a negative token-gone poll count"
+            "full lifecycle canary returned a negative token-gone poll count"
 
 loadConfig :: IO CanaryConfig
 loadConfig = do

--- a/specs/152-full-lifecycle-canary/tasks.md
+++ b/specs/152-full-lifecycle-canary/tasks.md
@@ -1,0 +1,4 @@
+# Tasks — #152 full-lifecycle live-boundary canary
+
+## Slice S1 — extend canary beyond boot/end to the write/submit cycle
+- [X] T152-S1 Extend app/moog-mpfs-v2-canary.hs (bootThenEndCanary) to exercise the facts write+submit path against the paired devnet: boot -> a requester request insert (+submit via /tx/submit) -> oracle update-token (merge the request) -> end; assert each tx is observed. Emit structured success JSON. Update .github/workflows/mpfs-v2-canary.yaml to run the full-cycle. `./gate.sh` green (builds canary exe). Live run happens in CI against the paired offchain devnet.

--- a/src/MPFS/API.hs
+++ b/src/MPFS/API.hs
@@ -1,6 +1,5 @@
 module MPFS.API
-    ( SubmitV2Body (..)
-    , requestInsertFromFacts
+    ( requestInsertFromFacts
     , requestDeleteFromFacts
     , requestUpdateFromFacts
     , retractChangeFromFacts
@@ -8,6 +7,7 @@ module MPFS.API
     , getToken
     , getTokenV2
     , getTokenFacts
+    , submitRequestFromSignedTx
     , submitTransactionV2
     , RequestInsertBody (..)
     , RequestDeleteBody (..)
@@ -34,22 +34,21 @@ import Cardano.MPFS.API.Types
     , RetractFacts
     , RetractRequest
     , StatusResponse
+    , SubmitRequest (..)
+    , SubmitResponse (..)
     , TokenResponse
     , UpdateRequest
     , UpdateValueRequest
     )
+import Cardano.MPFS.API.Encoding (Hex (..))
 import Cardano.MPFS.API.Types.Facts (UpdateFacts)
 import Control.Monad (void)
 import Core.Types.Basic (Address, RequestRefId, TokenId)
 import Core.Types.Tx (SignedTx (..), TxHash (..), WithUnsignedTx)
-import Data.Aeson
-    ( ToJSON (..)
-    , Value (..)
-    , object
-    , (.=)
-    )
+import Data.Aeson (Value (..))
+import Data.ByteString.Base16 qualified as Base16
 import Data.Data (Proxy (..))
-import Data.Text (Text)
+import Data.Text.Encoding qualified as Text
 import Lib.JSON.Canonical.Extra (fromAesonThrow)
 import MPFS.Boot (bootTokenFromFacts)
 import MPFS.End (endTokenFromFacts)
@@ -79,12 +78,6 @@ import Servant.Client (ClientM, client)
 import Text.JSON.Canonical
     ( JSValue (..)
     )
-
-newtype SubmitV2Body = SubmitV2Body SignedTx
-
-instance ToJSON SubmitV2Body where
-    toJSON (SubmitV2Body (SignedTx signedTx)) =
-        object ["tx" .= signedTx]
 
 type Status =
     "status"
@@ -158,10 +151,9 @@ type GetTokenRequests =
         :> Get '[JSON] RequestsResponse
 
 type SubmitTransactionV2 =
-    "tx"
-        :> "submit"
-        :> ReqBody '[JSON] SubmitV2Body
-        :> Post '[JSON] Text
+    "submit"
+        :> ReqBody '[JSON] SubmitRequest
+        :> Post '[JSON] SubmitResponse
 
 type AwaitTransactionV2 =
     "tx"
@@ -228,7 +220,22 @@ getTokenFacts =
 
 submitTransactionV2 :: SignedTx -> ClientM TxHash
 submitTransactionV2 signed =
-    TxHash <$> submitTransactionV2' (SubmitV2Body signed)
+    submitResponseToTxHash
+        <$> submitTransactionV2' (submitRequestFromSignedTx signed)
+
+submitRequestFromSignedTx :: SignedTx -> SubmitRequest
+submitRequestFromSignedTx (SignedTx signedTx) =
+    SubmitRequest
+        $ Hex
+        $ case Base16.decode (Text.encodeUtf8 signedTx) of
+            Right signedTxCbor -> signedTxCbor
+            Left err ->
+                error
+                    $ "SignedTx is not hex-encoded CBOR: " <> err
+
+submitResponseToTxHash :: SubmitResponse -> TxHash
+submitResponseToTxHash (SubmitResponse (Hex txId)) =
+    TxHash $ Text.decodeUtf8 $ Base16.encode txId
 
 awaitTransactionV2 :: TxHash -> ClientM ()
 awaitTransactionV2 txHash =
@@ -238,7 +245,7 @@ getTokenV2' :: TokenId -> ClientM Value
 getTokenRead' :: TokenId -> ClientM TokenResponse
 getTokenFacts' :: TokenId -> ClientM FactsResponse
 getTokenRequests' :: TokenId -> ClientM RequestsResponse
-submitTransactionV2' :: SubmitV2Body -> ClientM Text
+submitTransactionV2' :: SubmitRequest -> ClientM SubmitResponse
 awaitTransactionV2' :: TxHash -> Maybe Int -> ClientM NoContent
 
 status' :: ClientM StatusResponse

--- a/src/MPFS/Canary.hs
+++ b/src/MPFS/Canary.hs
@@ -2,8 +2,8 @@
 
 module MPFS.Canary
     ( BootCanaryFailure (..)
-    , EndBoundaryCanaryResult (..)
-    , bootThenEndCanary
+    , FullLifecycleCanaryResult (..)
+    , fullLifecycleCanary
     , pollGoneBoundaryWithDelay
     , tokenIdFromBootValue
     ) where
@@ -15,14 +15,25 @@ import Control.Exception
     , throwIO
     , try
     )
-import Core.Types.Basic (TokenId)
+import Control.Monad (unless)
+import Core.Types.Basic
+    ( RequestRefId
+    , TokenId
+    )
+import Core.Types.Fact
+    ( Fact (..)
+    , Slot (..)
+    , parseFacts
+    )
 import Core.Types.MPFS (MPFSClient (..))
 import Core.Types.Tx
     ( TxHash (..)
     , WithUnsignedTx (..)
     )
 import Core.Types.Wallet (Wallet (..))
+import Data.Functor.Identity (Identity (..))
 import Data.List (isInfixOf)
+import Data.Maybe (listToMaybe)
 import Lib.JSON.Canonical.Extra
     ( boolJSON
     , intJSON
@@ -31,15 +42,21 @@ import Lib.JSON.Canonical.Extra
     )
 import MPFS.API
     ( MPFS (..)
+    , RequestInsertBody (..)
     , awaitTransactionV2
     , getTokenV2
     , mpfsClient
     , submitTransactionV2
     )
+import Oracle.Types
+    ( Token (..)
+    , requestZooRefId
+    )
 import Text.JSON.Canonical
     ( FromJSON (fromJSON)
-    , JSValue
+    , JSValue (..)
     , ToJSON (..)
+    , toJSString
     )
 
 data BootCanaryFailure
@@ -51,40 +68,62 @@ data BootCanaryFailure
 
 instance Exception BootCanaryFailure
 
-data EndBoundaryCanaryResult = EndBoundaryCanaryResult
+data FullLifecycleCanaryResult = FullLifecycleCanaryResult
     { canaryBootTxHash :: TxHash
+    , canaryRequestInsertTxHash :: TxHash
+    , canaryUpdateTokenTxHash :: TxHash
     , canaryEndTxHash :: TxHash
     , canaryTokenId :: TokenId
     , bootTransactionPolls :: Int
+    , requestInsertTransactionPolls :: Int
+    , requestObservedPolls :: Int
+    , updateTokenTransactionPolls :: Int
+    , factObservedPolls :: Int
     , tokenBeforeEndPolls :: Int
     , endTransactionPolls :: Int
     , tokenGonePolls :: Int
     }
     deriving (Show, Eq)
 
-instance Monad m => ToJSON m EndBoundaryCanaryResult where
-    toJSON EndBoundaryCanaryResult{..} =
+instance Monad m => ToJSON m FullLifecycleCanaryResult where
+    toJSON FullLifecycleCanaryResult{..} =
         object
-            [ "boundary" .= ("mpfs-v2-end" :: String)
+            [ "boundary" .= ("mpfs-v2-full-lifecycle" :: String)
             , "bootTxHash" .= textOf canaryBootTxHash
+            , "requestInsertTxHash" .= textOf canaryRequestInsertTxHash
+            , "updateTokenTxHash" .= textOf canaryUpdateTokenTxHash
             , "endTxHash" .= textOf canaryEndTxHash
             , "tokenId" .= canaryTokenId
             , ("bootTransactionObserved", boolJSON True)
+            , ("requestInsertTransactionObserved", boolJSON True)
+            , ("requestObserved", boolJSON True)
+            , ("updateTokenTransactionObserved", boolJSON True)
+            , ("factObserved", boolJSON True)
             , ("endTransactionObserved", boolJSON True)
             , ("tokenObservedBeforeEnd", boolJSON True)
             , ("tokenGoneObserved", boolJSON True)
             , ("bootTransactionPolls", intJSON bootTransactionPolls)
+            ,
+                ( "requestInsertTransactionPolls"
+                , intJSON requestInsertTransactionPolls
+                )
+            , ("requestObservedPolls", intJSON requestObservedPolls)
+            ,
+                ( "updateTokenTransactionPolls"
+                , intJSON updateTokenTransactionPolls
+                )
+            , ("factObservedPolls", intJSON factObservedPolls)
             , ("tokenBeforeEndPolls", intJSON tokenBeforeEndPolls)
             , ("endTransactionPolls", intJSON endTransactionPolls)
             , ("tokenGonePolls", intJSON tokenGonePolls)
             ]
 
-bootThenEndCanary
+fullLifecycleCanary
     :: MPFSClient
     -> Wallet
     -> Int
-    -> IO EndBoundaryCanaryResult
-bootThenEndCanary MPFSClient{runMPFS} wallet@Wallet{sign} maxPolls = do
+    -> IO FullLifecycleCanaryResult
+fullLifecycleCanary MPFSClient{runMPFS} wallet@Wallet{sign} maxPolls = do
     WithUnsignedTx unsignedTx rawTokenId <-
         runMPFS $ mpfsBootToken mpfsClient (address wallet)
     signedTx <-
@@ -103,6 +142,48 @@ bootThenEndCanary MPFSClient{runMPFS} wallet@Wallet{sign} maxPolls = do
         pollBoundary "token before end" maxPolls
             $ runMPFS
             $ getTokenV2 tokenId
+    WithUnsignedTx requestUnsignedTx _ <-
+        runMPFS
+            $ mpfsRequestInsertFromFacts
+                mpfsClient
+                (address wallet)
+                tokenId
+            $ RequestInsertBody canaryFactKey canaryFactValue
+    signedRequestTx <-
+        case sign requestUnsignedTx of
+            Right tx -> pure tx
+            Left err -> throwIO err
+    requestInsertTxHash <-
+        runMPFS $ submitTransactionV2 signedRequestTx
+    requestInsertTransactionPolls <-
+        pollBoundary "request insert transaction" maxPolls
+            $ runMPFS
+            $ awaitTransactionV2 requestInsertTxHash
+    (requestRefId, requestObservedPolls) <-
+        pollObservedBoundaryValue "request" maxPolls
+            $ observedRequestRefId
+            =<< runMPFS (mpfsGetToken mpfsClient tokenId)
+    WithUnsignedTx updateUnsignedTx _ <-
+        runMPFS
+            $ mpfsUpdateTokenFromFacts
+                mpfsClient
+                (address wallet)
+                tokenId
+                [requestRefId]
+    signedUpdateTx <-
+        case sign updateUnsignedTx of
+            Right tx -> pure tx
+            Left err -> throwIO err
+    updateTokenTxHash <-
+        runMPFS $ submitTransactionV2 signedUpdateTx
+    updateTokenTransactionPolls <-
+        pollBoundary "update token transaction" maxPolls
+            $ runMPFS
+            $ awaitTransactionV2 updateTokenTxHash
+    factObservedPolls <-
+        pollBoundary "fact" maxPolls
+            $ assertCanaryFact
+            =<< runMPFS (mpfsGetTokenFacts mpfsClient tokenId)
     WithUnsignedTx endUnsignedTx endValue <-
         runMPFS $ mpfsEndToken mpfsClient (address wallet) tokenId
     case endValue of
@@ -126,15 +207,59 @@ bootThenEndCanary MPFSClient{runMPFS} wallet@Wallet{sign} maxPolls = do
             $ runMPFS
             $ getTokenV2 tokenId
     pure
-        EndBoundaryCanaryResult
+        FullLifecycleCanaryResult
             { canaryBootTxHash = bootTxHash
+            , canaryRequestInsertTxHash = requestInsertTxHash
+            , canaryUpdateTokenTxHash = updateTokenTxHash
             , canaryEndTxHash = endTxHash
             , canaryTokenId = tokenId
             , bootTransactionPolls
+            , requestInsertTransactionPolls
+            , requestObservedPolls
+            , updateTokenTransactionPolls
+            , factObservedPolls
             , tokenBeforeEndPolls
             , endTransactionPolls
             , tokenGonePolls
             }
+
+canaryFactKey :: JSValue
+canaryFactKey =
+    JSString $ toJSString "moog-mpfs-v2-canary/full-lifecycle"
+
+canaryFactValue :: JSValue
+canaryFactValue =
+    JSString $ toJSString "write-submit-observed"
+
+observedRequestRefId :: JSValue -> IO RequestRefId
+observedRequestRefId value =
+    case fromJSON value of
+        Just token ->
+            maybe
+                (throwIO $ userError "verified token read has no requests")
+                pure
+                $ firstRequestRefId token
+        Nothing ->
+            throwIO $ userError "verified token read did not parse"
+
+firstRequestRefId :: Token Identity -> Maybe RequestRefId
+firstRequestRefId Token{tokenRequests} =
+    requestZooRefId . runIdentity <$> listToMaybe tokenRequests
+
+assertCanaryFact :: JSValue -> IO ()
+assertCanaryFact value =
+    unless factObserved
+        $ throwIO
+        $ userError
+            "verified facts read did not include the canary insert"
+  where
+    facts = parseFacts value
+    factObserved =
+        any
+            ( \(Fact key value' (Slot _)) ->
+                key == canaryFactKey && value' == canaryFactValue
+            )
+            facts
 
 tokenIdFromBootValue
     :: Maybe JSValue -> Either BootCanaryFailure TokenId
@@ -147,20 +272,29 @@ tokenIdFromBootValue (Just value) =
 
 pollBoundary :: String -> Int -> IO a -> IO Int
 pollBoundary boundary maxPolls =
-    pollObservedBoundaryWithDelay
+    fmap snd
+        . pollObservedBoundaryValueWithDelay
+            boundary
+            maxPolls
+            (threadDelay 1_000_000)
+
+pollObservedBoundaryValue
+    :: String -> Int -> IO a -> IO (a, Int)
+pollObservedBoundaryValue boundary maxPolls =
+    pollObservedBoundaryValueWithDelay
         boundary
         maxPolls
         (threadDelay 1_000_000)
 
-pollObservedBoundaryWithDelay
-    :: String -> Int -> IO () -> IO a -> IO Int
-pollObservedBoundaryWithDelay boundary maxPolls delay action =
+pollObservedBoundaryValueWithDelay
+    :: String -> Int -> IO () -> IO a -> IO (a, Int)
+pollObservedBoundaryValueWithDelay boundary maxPolls delay action =
     go 0
   where
     go polls = do
         result <- try action
         case result of
-            Right _ -> pure polls
+            Right value -> pure (value, polls)
             Left (err :: SomeException)
                 | polls >= maxPolls ->
                     throwIO

--- a/test/MPFS/CanarySpec.hs
+++ b/test/MPFS/CanarySpec.hs
@@ -6,10 +6,10 @@ import Core.Types.Tx (SignedTx (..), TxHash (..))
 import Data.Aeson (encode)
 import Data.ByteString.Lazy.Char8 qualified as BSL
 import Data.IORef
-import MPFS.API (SubmitV2Body (..))
+import MPFS.API (submitRequestFromSignedTx)
 import MPFS.Canary
     ( BootCanaryFailure (..)
-    , EndBoundaryCanaryResult (..)
+    , FullLifecycleCanaryResult (..)
     , pollGoneBoundaryWithDelay
     , tokenIdFromBootValue
     )
@@ -46,25 +46,34 @@ spec =
 
         describe "MPFS v2 submit body" $ do
             it "uses the POST /tx/submit wire key" $ do
-                encode (SubmitV2Body (SignedTx "deadbeef"))
-                    `shouldBe` BSL.pack "{\"tx\":\"deadbeef\"}"
+                encode (submitRequestFromSignedTx (SignedTx "deadbeef"))
+                    `shouldBe` BSL.pack
+                        "{\"signedTxCbor\":\"deadbeef\"}"
 
-        describe "end boundary result" $ do
-            it "identifies the boot-then-end observations" $ do
+        describe "full lifecycle result" $ do
+            it "identifies the write-submit lifecycle observations" $ do
                 value <-
                     toJSON
-                        EndBoundaryCanaryResult
+                        FullLifecycleCanaryResult
                             { canaryBootTxHash = TxHash "boot"
+                            , canaryRequestInsertTxHash =
+                                TxHash "request-insert"
+                            , canaryUpdateTokenTxHash =
+                                TxHash "update-token"
                             , canaryEndTxHash = TxHash "end"
                             , canaryTokenId = TokenId "abcd"
                             , bootTransactionPolls = 1
-                            , tokenBeforeEndPolls = 2
-                            , endTransactionPolls = 3
-                            , tokenGonePolls = 4
+                            , requestInsertTransactionPolls = 2
+                            , requestObservedPolls = 3
+                            , updateTokenTransactionPolls = 4
+                            , factObservedPolls = 5
+                            , tokenBeforeEndPolls = 6
+                            , endTransactionPolls = 7
+                            , tokenGonePolls = 8
                             }
                 renderCanonicalJSON value
                     `shouldBe` BSL.pack
-                        "{\"bootTransactionObserved\":true,\"bootTransactionPolls\":1,\"bootTxHash\":\"boot\",\"boundary\":\"mpfs-v2-end\",\"endTransactionObserved\":true,\"endTransactionPolls\":3,\"endTxHash\":\"end\",\"tokenBeforeEndPolls\":2,\"tokenGoneObserved\":true,\"tokenGonePolls\":4,\"tokenId\":\"abcd\",\"tokenObservedBeforeEnd\":true}"
+                        "{\"bootTransactionObserved\":true,\"bootTransactionPolls\":1,\"bootTxHash\":\"boot\",\"boundary\":\"mpfs-v2-full-lifecycle\",\"endTransactionObserved\":true,\"endTransactionPolls\":7,\"endTxHash\":\"end\",\"factObserved\":true,\"factObservedPolls\":5,\"requestInsertTransactionObserved\":true,\"requestInsertTransactionPolls\":2,\"requestInsertTxHash\":\"request-insert\",\"requestObserved\":true,\"requestObservedPolls\":3,\"tokenBeforeEndPolls\":6,\"tokenGoneObserved\":true,\"tokenGonePolls\":8,\"tokenId\":\"abcd\",\"tokenObservedBeforeEnd\":true,\"updateTokenTransactionObserved\":true,\"updateTokenTransactionPolls\":4,\"updateTokenTxHash\":\"update-token\"}"
 
         describe "token-gone polling" $ do
             it


### PR DESCRIPTION
Extend the boot/end canary to exercise the facts write+submit cycle (boot -> requester request insert -> oracle update-token -> end) against the paired devnet — the live-boundary proof that /tx/submit + the verified reads + write builders work end-to-end (unit gates mock submission). Wire as CI readiness gate. Targets moog-v2. Closes #152.