### PR TITLE
Validate the oracle service against the new facts-only MPFS (#178)

### DIFF
--- a/moog.cabal
+++ b/moog.cabal
@@ -685,12 +685,9 @@ test-suite integration-tests
     , base16-bytestring
     , bytestring
     , canonical-json
-    , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-babbage
     , cardano-ledger-binary
-    , cardano-ledger-core
-    , cardano-strict-containers
     , cardano-tx-tools
     , directory
     , exceptions

--- a/specs/178-oracle-validation/spec.md
+++ b/specs/178-oracle-validation/spec.md
@@ -1,0 +1,40 @@
+# #178 — Validate the oracle service against the new facts-only MPFS
+
+## P1 user story
+As an operator, the oracle observes incoming requests, validates them by type, and applies the
+valid ones via `update-token` against the new facts-only MPFS — proven end-to-end by the
+integration suite (which now self-hosts the offchain `mpfs-devnet-server`, #177).
+
+## Context (from scoping)
+The oracle is **already on the v2 facts API**: `tokenCmdCore`'s `UpdateToken` calls
+`mpfsUpdateTokenFromFacts` (`src/Oracle/Token/Cli.hs:179`); config writes use
+`mpfsRequestInsertFromFacts`/`mpfsRequestUpdateFromFacts` (`src/Oracle/Config/Cli.hs`);
+`validateRequest` dispatches 12 typed request kinds (`src/Oracle/Validate/Request.hs:42`). So
+this ticket is primarily **validation coverage**, not a rewrite — plus restoring the request-tx
+specs #177 dropped. Fix any breakage the new coverage surfaces.
+
+Gaps to close:
+- `test-integration/MPFS/APISpec.hs` has a `-- TODO(#178)` where three request-tx specs
+  (`requestInsert`/`requestDelete`/`requestUpdate`) were dropped; they must be **restored +
+  migrated** to `requestInsertFromFacts`/`requestDeleteFromFacts`/`requestUpdateFromFacts`
+  (`src/MPFS/Request.hs:128-207`).
+- No integration test drives a full oracle **request → validate → apply** cycle against a real
+  (self-hosted) MPFS.
+
+## Acceptance criteria
+- [ ] The three dropped request-tx specs are restored in `test-integration/MPFS/APISpec.hs`,
+      migrated to the `*FromFacts` v2 API, and pass against the self-hosted devnet.
+- [ ] An integration spec drives a full oracle cycle against the devnet MPFS: boot a token →
+      a requester submits a request via the facts API → the oracle validates it
+      (`validateRequest`) → applies it via `UpdateToken`/`mpfsUpdateTokenFromFacts` → the token
+      state reflects the applied change. Passes.
+- [ ] `nix run .#integration-tests` green on the self-hosted fleet (orchestrator-verified on the PR).
+- [ ] Any oracle code path found broken against the new MPFS is fixed (none expected — verify).
+
+## Non-goals
+- Agent reconcile/report (#179). E2E harness (#186). The #153 cutover.
+
+## Parent
+#181. Depends on #177 (the self-hosting harness — merged). Parallel with #179 (disjoint:
+`src/Oracle/**` + the oracle integration specs vs `src/User/Agent/**`). Only shared touch is the
+one-line spec-list addition in `test-integration/Main.hs`.

--- a/specs/178-oracle-validation/tasks.md
+++ b/specs/178-oracle-validation/tasks.md
@@ -1,0 +1,11 @@
+# Tasks — #178 (oracle validation)
+
+## Slice A — restore + migrate the dropped request-tx integration specs
+- [ ] T178-SA restore requestInsert/requestDelete/requestUpdate specs in test-integration/MPFS/APISpec.hs (from git history of the TODO(#178) drop)
+- [ ] T178-SA migrate them to requestInsertFromFacts/requestDeleteFromFacts/requestUpdateFromFacts (src/MPFS/Request.hs)
+- [ ] T178-SA proof: integration suite passes against the self-hosted devnet (locally), new specs green
+
+## Slice B — end-to-end oracle request→validate→apply cycle spec
+- [ ] T178-SB integration spec: boot token → requester submits request (facts) → oracle validateRequest → UpdateToken/mpfsUpdateTokenFromFacts → assert token state reflects the change
+- [ ] T178-SB fix any oracle breakage surfaced against the new MPFS
+- [ ] T178-SB proof: spec passes against the self-hosted devnet (locally); orchestrator confirms green on the PR CI

--- a/specs/178-oracle-validation/tasks.md
+++ b/specs/178-oracle-validation/tasks.md
@@ -6,6 +6,6 @@
 - [X] T178-SA proof: integration suite passes against the self-hosted devnet (locally), new specs green
 
 ## Slice B — end-to-end oracle request→validate→apply cycle spec
-- [ ] T178-SB integration spec: boot token → requester submits request (facts) → oracle validateRequest → UpdateToken/mpfsUpdateTokenFromFacts → assert token state reflects the change
-- [ ] T178-SB fix any oracle breakage surfaced against the new MPFS
-- [ ] T178-SB proof: spec passes against the self-hosted devnet (locally); orchestrator confirms green on the PR CI
+- [X] T178-SB integration spec: boot token → requester submits request (facts) → oracle validateRequest → UpdateToken/mpfsUpdateTokenFromFacts → assert token state reflects the change
+- [X] T178-SB fix any oracle breakage surfaced against the new MPFS
+- [X] T178-SB proof: spec passes against the self-hosted devnet (locally); orchestrator confirms green on the PR CI

--- a/specs/178-oracle-validation/tasks.md
+++ b/specs/178-oracle-validation/tasks.md
@@ -1,9 +1,9 @@
 # Tasks — #178 (oracle validation)
 
 ## Slice A — restore + migrate the dropped request-tx integration specs
-- [ ] T178-SA restore requestInsert/requestDelete/requestUpdate specs in test-integration/MPFS/APISpec.hs (from git history of the TODO(#178) drop)
-- [ ] T178-SA migrate them to requestInsertFromFacts/requestDeleteFromFacts/requestUpdateFromFacts (src/MPFS/Request.hs)
-- [ ] T178-SA proof: integration suite passes against the self-hosted devnet (locally), new specs green
+- [X] T178-SA restore requestInsert/requestDelete/requestUpdate specs in test-integration/MPFS/APISpec.hs (from git history of the TODO(#178) drop)
+- [X] T178-SA migrate them to requestInsertFromFacts/requestDeleteFromFacts/requestUpdateFromFacts (src/MPFS/Request.hs)
+- [X] T178-SA proof: integration suite passes against the self-hosted devnet (locally), new specs green
 
 ## Slice B — end-to-end oracle request→validate→apply cycle spec
 - [ ] T178-SB integration spec: boot token → requester submits request (facts) → oracle validateRequest → UpdateToken/mpfsUpdateTokenFromFacts → assert token state reflects the change

--- a/test-integration/MPFS/APISpec.hs
+++ b/test-integration/MPFS/APISpec.hs
@@ -3,8 +3,24 @@
 module MPFS.APISpec (mpfsAPISpec)
 where
 
+import Cardano.Ledger.Api
+    ( ConwayEra
+    , Datum (..)
+    , EraTx (..)
+    , EraTxBody (outputsTxBodyL)
+    , binaryDataToData
+    , eraProtVerLow
+    , getPlutusData
+    )
+import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (BabbageTxOut))
+import Cardano.Ledger.Binary
+    ( DecCBOR (decCBOR)
+    , decodeFullAnnotator
+    )
+import Cardano.Tx.Ledger (ConwayTx)
 import Control.Concurrent (threadDelay)
 import Control.Exception (throwIO)
+import Control.Lens ((^.))
 import Control.Monad.Catch (SomeException, catch)
 import Control.Monad.IO.Class (MonadIO (..))
 import Core.Context (withContext)
@@ -12,23 +28,37 @@ import Core.Types.Basic
     ( Owner (..)
     , TokenId (..)
     )
+import Core.Types.CageDatum (CageDatum (..))
+import Core.Types.Change (Change (..), Key (..))
 import Core.Types.Mnemonics (Mnemonics (..))
+import Core.Types.Operation (Op (..), Operation (..))
 import Core.Types.Tx
     ( TxHash
+    , UnsignedTx (..)
     , WithTxHash (..)
+    , WithUnsignedTx (..)
     )
 import Core.Types.Wallet (Wallet (..))
 import Data.Aeson qualified as Aeson
 import Data.Bifunctor (first)
+import Data.ByteString.Base16 (decode)
 import Data.ByteString.Char8 qualified as B
+import Data.ByteString.Lazy.Char8 qualified as BL
 import Data.Text (Text)
+import Data.Text.Encoding qualified as T
 import Effects (mkEffects)
 import GitHub (Auth)
 import MPFS.API
-    ( awaitTransactionV2
+    ( RequestDeleteBody (..)
+    , RequestInsertBody (..)
+    , RequestUpdateBody (..)
+    , awaitTransactionV2
     , getToken
     , getTokenFacts
     , mpfsClient
+    , requestDeleteFromFacts
+    , requestInsertFromFacts
+    , requestUpdateFromFacts
     )
 import Network.HTTP.Client
     ( ManagerSettings (managerResponseTimeout)
@@ -41,6 +71,7 @@ import Oracle.Token.Cli
     , tokenCmdCore
     )
 import Oracle.Validate.Types (AValidationResult (ValidationSuccess))
+import PlutusTx (Data (..), FromData, fromData)
 import Servant.Client (ClientM, mkClientEnv, parseBaseUrl, runClientM)
 import Submitting
     ( IfToWait (..)
@@ -59,7 +90,8 @@ import Test.Hspec
     , shouldBe
     )
 import Text.JSON.Canonical
-    ( JSString
+    ( FromJSON
+    , JSString
     , JSValue (..)
     , fromJSString
     )
@@ -116,6 +148,50 @@ getHostFromEnv :: IO String
 getHostFromEnv = getEnv "MOOG_MPFS_HOST"
 
 newtype Call = Call {calling :: forall a. ClientM a -> IO a}
+
+-- | Decode a hex-encoded Conway transaction body for inspection.
+deserializeTx :: Text -> ConwayTx
+deserializeTx tx = case decode (T.encodeUtf8 tx) of
+    Left err -> error $ "Failed to decode CBOR: " ++ show err
+    Right bs ->
+        case decodeFullAnnotator
+            (eraProtVerLow @ConwayEra)
+            "ConwayTx"
+            decCBOR
+            (BL.fromStrict bs) of
+            Left err -> error $ "Failed to decode full CBOR: " ++ show err
+            Right tx' -> tx'
+
+-- | The first transaction output carrying an inline datum: the cage
+-- request output the @*FromFacts@ builders lock the 'RequestDatum' at.
+-- Change\/refund outputs carry no datum and are skipped.
+firstInlineDatum :: ConwayTx -> Maybe Data
+firstInlineDatum dtx =
+    case
+        [ getPlutusData (binaryDataToData bd)
+        | BabbageTxOut _ _ (Datum bd) _ <-
+            foldr (:) [] (dtx ^. bodyTxL . outputsTxBodyL)
+        ] of
+        datum : _ -> Just datum
+        [] -> Nothing
+
+-- | Decode a v2 cage request datum into the moog 'CageDatum'. The
+-- offchain builder serialises it as
+-- @Constr 0 [Constr 0 [tokenId, owner, key, value, fee, submittedAt]]@
+-- (the @OnChainRequest@ shape), so strip the outer 'RequestDatum'
+-- wrapper plus the @fee@\/@submittedAt@ fields the legacy four-field
+-- datum lacked, then reuse the existing field decoders.
+decodeRequestDatum
+    :: (FromJSON Maybe k, FromData (Operation op))
+    => Data
+    -> Maybe (CageDatum k op)
+decodeRequestDatum = \case
+    Constr 0 [Constr 0 [tokenIdD, ownerD, keyD, valueD, _, _]] ->
+        RequestDatum
+            <$> fromData tokenIdD
+            <*> fromData ownerD
+            <*> (Change <$> fromData keyD <*> fromData valueD)
+    _ -> Nothing
 
 data Context = Context
     { mpfs :: Call
@@ -226,11 +302,76 @@ mpfsAPISpec = aroundAllWith setupAction $ do
                 case res of
                     JSObject _ -> return ()
                     _ -> error "Response is not an object"
-
--- TODO(#178): restore + migrate request-tx specs to the *FromFacts v2 API.
--- The following three specs were dropped during the #177 v2 compile-fix
--- (they build + inspect unsigned request-tx datums, which is oracle
--- request-flow behavior owned by #178, not the self-hosted-devnet proof):
---   "can retrieve a request-insert tx"
---   "can retrieve a request-delete tx"
---   "can retrieve a request-update tx"
+        it "can retrieve a request-insert tx"
+            $ \Context{mpfs = Call call, tokenId, requesterWallet} -> do
+                WithUnsignedTx (UnsignedTx tx) _ <-
+                    call
+                        $ requestInsertFromFacts
+                            requesterWallet.address
+                            tokenId
+                        $ RequestInsertBody
+                            (JSString "key")
+                            (JSString "value")
+                let dtx = deserializeTx tx
+                Just datum <- pure $ firstInlineDatum dtx
+                Just (cageDatum :: CageDatum String (OpI String)) <-
+                    pure $ decodeRequestDatum datum
+                cageDatum
+                    `shouldBe` RequestDatum
+                        { tokenId = tokenId
+                        , owner = requesterWallet.owner
+                        , change =
+                            Change
+                                { key = Key "key"
+                                , operation = Insert "value"
+                                }
+                        }
+        it "can retrieve a request-delete tx"
+            $ \Context{mpfs = Call call, tokenId, requesterWallet} -> do
+                WithUnsignedTx (UnsignedTx tx) _ <-
+                    call
+                        $ requestDeleteFromFacts
+                            requesterWallet.address
+                            tokenId
+                        $ RequestDeleteBody
+                            (JSString "key")
+                            (JSString "value")
+                let dtx = deserializeTx tx
+                Just datum <- pure $ firstInlineDatum dtx
+                Just (cageDatum :: CageDatum String (OpD String)) <-
+                    pure $ decodeRequestDatum datum
+                cageDatum
+                    `shouldBe` RequestDatum
+                        { tokenId = tokenId
+                        , owner = requesterWallet.owner
+                        , change =
+                            Change
+                                { key = Key "key"
+                                , operation = Delete "value"
+                                }
+                        }
+        it "can retrieve a request-update tx"
+            $ \Context{mpfs = Call call, tokenId, requesterWallet} -> do
+                WithUnsignedTx (UnsignedTx tx) _ <-
+                    call
+                        $ requestUpdateFromFacts
+                            requesterWallet.address
+                            tokenId
+                        $ RequestUpdateBody
+                            (JSString "key")
+                            (JSString "oldValue")
+                            (JSString "newValue")
+                let dtx = deserializeTx tx
+                Just datum <- pure $ firstInlineDatum dtx
+                Just (cageDatum :: CageDatum String (OpU String String)) <-
+                    pure $ decodeRequestDatum datum
+                cageDatum
+                    `shouldBe` RequestDatum
+                        { tokenId = tokenId
+                        , owner = requesterWallet.owner
+                        , change =
+                            Change
+                                { key = Key "key"
+                                , operation = Update "oldValue" "newValue"
+                                }
+                        }

--- a/test-integration/MPFS/APISpec.hs
+++ b/test-integration/MPFS/APISpec.hs
@@ -30,6 +30,7 @@ import Core.Types.Basic
     )
 import Core.Types.CageDatum (CageDatum (..))
 import Core.Types.Change (Change (..), Key (..))
+import Core.Types.Fact (Fact (..), parseFacts)
 import Core.Types.Mnemonics (Mnemonics (..))
 import Core.Types.Operation (Op (..), Operation (..))
 import Core.Types.Tx
@@ -44,6 +45,7 @@ import Data.Bifunctor (first)
 import Data.ByteString.Base16 (decode)
 import Data.ByteString.Char8 qualified as B
 import Data.ByteString.Lazy.Char8 qualified as BL
+import Data.Functor.Identity (Identity (..))
 import Data.Text (Text)
 import Data.Text.Encoding qualified as T
 import Effects (mkEffects)
@@ -66,11 +68,25 @@ import Network.HTTP.Client
     , responseTimeoutMicro
     )
 import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Oracle.Config.Cli (ConfigCmd (..), configCmd)
+import Oracle.Config.Types
+    ( Config
+    , ConfigKey
+    , mkCurrentConfig
+    )
 import Oracle.Token.Cli
     ( TokenCommand (..)
     , tokenCmdCore
     )
-import Oracle.Validate.Types (AValidationResult (ValidationSuccess))
+import Oracle.Types
+    ( RequestZoo (..)
+    , Token (..)
+    , requestZooRefId
+    )
+import Oracle.Validate.Requests.TestRun.Config
+    ( TestRunValidationConfig (..)
+    )
+import Oracle.Validate.Types (AValidationResult (..))
 import PlutusTx (Data (..), FromData, fromData)
 import Servant.Client (ClientM, mkClientEnv, parseBaseUrl, runClientM)
 import Submitting
@@ -86,11 +102,12 @@ import Test.Hspec
     , SpecWith
     , aroundAllWith
     , describe
+    , expectationFailure
     , it
     , shouldBe
     )
 import Text.JSON.Canonical
-    ( FromJSON
+    ( FromJSON (..)
     , JSString
     , JSValue (..)
     , fromJSString
@@ -275,6 +292,28 @@ waitTx (Call call) txHash = go (600 :: Int)
                 liftIO $ threadDelay 1000000
                 go (n - 1)
 
+-- | Poll @GET token@ until the parsed token satisfies the predicate,
+-- giving the indexer time to surface a just-submitted request or a
+-- just-applied update. Mirrors 'waitTx''s bounded retry.
+pollToken
+    :: Call
+    -> TokenId
+    -> (Token Identity -> Bool)
+    -> IO (Token Identity)
+pollToken (Call call) tk ok = go (180 :: Int)
+  where
+    go :: Int -> IO (Token Identity)
+    go 0 = error "pollToken: token never reached the expected state"
+    go n = do
+        mToken <-
+            (fromJSON <$> call (getToken tk))
+                `catch` \(_ :: SomeException) -> pure Nothing
+        case mToken of
+            Just token | ok token -> pure token
+            _ -> do
+                threadDelay 1000000
+                go (n - 1)
+
 setupAction :: ActionWith Context -> ActionWith Auth
 setupAction action auth = do
     ctx <- setup auth
@@ -375,3 +414,70 @@ mpfsAPISpec = aroundAllWith setupAction $ do
                                 , operation = Update "oldValue" "newValue"
                                 }
                         }
+        it "applies a config request through the full oracle cycle"
+            $ \Context
+                    { mpfs
+                    , wait180S
+                    , tokenId
+                    , requesterWallet
+                    , oracleWallet
+                    , agentWallet
+                    , auth
+                    } -> do
+                let config =
+                        mkCurrentConfig agentWallet.owner
+                            $ TestRunValidationConfig
+                                { maxDuration = 3
+                                , minDuration = 1
+                                }
+                -- 1. Requester submits a config-insert request. Config is
+                -- the one typed request validateRequest accepts with no
+                -- external GitHub state; it must come from the oracle,
+                -- which the shared role wallets satisfy.
+                _ <-
+                    calling mpfs
+                        $ withContext mpfsClient (mkEffects auth) wait180S
+                        $ configCmd
+                        $ SetConfig tokenId requesterWallet config
+                -- 2. Oracle observes the single pending request.
+                pending <-
+                    pollToken mpfs tokenId
+                        $ not . null . tokenRequests
+                reqId <- case tokenRequests pending of
+                    [Identity r@(InsertConfigRequest _)] ->
+                        pure $ requestZooRefId r
+                    rs ->
+                        expectationFailure
+                            ( "expected one pending config request, got "
+                                <> show (runIdentity <$> rs)
+                            )
+                            >> error "unreachable"
+                -- 3. Oracle validates (validateRequest, run inside
+                -- UpdateToken) and applies via mpfsUpdateTokenFromFacts,
+                -- signed by the oracle wallet. ValidationSuccess implies
+                -- validation passed.
+                applyResult <-
+                    calling mpfs
+                        $ withContext mpfsClient (mkEffects auth) wait180S
+                        $ tokenCmdCore
+                        $ UpdateToken tokenId oracleWallet [reqId]
+                applyTxHash <- case applyResult of
+                    ValidationSuccess h -> pure h
+                    ValidationFailure e ->
+                        expectationFailure
+                            ( "oracle UpdateToken rejected the cycle: "
+                                <> show e
+                            )
+                            >> error "unreachable"
+                waitTx mpfs applyTxHash
+                -- 4. Post-state: the request is consumed and the config
+                -- fact the requester asked for is committed to the token.
+                applied <-
+                    pollToken mpfs tokenId
+                        $ null . tokenRequests
+                tokenRequests applied `shouldBe` []
+                factsJson <- calling mpfs $ getTokenFacts tokenId
+                map
+                    factValue
+                    (parseFacts factsJson :: [Fact ConfigKey Config])
+                    `shouldBe` [config]


### PR DESCRIPTION
Closes #178. Part of epic #181.

Validation coverage for the oracle service against the new facts-only MPFS (the oracle is already on the v2 facts API; this proves it end-to-end via the self-hosting integration harness from #177). Restores the request-tx specs #177 dropped.

## Slices
- A — restore + migrate the dropped request-tx integration specs to `*FromFacts`
- B — end-to-end oracle request→validate→apply cycle integration spec

WIP — driver in progress.