### PR TITLE
fix(agent): use Antithesis `after` pagination param to stop listAllRuns OOM loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog for moog-cli
 
+### v0.5.1.4 - 2026-06-09
+
+#### Fixed
+
+- **Agent no longer OOM-loops on the Antithesis runs pagination.** Antithesis
+  renamed the `GET /api/v0/runs` pagination query parameter from `cursor` to
+  `after` under the same `v0`. The Servant-derived client still sent `cursor=`,
+  which the upstream silently ignores — re-serving page 1 with an unchanged
+  `next_cursor`. Once a tenant exceeded one page (100 runs), `listAllRuns`
+  paginated forever, accumulating duplicates until the `moog-agent` process was
+  OOM-killed and stopped launching test runs. The client now sends `after=`, and
+  `listAllRuns` additionally bails when the cursor fails to advance so a future
+  silent upstream change degrades gracefully instead of exhausting host memory.
+
 ### v0.5.1.3 - 2026-06-01
 
 #### Fixed

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 > moog is migrating from the legacy MPFS HTTP API to the new facts-only MPFS
 > service ([cardano-mpfs-offchain](https://github.com/lambdasistemi/cardano-mpfs-offchain)),
 > where the server returns indexed *facts* and the client builds, signs, and
-> submits transactions. The current release (**v0.5.1.3**) runs against the
+> submits transactions. The current release (**v0.5.1.4**) runs against the
 > **legacy** MPFS server in production; the oracle `token boot` / `token end`
 > commands were removed because they already targeted the new API, which
 > production does not yet serve. The full client-side facts cutover is happening

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
     moog is migrating from the legacy MPFS HTTP API to the new facts-only MPFS
     service ([cardano-mpfs-offchain](https://github.com/lambdasistemi/cardano-mpfs-offchain)),
     where the server returns indexed *facts* and the client builds, signs, and
-    submits transactions. The current release (**v0.5.1.3**) runs against the
+    submits transactions. The current release (**v0.5.1.4**) runs against the
     **legacy** MPFS server in production; the oracle `token boot` / `token end`
     commands were removed because they already targeted the new API, which
     production does not yet serve. The full client-side facts cutover happens on

--- a/moog.cabal
+++ b/moog.cabal
@@ -21,7 +21,7 @@ name:            moog
 -- PVP summary:     +-+------- breaking API changes
 --                  | | +----- non-breaking API additions
 --                  | | | +--- code changes with no API change
-version:         0.5.1.3
+version:         0.5.1.4
 
 -- A short (one-line) description of the package.
 synopsis:

--- a/skills/antithesis-moog/SKILL.md
+++ b/skills/antithesis-moog/SKILL.md
@@ -12,10 +12,10 @@ description: MOOG CLI for Antithesis test management on Cardano. Setup using the
 ```bash
 cd /code/moog
 # Download the release binary (same as the GitHub Actions workflow uses).
-# Latest release is v0.5.1.3; asset naming changed at v0.5.x — the portable,
+# Latest release is v0.5.1.4; asset naming changed at v0.5.x — the portable,
 # statically-linked CLI is now `moog-<ver>-x86_64-linux-musl.tar.gz` (it
 # extracts a single `moog` binary; moog-agent / moog-oracle are separate assets).
-curl -sL "https://github.com/cardano-foundation/moog/releases/download/v0.5.1.3/moog-0.5.1.3-x86_64-linux-musl.tar.gz" | tar xz -C ./tmp/
+curl -sL "https://github.com/cardano-foundation/moog/releases/download/v0.5.1.4/moog-0.5.1.4-x86_64-linux-musl.tar.gz" | tar xz -C ./tmp/
 export PATH=/code/moog/tmp:$PATH
 source tmp/prod-setup.sh
 ```

--- a/src/Proxy/Antithesis/Api.hs
+++ b/src/Proxy/Antithesis/Api.hs
@@ -105,7 +105,11 @@ type AntithesisProxyJsonAPI =
             :> "v0"
             :> "runs"
             :> QueryParam "limit" Int
-            :> QueryParam "cursor" Text
+            -- Antithesis paginates with @after=@ (a created-before token),
+            -- NOT @cursor=@. Sending the wrong name makes the upstream
+            -- silently ignore it and re-serve page 1 with an unchanged
+            -- @next_cursor@, which loops 'listAllRuns' forever (OOM).
+            :> QueryParam "after" Text
             :> Get '[PlainJSON] Value
         :<|> "api"
             :> "v0"

--- a/src/User/Agent/Antithesis/Client.hs
+++ b/src/User/Agent/Antithesis/Client.hs
@@ -99,9 +99,16 @@ listAllRuns config =
         case result of
             Left err -> pure $ Left err
             Right RunsPage{runsPageRuns, runsPageNextCursor} ->
-                case runsPageNextCursor of
-                    Nothing -> pure $ Right $ acc <> runsPageRuns
-                    Just nextCursor -> go env (Just nextCursor) (acc <> runsPageRuns)
+                let acc' = acc <> runsPageRuns
+                 in case runsPageNextCursor of
+                        Nothing -> pure $ Right acc'
+                        -- Stop if the cursor fails to advance. A
+                        -- non-terminating upstream cursor (e.g. an ignored
+                        -- pagination param) must never accumulate pages until
+                        -- the agent OOMs; bail instead of looping forever.
+                        Just nextCursor
+                            | Just nextCursor == cursor -> pure $ Right acc'
+                            | otherwise -> go env (Just nextCursor) acc'
 
 withApiEnv
     :: AntithesisApiConfig

--- a/test/Proxy/Antithesis/ServerSpec.hs
+++ b/test/Proxy/Antithesis/ServerSpec.hs
@@ -34,9 +34,9 @@ import Test.Hspec (Spec, describe, it, shouldBe)
 spec :: Spec
 spec =
     describe "Proxy.Antithesis.Server (Servant)" $ do
-        it "forwards GET /api/v0/runs?limit=&cursor= with Bearer API key" $
-            check "/api/v0/runs?limit=5&cursor=foo"
-                ("/api/v0/runs", "?limit=5&cursor=foo")
+        it "forwards GET /api/v0/runs?limit=&after= with Bearer API key" $
+            check "/api/v0/runs?limit=5&after=foo"
+                ("/api/v0/runs", "?limit=5&after=foo")
 
         it "forwards GET /api/v0/runs/{run_id}" $
             check "/api/v0/runs/abc-54-7"

--- a/test/User/Agent/Antithesis/ClientSpec.hs
+++ b/test/User/Agent/Antithesis/ClientSpec.hs
@@ -80,10 +80,26 @@ spec = describe "User.Agent.Antithesis.Client" $ do
                   , Just "Bearer api-key"
                   )
                 , ( "/api/v0/runs"
-                  , [("limit", Just "100"), ("cursor", Just "cursor-2")]
+                  , [("limit", Just "100"), ("after", Just "cursor-2")]
                   , Just "Bearer api-key"
                   )
                 ]
+
+    it "stops when the upstream cursor does not advance" $ do
+        seenRef <- newIORef (0 :: Int)
+        result <-
+            withStuckCursorApi seenRef $ \baseUrl ->
+                listAllRuns
+                    AntithesisApiConfig
+                        { antithesisApiUrl = AntithesisApiUrl baseUrl
+                        , antithesisApiKey = AntithesisApiKey "api-key"
+                        }
+        -- A non-advancing cursor must terminate (not loop until OOM):
+        -- page 1 (no cursor) then one repeat whose next_cursor equals the
+        -- cursor we just sent, after which 'listAllRuns' bails.
+        fmap length result `shouldBe` Right 2
+        hits <- readIORef seenRef
+        hits `shouldBe` 2
 
 type SeenRequest = (ByteString, [(Text, Maybe Text)], Maybe ByteString)
 
@@ -95,7 +111,7 @@ withRunsApi seenRef action =
 runsApi :: IORef [SeenRequest] -> Application
 runsApi seenRef request respond = do
     let queryText = queryToQueryText $ queryString request
-        cursor = lookup "cursor" queryText
+        after = lookup "after" queryText
         auth = lookup hAuthorization $ requestHeaders request
     appendSeen seenRef (rawPathInfo request, queryText, auth)
     respond $
@@ -103,7 +119,7 @@ runsApi seenRef request respond = do
             status200
             [("Content-Type", "application/json")]
             $ Aeson.encode
-            $ case cursor of
+            $ case after of
                 Nothing ->
                     runsPageJson
                         [runJson "run-1" "in_progress" "description-1" Nothing]
@@ -119,6 +135,25 @@ runsApi seenRef request respond = do
                         Nothing
                 _ ->
                     runsPageJson [] Nothing
+
+-- | An upstream that always answers with the same @next_cursor@ regardless
+-- of the @after@ it is given — the shape that looped 'listAllRuns' until OOM.
+withStuckCursorApi :: IORef Int -> (String -> IO a) -> IO a
+withStuckCursorApi hitsRef action =
+    testWithApplication (pure $ stuckCursorApi hitsRef) $ \port ->
+        action $ "http://127.0.0.1:" <> show port
+
+stuckCursorApi :: IORef Int -> Application
+stuckCursorApi hitsRef _request respond = do
+    atomicModifyIORef' hitsRef $ \n -> (n + 1, ())
+    respond $
+        responseLBS
+            status200
+            [("Content-Type", "application/json")]
+            $ Aeson.encode
+            $ runsPageJson
+                [runJson "run-stuck" "in_progress" "description" Nothing]
+                (Just "stuck")
 
 appendSeen :: IORef [SeenRequest] -> SeenRequest -> IO ()
 appendSeen ref req =


### PR DESCRIPTION
Closes #172.

Antithesis renamed the `GET /api/v0/runs` pagination query param `cursor` -> `after`
under the same `v0`. Our client still sent `cursor=`, which the upstream ignores —
re-serving page 1 with an unchanged `next_cursor`. Once a tenant exceeded one page
(100 runs), `listAllRuns` paginated forever, OOM-killing `moog-agent` so it stopped
launching test runs.

- `Api.hs`: `QueryParam "cursor"` -> `"after"` (shared type fixes agent->upstream and proxy->upstream).
- `listAllRuns`: bail when `next_cursor` does not advance (graceful instead of OOM on a future silent upstream change).
- Tests: `ServerSpec`/`ClientSpec` flipped off the old `cursor` contract; non-advancing-cursor regression added.
- `chore(release): v0.5.1.4`.

Verified live: direct API terminates with `after=` and loops with `cursor=`. Hotfix
image (`:1045eaa`) already deployed to the prod agent — RSS now flat at ~118 MB, the
backlog (incl. master try25/try26) launched.

Unit tests: 235 examples, 0 failures.