### PR TITLE
Validate the agent service against the new facts-only MPFS (mock Antithesis) (#179)

### DIFF
--- a/moog.cabal
+++ b/moog.cabal
@@ -667,6 +667,7 @@ test-suite integration-tests
   -- Modules included in this executable, other than Main.
   other-modules:
     Agent.ValidationSpec
+    Lib.Agent.AcceptHarness
     Lib.Agent.MockAntithesis
     Lib.Github.OracleValidationSpec
     Lib.GitHubSpec
@@ -698,6 +699,8 @@ test-suite integration-tests
     , cardano-ledger-core
     , cardano-strict-containers
     , cardano-tx-tools
+    , case-insensitive
+    , crypton
     , directory
     , exceptions
     , github

--- a/moog.cabal
+++ b/moog.cabal
@@ -657,11 +657,17 @@ test-suite integration-tests
   -- Import common warning flags.
   import:           warnings
 
+  -- Warp's 'testWithApplication' (the mock Antithesis server) and the
+  -- devnet server boot need the threaded runtime.
+  ghc-options:      -threaded
+
   -- Base language which the package is written in.
   default-language: Haskell2010
 
   -- Modules included in this executable, other than Main.
   other-modules:
+    Agent.ValidationSpec
+    Lib.Agent.MockAntithesis
     Lib.Github.OracleValidationSpec
     Lib.GitHubSpec
     MPFS.APISpec
@@ -698,6 +704,7 @@ test-suite integration-tests
     , hspec
     , http-client
     , http-client-tls
+    , http-types
     , lens
     , moog
     , path
@@ -705,3 +712,5 @@ test-suite integration-tests
     , servant-client
     , temporary
     , text
+    , wai
+    , warp

--- a/specs/179-agent-validation/spec.md
+++ b/specs/179-agent-validation/spec.md
@@ -1,0 +1,45 @@
+# #179 — Validate the agent service against the new facts-only MPFS (mock Antithesis)
+
+## P1 user story
+As an operator, the agent takes accepted on-chain test-runs, looks up their status (a mock
+Antithesis API in tests), and writes results back on-chain via the new facts-only MPFS —
+proven end-to-end by the integration suite (self-hosting the offchain `mpfs-devnet-server`, #177).
+
+## Context (from scoping)
+The agent is **already on the v2 facts API**: reads via `mpfsGetTokenFacts`
+(`src/User/Agent/Process.hs:557`, facts-native), writes via
+`mpfsRequestUpdateFromFacts`/`mpfsRequestInsertFromFacts`/`mpfsRequestDeleteFromFacts`
+(`src/User/Agent/Cli.hs:424,454,513`). No legacy MPFS surface remains. So this ticket is
+**validation coverage**: prove the reconcile→report cycle against the new MPFS, with a mock
+Antithesis. Fix any breakage surfaced.
+
+Key facts:
+- Reconcile loop: `agentProcess` (`src/User/Agent/Process.hs:298`); transitions
+  `submitRunning` (Pending→Running, Accept) and `submitDone` (Running→Done, Report) at
+  `Process.hs:581-626`, routed through `agentCmd` (`src/User/Agent/Cli.hs:198`).
+- Antithesis client is **direct ClientM, no DI seam** (`src/User/Agent/Antithesis/Client.hs:80-111`).
+  Mocking ⇒ a Warp test server, pattern already proven in
+  `test/User/Agent/Antithesis/ClientSpec.hs:106-157`. Use the **lightweight** approach (fake
+  `ClientEnv` → Warp server), NOT a typeclass refactor.
+- Pure planning is already unit-tested (`Antithesis/Plan.hs`, `State.hs`); the gap is the
+  **integration** reconcile→report cycle against a real MPFS.
+
+## Acceptance criteria
+- [ ] A reusable mock-Antithesis Warp server helper (factored from `ClientSpec`) serves a
+      configurable run list, wired into the integration harness.
+- [ ] Integration spec: **Pending→Running** — boot a token, register a Pending test-run on-chain
+      (facts), mock Antithesis returns the matching run in-progress, drive the agent accept;
+      assert a Running fact is written to the devnet MPFS.
+- [ ] Integration spec: **Running→Done** — mock Antithesis returns the run completed, drive the
+      agent report; assert a Done fact (correct outcome + requester-encrypted URL) on-chain.
+- [ ] `nix run .#integration-tests` green on the self-hosted fleet (orchestrator-verified on PR).
+- [ ] Any agent code path found broken against the new MPFS is fixed (none expected — verify).
+
+## Non-goals
+- Real Antithesis API (the manual smoke is #180). Oracle flows (#178). E2E harness (#186).
+- A typeclass refactor of the Antithesis client (use the Warp-server mock seam).
+
+## Parent
+#181. Depends on #177 (merged). Parallel with #178 (disjoint: `src/User/Agent/**` +
+`test/MockMPFS.hs` + the agent integration specs vs `src/Oracle/**`). Only shared touch is the
+one-line spec-list addition in `test-integration/Main.hs`.

--- a/specs/179-agent-validation/tasks.md
+++ b/specs/179-agent-validation/tasks.md
@@ -1,9 +1,9 @@
 # Tasks — #179 (agent validation, mock Antithesis)
 
 ## Slice A — mock-Antithesis Warp helper + agent integration spec module
-- [ ] T179-SA factor a reusable `withMockAntithesisServer` (from test/User/Agent/Antithesis/ClientSpec.hs) serving a configurable run list
-- [ ] T179-SA add an agent integration spec module + wire it into test-integration/Main.hs (one-line)
-- [ ] T179-SA proof: mock server boots + the (stub) spec runs under the integration harness
+- [X] T179-SA factor a reusable `withMockAntithesisServer` (from test/User/Agent/Antithesis/ClientSpec.hs) serving a configurable run list
+- [X] T179-SA add an agent integration spec module + wire it into test-integration/Main.hs (one-line)
+- [X] T179-SA proof: mock server boots + the (stub) spec runs under the integration harness
 
 ## Slice B — Pending→Running (Accept) integration test
 - [ ] T179-SB boot token; register a Pending test-run on-chain (facts); mock Antithesis returns the run in-progress; drive the agent accept (submitRunning / planAgentPoll+execute)

--- a/specs/179-agent-validation/tasks.md
+++ b/specs/179-agent-validation/tasks.md
@@ -1,0 +1,16 @@
+# Tasks — #179 (agent validation, mock Antithesis)
+
+## Slice A — mock-Antithesis Warp helper + agent integration spec module
+- [ ] T179-SA factor a reusable `withMockAntithesisServer` (from test/User/Agent/Antithesis/ClientSpec.hs) serving a configurable run list
+- [ ] T179-SA add an agent integration spec module + wire it into test-integration/Main.hs (one-line)
+- [ ] T179-SA proof: mock server boots + the (stub) spec runs under the integration harness
+
+## Slice B — Pending→Running (Accept) integration test
+- [ ] T179-SB boot token; register a Pending test-run on-chain (facts); mock Antithesis returns the run in-progress; drive the agent accept (submitRunning / planAgentPoll+execute)
+- [ ] T179-SB assert a Running fact is written to the devnet MPFS
+- [ ] T179-SB proof: spec passes against the self-hosted devnet (locally)
+
+## Slice C — Running→Done (Report) integration test
+- [ ] T179-SC mock Antithesis returns the run completed; drive the agent report (submitDone)
+- [ ] T179-SC assert a Done fact on-chain with correct outcome + requester-encrypted URL
+- [ ] T179-SC fix any agent breakage surfaced; proof: spec passes against the devnet (locally); orchestrator confirms green on PR CI

--- a/specs/179-agent-validation/tasks.md
+++ b/specs/179-agent-validation/tasks.md
@@ -6,9 +6,9 @@
 - [X] T179-SA proof: mock server boots + the (stub) spec runs under the integration harness
 
 ## Slice B — Pending→Running (Accept) integration test
-- [ ] T179-SB boot token; register a Pending test-run on-chain (facts); mock Antithesis returns the run in-progress; drive the agent accept (submitRunning / planAgentPoll+execute)
-- [ ] T179-SB assert a Running fact is written to the devnet MPFS
-- [ ] T179-SB proof: spec passes against the self-hosted devnet (locally)
+- [X] T179-SB boot token; register a Pending test-run on-chain (facts); mock Antithesis returns the run in-progress; drive the agent accept (submitRunning / planAgentPoll+execute)
+- [X] T179-SB assert a Running fact is written to the devnet MPFS
+- [X] T179-SB proof: spec passes against the self-hosted devnet (locally)
 
 ## Slice C — Running→Done (Report) integration test
 - [ ] T179-SC mock Antithesis returns the run completed; drive the agent report (submitDone)

--- a/specs/179-agent-validation/tasks.md
+++ b/specs/179-agent-validation/tasks.md
@@ -11,6 +11,6 @@
 - [X] T179-SB proof: spec passes against the self-hosted devnet (locally)
 
 ## Slice C — Running→Done (Report) integration test
-- [ ] T179-SC mock Antithesis returns the run completed; drive the agent report (submitDone)
-- [ ] T179-SC assert a Done fact on-chain with correct outcome + requester-encrypted URL
-- [ ] T179-SC fix any agent breakage surfaced; proof: spec passes against the devnet (locally); orchestrator confirms green on PR CI
+- [X] T179-SC mock Antithesis returns the run completed; drive the agent report (submitDone)
+- [X] T179-SC assert a Done fact on-chain with correct outcome + requester-encrypted URL
+- [X] T179-SC fix any agent breakage surfaced; proof: spec passes against the devnet (locally); orchestrator confirms green on PR CI

--- a/src/MPFS/Read.hs
+++ b/src/MPFS/Read.hs
@@ -9,11 +9,18 @@ module MPFS.Read
     , verifyTokenResponsesWith
     ) where
 
+import Cardano.Ledger.Api (ConwayEra, eraProtVerLow)
+import Cardano.Ledger.Api.Scripts.Data
+    ( Data (..)
+    , Datum (..)
+    , binaryDataToData
+    )
+import Cardano.Ledger.Api.Tx.Out (TxOut, datumTxOutL)
+import Cardano.Ledger.Binary (decodeFull)
 import Cardano.MPFS.API.Encoding (Hex (..))
 import Cardano.MPFS.API.Types
     ( FactEntry (..)
     , FactsResponse (..)
-    , RequestJSON (..)
     , RequestsResponse (..)
     , StatusResponse (..)
     , TokenResponse (..)
@@ -24,6 +31,11 @@ import Cardano.MPFS.API.Types
     , WitnessedUtxo (..)
     )
 import Cardano.MPFS.API.Types.Common (TokenIdJSON)
+import Cardano.MPFS.Cage.Types
+    ( CageDatum (..)
+    , OnChainOperation (..)
+    , OnChainRequest (..)
+    )
 import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
 import Cardano.MPFS.Client.Verify.Replay (VerifyError)
 import Cardano.MPFS.Client.Verify.Read
@@ -34,13 +46,16 @@ import Cardano.MPFS.Client.Verify.Read
     , verifyTokenState
     , verifiedTokenFacts
     )
+import Control.Lens ((^.))
 import Control.Monad.IO.Class (liftIO)
 import Core.Types.Basic (Owner (..), RequestRefId (..), TokenId)
 import Core.Types.Fact (Slot (..))
 import Core.Types.Tx (Root (..))
+import Data.Bifunctor (first)
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as Base16
 import Data.ByteString.Char8 qualified as B8
+import Data.ByteString.Lazy qualified as BL
 import Data.Functor.Identity (Identity (Identity, runIdentity))
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
@@ -57,6 +72,9 @@ import Oracle.Types
     , Token (..)
     , TokenState (..)
     )
+import PlutusTx.Builtins (fromBuiltin)
+import PlutusTx.Builtins.Internal (BuiltinData (..))
+import PlutusTx.IsData.Class (fromBuiltinData)
 import Servant.Client (ClientM)
 import Text.JSON.Canonical (FromJSON (..), JSValue (..), ToJSON (..))
 
@@ -172,64 +190,84 @@ verifyFactsResponse trustedRoot facts =
     verifiedTokenFacts <$> verifyTokenFacts trustedRoot facts
 
 requestJSONToRequestZoo :: WitnessedRequest -> Either String RequestZoo
-requestJSONToRequestZoo WitnessedRequest{wrUtxo, wrRequest} =
+requestJSONToRequestZoo WitnessedRequest{wrUtxo} = do
     let refId = txInRefId $ wuTxIn wrUtxo
-    in  requestJSONToJSValue refId wrRequest >>= parseRequestZoo
+    -- Decode the typed request from the VERIFIED inline-datum TxOut
+    -- (proof-bound to the trusted root by 'verifyTokenRequests'), NOT from
+    -- the unverified, lossy 'RequestJSON' projection — which drops an
+    -- update's old value and so cannot type accept\/reject\/finished\/config
+    -- updates (they collapse to UnknownUpdate).
+    request <- decodeRequestDatum $ wuTxOut wrUtxo
+    requestDatumToJSValue refId request >>= parseRequestZoo
 
-requestJSONToJSValue
-    :: RequestRefId -> RequestJSON -> Either String JSValue
-requestJSONToJSValue
-    refId
-    RequestJSON{rjOwner, rjKey = Hex key, rjOperation, rjValue} = do
-        keyValue <- canonicalBytesToJSValue "request.key" (Hex key)
-        operationFields <- requestOperationFields rjOperation rjValue
-        pure
-            $ runIdentity
-            $ object
-                [ "outputRefId" .= refId
-                , "owner" .= Owner (T.unpack rjOwner)
-                ,
-                    ( "change"
-                    , object
-                        $ ("key" .= jsonToString keyValue)
-                            : operationFields
-                    )
-                ]
+-- | Decode the on-chain 'OnChainRequest' from a request UTxO's inline datum.
+-- @wuTxOut@ is the CBOR of the Conway 'TxOut'; its inline datum is the cage
+-- 'RequestDatum', which carries BOTH the old and new values for updates.
+decodeRequestDatum :: Hex -> Either String OnChainRequest
+decodeRequestDatum (Hex txOutBytes) = do
+    txOut <-
+        first (("request TxOut decode failed: " <>) . show)
+            $ decodeFull (eraProtVerLow @ConwayEra) (BL.fromStrict txOutBytes)
+    case cageDatumOf txOut of
+        Just (RequestDatum request) -> Right request
+        Just (StateDatum _) ->
+            Left "request UTxO carries a state datum, not a request datum"
+        Nothing -> Left "request UTxO has no inline cage datum"
+
+-- | Extract the cage datum from a Conway 'TxOut' inline datum.
+cageDatumOf :: TxOut ConwayEra -> Maybe CageDatum
+cageDatumOf txOut = case txOut ^. datumTxOutL of
+    Datum binaryData ->
+        let Data plutusData = binaryDataToData binaryData
+         in fromBuiltinData (BuiltinData plutusData)
+    _ -> Nothing
+
+-- | Render an 'OnChainRequest' as the @change@-bearing JSValue that
+-- 'parseRequestZoo' consumes — now with the REAL old and new values.
+requestDatumToJSValue
+    :: RequestRefId -> OnChainRequest -> Either String JSValue
+requestDatumToJSValue refId request = do
+    keyValue <- canonicalBytesToJSValue "request.key" (Hex $ requestKey request)
+    operationFields <- requestOperationFields $ requestValue request
+    pure
+        $ runIdentity
+        $ object
+            [ "outputRefId" .= refId
+            , "owner"
+                .= Owner (hexString $ fromBuiltin $ requestOwner request)
+            ,
+                ( "change"
+                , object
+                    $ ("key" .= jsonToString keyValue) : operationFields
+                )
+            ]
 
 requestOperationFields
-    :: T.Text -> Maybe Hex -> Either String [(String, Identity JSValue)]
-requestOperationFields "insert" maybeValue = do
-    value <- requiredValue "insert" maybeValue
-    pure
-        [ "type" .= ("insert" :: String)
-        , "newValue" .= jsonToString value
-        ]
-requestOperationFields "delete" maybeValue = do
-    value <- optionalValue maybeValue
-    pure
-        [ "type" .= ("delete" :: String)
-        , "oldValue" .= jsonToString value
-        ]
-requestOperationFields "update" maybeValue = do
-    value <- optionalValue maybeValue
-    pure
-        [ "type" .= ("update" :: String)
-        , "oldValue" .= jsonToString JSNull
-        , "newValue" .= jsonToString value
-        ]
-requestOperationFields operation _ =
-    Left $ "unknown request operation: " <> T.unpack operation
+    :: OnChainOperation -> Either String [(String, Identity JSValue)]
+requestOperationFields = \case
+    OpInsert v -> do
+        newValue <- requestValueJSON v
+        pure
+            [ "type" .= ("insert" :: String)
+            , "newValue" .= jsonToString newValue
+            ]
+    OpDelete v -> do
+        oldValue <- requestValueJSON v
+        pure
+            [ "type" .= ("delete" :: String)
+            , "oldValue" .= jsonToString oldValue
+            ]
+    OpUpdate old new -> do
+        oldValue <- requestValueJSON old
+        newValue <- requestValueJSON new
+        pure
+            [ "type" .= ("update" :: String)
+            , "oldValue" .= jsonToString oldValue
+            , "newValue" .= jsonToString newValue
+            ]
 
-requiredValue :: String -> Maybe Hex -> Either String JSValue
-requiredValue operation =
-    maybe
-        (Left $ operation <> " request is missing value")
-        (canonicalBytesToJSValue $ "request." <> operation <> ".value")
-
-optionalValue :: Maybe Hex -> Either String JSValue
-optionalValue Nothing = Right JSNull
-optionalValue (Just hexValue) =
-    canonicalBytesToJSValue "request.value" hexValue
+requestValueJSON :: BS.ByteString -> Either String JSValue
+requestValueJSON = canonicalBytesToJSValue "request.value" . Hex
 
 canonicalBytesToJSValue :: String -> Hex -> Either String JSValue
 canonicalBytesToJSValue field (Hex bytes) =

--- a/test-integration/Agent/ValidationSpec.hs
+++ b/test-integration/Agent/ValidationSpec.hs
@@ -9,21 +9,29 @@
 --     the configured runs);
 --   * the Accept test proves the Pending→Running transition: a pending
 --     test-run fact on-chain plus a matching in-progress Antithesis run
---     drives the real agent Accept, and a Running fact is written.
+--     drives the real agent Accept, and a Running fact is written;
+--   * the Report test proves the Running→Done transition: a running
+--     test-run plus a matching completed Antithesis run drives the real
+--     agent Report, and a Done fact is written with the success outcome
+--     and the result URL encrypted for the requester.
 module Agent.ValidationSpec
     ( agentValidationSpec
     )
 where
 
+import Core.Types.Fact (Fact (..))
 import Data.Text qualified as T
 import Lib.Agent.AcceptHarness
     ( acceptViaAgent
     , factTestRun
     , foldPendingRequests
+    , readDoneFacts
     , readPendingFacts
     , readRunningFacts
+    , reportViaAgent
     , sampleTestRun
     , seedConfigAndPending
+    , seedConfigRunningUser
     , tokenRequestRefIds
     , withAcceptEnv
     )
@@ -47,14 +55,21 @@ import User.Agent.Antithesis.Client
 import User.Agent.Antithesis.Plan
     ( PendingAction (..)
     , PollPlan (..)
+    , RunningAction (..)
     , planAgentPoll
     )
 import User.Agent.Antithesis.State
     ( AntithesisRun (..)
     , AntithesisRunStatus (..)
     )
+import User.Agent.Lib (testRunDuration)
 import User.Agent.PushTest (renderTestRun)
 import User.Agent.Types (mkTestRunId)
+import User.Types
+    ( Outcome (..)
+    , TestRunState (..)
+    , URL (..)
+    )
 
 agentValidationSpec :: Spec
 agentValidationSpec = describe "Agent.Validation" $ do
@@ -146,6 +161,110 @@ agentValidationSpec = describe "Agent.Validation" $ do
                 runningFinal <- readRunningFacts env
                 length (filter (== testRun) (map factTestRun runningFinal))
                     `shouldBe` 1
+
+    it
+        "writes a Done fact (success + requester-encrypted URL) when a \
+        \running test-run's Antithesis run completes"
+        $ withAcceptEnv
+        $ \env -> do
+            let testRun = sampleTestRun
+                trId = mkTestRunId testRun
+                reportUrl = "https://report.example/run-c"
+                apiRun =
+                    AntithesisRun
+                        { antithesisRunId = "run-report-1"
+                        , antithesisRunStatus = RunCompleted
+                        , antithesisRunDescription =
+                            Just (T.pack (renderTestRun trId testRun))
+                        , antithesisRunTriageReport = Just (T.pack reportUrl)
+                        }
+            -- A running test-run + config + the requester's registration.
+            seedConfigRunningUser env testRun
+            withMockAntithesisServer (pure [apiRun]) $ \baseUrl -> do
+                let apiConfig =
+                        AntithesisApiConfig
+                            { antithesisApiUrl = AntithesisApiUrl baseUrl
+                            , antithesisApiKey = AntithesisApiKey "itest-key"
+                            }
+                apiRuns <-
+                    either
+                        (\e -> fail $ "listAllRuns: " <> show e)
+                        pure
+                        =<< listAllRuns apiConfig
+                runningFacts <- readRunningFacts env
+                -- The real planner maps the completed run to a finish action.
+                let plan = planAgentPoll (const True) apiRuns [] runningFacts
+                case runningActions plan of
+                    [RunningFinishObserved (Fact tr running _) run outcome url] ->
+                        do
+                            tr `shouldBe` testRun
+                            run `shouldBe` apiRun
+                            outcome `shouldBe` OutcomeSuccess
+                            url `shouldBe` URL reportUrl
+                            -- Drive the agent Report, signed by the agent.
+                            reportRes <-
+                                reportViaAgent
+                                    env
+                                    trId
+                                    (testRunDuration running)
+                                    outcome
+                                    url
+                            case reportRes of
+                                ValidationSuccess _ -> pure ()
+                                ValidationFailure err ->
+                                    expectationFailure
+                                        $ "agent Report failed: " <> show err
+                            -- Oracle folds the Report into a Done fact.
+                            reportRefs <- tokenRequestRefIds env
+                            foldRes <- foldPendingRequests env reportRefs
+                            case foldRes of
+                                ValidationSuccess _ -> pure ()
+                                ValidationFailure err ->
+                                    expectationFailure
+                                        $ "oracle fold failed: " <> show err
+                            -- The Done fact carries the success outcome and the
+                            -- result URL, encrypted for the requester (decrypted
+                            -- here with the requester wallet key).
+                            doneFacts <- readDoneFacts env
+                            case filter ((== testRun) . factTestRun) doneFacts of
+                                [Fact _ (Finished _ _ doneOutcome (URL doneUrl)) _] ->
+                                    do
+                                        doneOutcome `shouldBe` OutcomeSuccess
+                                        doneUrl `shouldBe` reportUrl
+                                other ->
+                                    expectationFailure
+                                        $ "expected one Done fact, got: "
+                                            <> show other
+                            -- Report is idempotent: the running fact is gone and
+                            -- a second poll neither plans nor writes.
+                            runningAfter <- readRunningFacts env
+                            map factTestRun runningAfter
+                                `shouldNotContain` [testRun]
+                            reportAgain <-
+                                reportViaAgent
+                                    env
+                                    trId
+                                    (testRunDuration running)
+                                    outcome
+                                    url
+                            case reportAgain of
+                                ValidationFailure _ -> pure ()
+                                ValidationSuccess _ ->
+                                    expectationFailure
+                                        "second Report unexpectedly succeeded"
+                            runningFinal <- readRunningFacts env
+                            runningActions
+                                ( planAgentPoll
+                                    (const True)
+                                    apiRuns
+                                    []
+                                    runningFinal
+                                )
+                                `shouldBe` []
+                    other ->
+                        expectationFailure
+                            $ "expected one RunningFinishObserved, got: "
+                                <> show other
 
 -- | A representative two-run list spanning a non-terminal run with no
 -- triage report and a terminal run with one, so the round-trip exercises

--- a/test-integration/Agent/ValidationSpec.hs
+++ b/test-integration/Agent/ValidationSpec.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Integration coverage of the agent's Antithesis read seam against the
+-- mock Antithesis Warp server ("Lib.Agent.MockAntithesis").
+--
+-- This slice (A) is infrastructure only: a single smoke that boots the
+-- mock and asserts 'listAllRuns' round-trips the configured run list,
+-- proving the seam works end to end. The Pending→Running and
+-- Running→Done reconcile→report transition tests land in slices B\/C.
+module Agent.ValidationSpec
+    ( agentValidationSpec
+    )
+where
+
+import Lib.Agent.MockAntithesis (withMockAntithesisServer)
+import Test.Hspec (Spec, describe, it, shouldBe)
+import User.Agent.Antithesis.Client
+    ( AntithesisApiConfig (..)
+    , AntithesisApiKey (..)
+    , AntithesisApiUrl (..)
+    , listAllRuns
+    )
+import User.Agent.Antithesis.State
+    ( AntithesisRun (..)
+    , AntithesisRunStatus (..)
+    )
+
+agentValidationSpec :: Spec
+agentValidationSpec = describe "Agent.Validation" $ do
+    it "round-trips the configured runs via the mock Antithesis server" $ do
+        result <-
+            withMockAntithesisServer (pure sampleRuns) $ \baseUrl ->
+                listAllRuns
+                    AntithesisApiConfig
+                        { antithesisApiUrl = AntithesisApiUrl baseUrl
+                        , antithesisApiKey = AntithesisApiKey "api-key"
+                        }
+        result `shouldBe` Right sampleRuns
+
+-- | A representative two-run list spanning a non-terminal run with no
+-- triage report and a terminal run with one, so the round-trip exercises
+-- both the present and absent optional fields.
+sampleRuns :: [AntithesisRun]
+sampleRuns =
+    [ AntithesisRun
+        { antithesisRunId = "run-1"
+        , antithesisRunStatus = RunInProgress
+        , antithesisRunDescription = Just "description-1"
+        , antithesisRunTriageReport = Nothing
+        }
+    , AntithesisRun
+        { antithesisRunId = "run-2"
+        , antithesisRunStatus = RunCompleted
+        , antithesisRunDescription = Just "description-2"
+        , antithesisRunTriageReport = Just "https://report.example/run-2"
+        }
+    ]

--- a/test-integration/Agent/ValidationSpec.hs
+++ b/test-integration/Agent/ValidationSpec.hs
@@ -1,29 +1,60 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Integration coverage of the agent's Antithesis read seam against the
--- mock Antithesis Warp server ("Lib.Agent.MockAntithesis").
+-- | Integration coverage of the agent's Antithesis reconcile cycle
+-- against the mock Antithesis Warp server ("Lib.Agent.MockAntithesis")
+-- and the self-hosted devnet MPFS.
 --
--- This slice (A) is infrastructure only: a single smoke that boots the
--- mock and asserts 'listAllRuns' round-trips the configured run list,
--- proving the seam works end to end. The Pending→Running and
--- Running→Done reconcile→report transition tests land in slices B\/C.
+--   * the slice-A smoke proves the read seam ('listAllRuns' round-trips
+--     the configured runs);
+--   * the Accept test proves the Pending→Running transition: a pending
+--     test-run fact on-chain plus a matching in-progress Antithesis run
+--     drives the real agent Accept, and a Running fact is written.
 module Agent.ValidationSpec
     ( agentValidationSpec
     )
 where
 
+import Data.Text qualified as T
+import Lib.Agent.AcceptHarness
+    ( acceptViaAgent
+    , factTestRun
+    , foldPendingRequests
+    , readPendingFacts
+    , readRunningFacts
+    , sampleTestRun
+    , seedConfigAndPending
+    , tokenRequestRefIds
+    , withAcceptEnv
+    )
 import Lib.Agent.MockAntithesis (withMockAntithesisServer)
-import Test.Hspec (Spec, describe, it, shouldBe)
+import Oracle.Validate.Types (AValidationResult (..))
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    , shouldContain
+    , shouldNotContain
+    )
 import User.Agent.Antithesis.Client
     ( AntithesisApiConfig (..)
     , AntithesisApiKey (..)
     , AntithesisApiUrl (..)
     , listAllRuns
     )
+import User.Agent.Antithesis.Plan
+    ( PendingAction (..)
+    , PollPlan (..)
+    , planAgentPoll
+    )
 import User.Agent.Antithesis.State
     ( AntithesisRun (..)
     , AntithesisRunStatus (..)
     )
+import User.Agent.PushTest (renderTestRun)
+import User.Agent.Types (mkTestRunId)
 
 agentValidationSpec :: Spec
 agentValidationSpec = describe "Agent.Validation" $ do
@@ -36,6 +67,85 @@ agentValidationSpec = describe "Agent.Validation" $ do
                         , antithesisApiKey = AntithesisApiKey "api-key"
                         }
         result `shouldBe` Right sampleRuns
+
+    it
+        "writes a Running fact when a pending test-run matches an \
+        \in-progress Antithesis run"
+        $ withAcceptEnv
+        $ \env -> do
+            let testRun = sampleTestRun
+                trId = mkTestRunId testRun
+                apiRun =
+                    AntithesisRun
+                        { antithesisRunId = "run-accept-1"
+                        , antithesisRunStatus = RunInProgress
+                        , antithesisRunDescription =
+                            Just (T.pack (renderTestRun trId testRun))
+                        , antithesisRunTriageReport = Nothing
+                        }
+            -- A pending test-run + its token config seeded on-chain.
+            seedConfigAndPending env testRun
+            withMockAntithesisServer (pure [apiRun]) $ \baseUrl -> do
+                let apiConfig =
+                        AntithesisApiConfig
+                            { antithesisApiUrl = AntithesisApiUrl baseUrl
+                            , antithesisApiKey = AntithesisApiKey "itest-key"
+                            }
+                apiRuns <-
+                    either
+                        (\e -> fail $ "listAllRuns: " <> show e)
+                        pure
+                        =<< listAllRuns apiConfig
+                pendingFacts <- readPendingFacts env
+                runningBefore <- readRunningFacts env
+                -- The real planner pairs the pending fact to the run.
+                let plan =
+                        planAgentPoll
+                            (const True)
+                            apiRuns
+                            pendingFacts
+                            runningBefore
+                case pendingActions plan of
+                    [PendingAcceptObserved fact run] -> do
+                        factTestRun fact `shouldBe` testRun
+                        run `shouldBe` apiRun
+                    other ->
+                        expectationFailure
+                            $ "expected one PendingAcceptObserved, got: "
+                                <> show other
+                -- Drive the agent Accept, signed by the agent wallet.
+                acceptRes <- acceptViaAgent env trId
+                case acceptRes of
+                    ValidationSuccess _ -> pure ()
+                    ValidationFailure err ->
+                        expectationFailure $ "agent Accept failed: " <> show err
+                -- Oracle folds the Accept request into a Running fact.
+                acceptRefs <- tokenRequestRefIds env
+                foldRes <- foldPendingRequests env acceptRefs
+                case foldRes of
+                    ValidationSuccess _ -> pure ()
+                    ValidationFailure err ->
+                        expectationFailure $ "oracle fold failed: " <> show err
+                -- The transition is now visible on-chain.
+                runningAfter <- readRunningFacts env
+                map factTestRun runningAfter `shouldContain` [testRun]
+                pendingAfter <- readPendingFacts env
+                map factTestRun pendingAfter `shouldNotContain` [testRun]
+                -- Accept is idempotent: with no pending fact left, a
+                -- second poll neither plans nor writes a transition.
+                acceptAgain <- acceptViaAgent env trId
+                case acceptAgain of
+                    ValidationFailure _ -> pure ()
+                    ValidationSuccess _ ->
+                        expectationFailure
+                            "second Accept unexpectedly succeeded"
+                pendingFinal <- readPendingFacts env
+                pendingActions
+                    (planAgentPoll (const True) apiRuns pendingFinal [])
+                    `shouldBe` []
+                runningFinal <- readRunningFacts env
+                length (filter (== testRun) (map factTestRun runningFinal))
+                    `shouldBe` 1
 
 -- | A representative two-run list spanning a non-terminal run with no
 -- triage report and a terminal run with one, so the round-trip exercises

--- a/test-integration/Lib/Agent/AcceptHarness.hs
+++ b/test-integration/Lib/Agent/AcceptHarness.hs
@@ -1,0 +1,344 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Devnet-MPFS harness for the agent Pending→Running (Accept)
+-- integration test. It boots a fresh token against the self-hosted
+-- @mpfs-devnet-server@ (env @MOOG_MPFS_HOST@, role wallets via
+-- @MOOG_TEST_*_WALLET@), seeds the on-chain prerequisites for an agent
+-- Accept, and exposes the real agent\/oracle code paths needed to drive
+-- and observe the transition.
+--
+-- The Accept validation only requires a token 'Config' fact (whose
+-- @configAgent@ is the agent owner) and a Pending test-run fact; the
+-- Pending signature is not verified on Accept. A valid Pending fact
+-- cannot be produced hermetically through the normal create flow
+-- (`validateCreateTestRunCore` makes a live GitHub commit check and
+-- verifies a registered-key signature), so those two facts are
+-- **seeded directly**: an MPFS insert request is folded into the token
+-- via 'mpfsUpdateTokenFromFacts' signed by the oracle, bypassing moog's
+-- off-chain request validation. The agent Accept and the oracle fold of
+-- the resulting Accept request then exercise the real validated paths.
+module Lib.Agent.AcceptHarness
+    ( AcceptEnv (..)
+    , withAcceptEnv
+    , sampleTestRun
+    , seedConfigAndPending
+    , acceptViaAgent
+    , foldPendingRequests
+    , tokenRequestRefIds
+    , readPendingFacts
+    , readRunningFacts
+    , factTestRun
+    )
+where
+
+import Cli (Command (AgentCommand, GetFacts), cmd)
+import Control.Concurrent (threadDelay)
+import Control.Exception (SomeException, catch, finally)
+import Core.Context (withContext)
+import Core.Types.Basic
+    ( Commit (..)
+    , Directory (..)
+    , Duration (..)
+    , FaultsEnabled (..)
+    , GithubRepository (..)
+    , GithubUsername (..)
+    , HasInstrumentation (..)
+    , Owner
+    , Platform (..)
+    , RequestRefId
+    , TokenId
+    , Try (..)
+    )
+import Core.Types.Fact (Fact (..))
+import Core.Types.MPFS (MPFSClient (..), newClient)
+import Core.Types.Mnemonics (Mnemonics (ClearText))
+import Core.Types.Tx
+    ( TxHash
+    , WithTxHash (..)
+    )
+import Core.Types.Wallet (Wallet (..))
+import Crypto.PubKey.Ed25519 qualified as Ed25519
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Char8 qualified as BC
+import Data.ByteString.Lazy qualified as BL
+import Data.CaseInsensitive (mk)
+import Data.Functor.Identity (Identity, runIdentity)
+import Data.Text (Text)
+import Effects (mkEffects)
+import Facts
+    ( All (..)
+    , FactsSelection (..)
+    , TestRunSelection (..)
+    )
+import GitHub (Auth (..))
+import MPFS.API
+    ( MPFS (..)
+    , RequestInsertBody (..)
+    , awaitTransactionV2
+    , mpfsClient
+    )
+import Oracle.Config.Types
+    ( ConfigKey (..)
+    , mkCurrentConfig
+    )
+import Oracle.Token.Cli
+    ( TokenCommand (..)
+    , TokenUpdateFailure
+    , tokenCmdCore
+    )
+import Oracle.Types
+    ( Token (..)
+    , requestZooRefId
+    )
+import Oracle.Validate.Requests.TestRun.Config
+    ( TestRunValidationConfig (..)
+    )
+import Oracle.Validate.Requests.TestRun.Update (UpdateTestRunFailure)
+import Oracle.Validate.Types (AValidationResult (..))
+import Servant.Client (ClientM)
+import Submitting (IfToWait (..), Submission (..), readWallet)
+import System.Environment (getEnv, lookupEnv)
+import Text.JSON.Canonical
+    ( FromJSON (..)
+    , JSValue
+    , ToJSON (..)
+    , renderCanonicalJSON
+    )
+import User.Agent.Cli (AgentCommand (Accept))
+import User.Agent.Types (TestRunId)
+import User.Types
+    ( Phase (..)
+    , TestRun (..)
+    , TestRunState (..)
+    )
+
+-- | A booted token plus the wallets and credentials the Accept cycle
+-- needs.
+data AcceptEnv = AcceptEnv
+    { aeClient :: MPFSClient
+    , aeAuth :: Auth
+    , aeOracle :: Wallet
+    , aeAgent :: Wallet
+    , aeTokenId :: TokenId
+    }
+
+-- | Read the devnet host + role wallets from the environment, boot a
+-- fresh token (owned by the oracle), run the action, then end the token.
+withAcceptEnv :: (AcceptEnv -> IO a) -> IO a
+withAcceptEnv action = do
+    host <- getEnv "MOOG_MPFS_HOST"
+    client <- newClient (host, Wait 180, 120)
+    oracle <- loadWallet "MOOG_TEST_ORACLE_WALLET"
+    agent <- loadWallet "MOOG_TEST_AGENT_WALLET"
+    auth <- loadAuth
+    tokenId <- bootToken client auth oracle
+    let env = AcceptEnv client auth oracle agent tokenId
+    action env `finally` endTokenQuietly env
+
+-- | A fixed test-run used by the Accept spec. Its content is never
+-- validated by the Accept path, so concrete (offline) values suffice.
+sampleTestRun :: TestRun
+sampleTestRun =
+    TestRun
+        (Platform "linux")
+        (GithubRepository (mk "cardano-foundation") (mk "moog"))
+        (Directory ".")
+        (Commit "0000000000000000000000000000000000000000")
+        (Try 1)
+        (GithubUsername (mk "moog-itest-requester"))
+
+-- | Seed the two facts an agent Accept depends on — the token 'Config'
+-- (with @configAgent@ = the agent owner) and the Pending test-run fact —
+-- by inserting them and folding them into the token directly (oracle
+-- signed), bypassing moog request validation.
+seedConfigAndPending :: AcceptEnv -> TestRun -> IO ()
+seedConfigAndPending env testRun = do
+    let config =
+            mkCurrentConfig
+                (owner (aeAgent env))
+                (TestRunValidationConfig{maxDuration = 7200, minDuration = 0})
+        pending = mkPendingState (aeOracle env) testRun
+    insertRequest env (jsonOf ConfigKey) (jsonOf config)
+    insertRequest env (jsonOf testRun) (jsonOf pending)
+    refIds <- tokenRequestRefIds env
+    foldDirect env refIds
+
+-- | Drive the real agent Accept (Pending→Running) for the test-run,
+-- signing with the agent wallet — exactly what the agent process'
+-- @submitRunning@ does.
+acceptViaAgent
+    :: AcceptEnv
+    -> TestRunId
+    -> IO
+        ( AValidationResult
+            UpdateTestRunFailure
+            (WithTxHash (TestRunState 'RunningT))
+        )
+acceptViaAgent AcceptEnv{aeClient, aeAuth, aeAgent, aeTokenId} trId = do
+    res <-
+        cmd
+            $ AgentCommand aeAuth aeClient
+            $ Accept aeTokenId aeAgent trId ()
+    case res of
+        ValidationSuccess (WithTxHash txh _) -> waitConfirmed aeClient txh
+        _ -> pure ()
+    pure res
+
+-- | Fold the given requests into the token via the real oracle
+-- @UpdateToken@ path (which re-validates each request). Used to
+-- materialize the agent's Accept request as a Running fact.
+foldPendingRequests
+    :: AcceptEnv
+    -> [RequestRefId]
+    -> IO (AValidationResult TokenUpdateFailure TxHash)
+foldPendingRequests AcceptEnv{aeClient, aeAuth, aeOracle, aeTokenId} refIds = do
+    let MPFSClient{runMPFS, submitTx} = aeClient
+    res <-
+        runMPFS
+            $ withContext mpfsClient (mkEffects aeAuth) submitTx
+            $ tokenCmdCore
+            $ UpdateToken aeTokenId aeOracle refIds
+    case res of
+        ValidationSuccess txh -> waitConfirmed aeClient txh
+        _ -> pure ()
+    pure res
+
+-- | The outstanding request ref ids on the token.
+tokenRequestRefIds :: AcceptEnv -> IO [RequestRefId]
+tokenRequestRefIds AcceptEnv{aeClient, aeTokenId} = do
+    let MPFSClient{runMPFS} = aeClient
+    j <- runMPFS $ mpfsGetToken mpfsClient aeTokenId
+    case fromJSON j of
+        Just token ->
+            pure $ requestZooRefId . runIdentity <$> tokenRequests token
+        Nothing -> error "tokenRequestRefIds: could not parse token"
+
+-- | Pending test-run facts on the token (the agent's pending poll
+-- input).
+readPendingFacts
+    :: AcceptEnv -> IO [Fact TestRun (TestRunState 'PendingT)]
+readPendingFacts AcceptEnv{aeClient, aeTokenId} =
+    cmd $ GetFacts aeClient aeTokenId (TestRunFacts (TestRunPending [] All))
+
+-- | Running (accepted) test-run facts on the token.
+readRunningFacts
+    :: AcceptEnv -> IO [Fact TestRun (TestRunState 'RunningT)]
+readRunningFacts AcceptEnv{aeClient, aeTokenId} =
+    cmd $ GetFacts aeClient aeTokenId (TestRunFacts (TestRunRunning [] All))
+
+factTestRun :: Fact TestRun v -> TestRun
+factTestRun (Fact k _ _) = k
+
+-- Internal helpers --------------------------------------------------------
+
+jsonOf :: ToJSON Identity a => a -> JSValue
+jsonOf = runIdentity . toJSON
+
+bootToken :: MPFSClient -> Auth -> Wallet -> IO TokenId
+bootToken client@MPFSClient{runMPFS, submitTx} auth oracle = do
+    res <-
+        runMPFS
+            $ withContext mpfsClient (mkEffects auth) submitTx
+            $ tokenCmdCore
+            $ BootToken oracle
+    case res of
+        ValidationSuccess (WithTxHash txh (Just tokenId)) -> do
+            waitConfirmed client txh
+            pure tokenId
+        ValidationSuccess (WithTxHash _ Nothing) ->
+            error "bootToken: no TokenId returned"
+        ValidationFailure err ->
+            error $ "bootToken failed: " <> show err
+
+endTokenQuietly :: AcceptEnv -> IO ()
+endTokenQuietly AcceptEnv{aeClient, aeAuth, aeOracle, aeTokenId} =
+    ( do
+        let MPFSClient{runMPFS, submitTx} = aeClient
+        txh <-
+            runMPFS
+                $ withContext mpfsClient (mkEffects aeAuth) submitTx
+                $ tokenCmdCore
+                $ EndToken aeTokenId aeOracle
+        waitConfirmed aeClient txh
+    )
+        `catch` \(_ :: SomeException) -> pure ()
+
+insertRequest :: AcceptEnv -> JSValue -> JSValue -> IO ()
+insertRequest AcceptEnv{aeClient, aeOracle, aeTokenId} key value = do
+    let MPFSClient{runMPFS, submitTx} = aeClient
+        Submission submit = submitTx aeOracle
+    WithTxHash txh _ <-
+        runMPFS
+            $ submit
+            $ \address ->
+                mpfsRequestInsertFromFacts
+                    mpfsClient
+                    address
+                    aeTokenId
+                    RequestInsertBody{key, value}
+    waitConfirmed aeClient txh
+
+foldDirect :: AcceptEnv -> [RequestRefId] -> IO ()
+foldDirect AcceptEnv{aeClient, aeOracle, aeTokenId} refIds = do
+    let MPFSClient{runMPFS, submitTx} = aeClient
+        Submission submit = submitTx aeOracle
+    WithTxHash txh _ <-
+        runMPFS
+            $ submit
+            $ \address ->
+                mpfsUpdateTokenFromFacts mpfsClient address aeTokenId refIds
+    waitConfirmed aeClient txh
+
+-- | A Pending state with a real (but, for Accept, unverified) Ed25519
+-- signature over the test-run by the given wallet's key.
+mkPendingState :: Wallet -> TestRun -> TestRunState 'PendingT
+mkPendingState wallet testRun =
+    Pending
+        (Duration 3600)
+        (FaultsEnabled True)
+        (HasInstrumentation True)
+        signature
+  where
+    sk = privateKey wallet
+    pk = Ed25519.toPublic sk
+    message = BL.toStrict $ renderCanonicalJSON $ jsonOf testRun
+    signature = Ed25519.sign sk pk message
+
+waitConfirmed :: MPFSClient -> TxHash -> IO ()
+waitConfirmed MPFSClient{runMPFS} txh = go (300 :: Int)
+  where
+    go 0 = error "waitConfirmed: transaction not confirmed in time"
+    go n =
+        runMPFS (awaitTransactionV2 txh)
+            `catch` \(_ :: SomeException) -> do
+                threadDelay 1_000_000
+                go (n - 1)
+
+loadAuth :: IO Auth
+loadAuth =
+    maybe (OAuth "unused") (OAuth . BC.pack) <$> lookupEnv "MOOG_GITHUB_PAT"
+
+newtype UnencryptedWallet = UnencryptedWallet Text
+
+instance Aeson.FromJSON UnencryptedWallet where
+    parseJSON =
+        Aeson.withObject "UnencryptedWallet" $ \v ->
+            UnencryptedWallet <$> v Aeson..: "mnemonics"
+
+loadWallet :: String -> IO Wallet
+loadWallet envVar = do
+    mfile <- lookupEnv envVar
+    file <-
+        maybe (error $ envVar <> " is not set") pure mfile
+    content <- BC.readFile file
+    case Aeson.decodeStrict content of
+        Just (UnencryptedWallet mnemonics) ->
+            case readWallet (True, ClearText mnemonics) of
+                Right wallet -> pure wallet
+                Left err ->
+                    error $ "loadWallet " <> file <> ": " <> show err
+        Nothing -> error $ "loadWallet: cannot decode " <> file

--- a/test-integration/Lib/Agent/AcceptHarness.hs
+++ b/test-integration/Lib/Agent/AcceptHarness.hs
@@ -26,11 +26,14 @@ module Lib.Agent.AcceptHarness
     , withAcceptEnv
     , sampleTestRun
     , seedConfigAndPending
+    , seedConfigRunningUser
     , acceptViaAgent
+    , reportViaAgent
     , foldPendingRequests
     , tokenRequestRefIds
     , readPendingFacts
     , readRunningFacts
+    , readDoneFacts
     , factTestRun
     )
 where
@@ -60,6 +63,7 @@ import Core.Types.Tx
     ( TxHash
     , WithTxHash (..)
     )
+import Core.Types.VKey (encodeVKey)
 import Core.Types.Wallet (Wallet (..))
 import Crypto.PubKey.Ed25519 qualified as Ed25519
 import Data.Aeson qualified as Aeson
@@ -108,21 +112,27 @@ import Text.JSON.Canonical
     , ToJSON (..)
     , renderCanonicalJSON
     )
-import User.Agent.Cli (AgentCommand (Accept))
+import User.Agent.Cli (AgentCommand (Accept, Report), ReportFailure)
 import User.Agent.Types (TestRunId)
 import User.Types
-    ( Phase (..)
+    ( GithubIdentification (..)
+    , Outcome
+    , Phase (..)
+    , RegisterUserKey (..)
     , TestRun (..)
     , TestRunState (..)
+    , URL
+    , requester
     )
 
--- | A booted token plus the wallets and credentials the Accept cycle
--- needs.
+-- | A booted token plus the wallets and credentials the Accept\/Report
+-- cycles need.
 data AcceptEnv = AcceptEnv
     { aeClient :: MPFSClient
     , aeAuth :: Auth
     , aeOracle :: Wallet
     , aeAgent :: Wallet
+    , aeRequester :: Wallet
     , aeTokenId :: TokenId
     }
 
@@ -134,9 +144,10 @@ withAcceptEnv action = do
     client <- newClient (host, Wait 180, 120)
     oracle <- loadWallet "MOOG_TEST_ORACLE_WALLET"
     agent <- loadWallet "MOOG_TEST_AGENT_WALLET"
+    reqWallet <- loadWallet "MOOG_TEST_REQUESTER_WALLET"
     auth <- loadAuth
     tokenId <- bootToken client auth oracle
-    let env = AcceptEnv client auth oracle agent tokenId
+    let env = AcceptEnv client auth oracle agent reqWallet tokenId
     action env `finally` endTokenQuietly env
 
 -- | A fixed test-run used by the Accept spec. Its content is never
@@ -156,16 +167,26 @@ sampleTestRun =
 -- by inserting them and folding them into the token directly (oracle
 -- signed), bypassing moog request validation.
 seedConfigAndPending :: AcceptEnv -> TestRun -> IO ()
-seedConfigAndPending env testRun = do
-    let config =
-            mkCurrentConfig
-                (owner (aeAgent env))
-                (TestRunValidationConfig{maxDuration = 7200, minDuration = 0})
-        pending = mkPendingState (aeOracle env) testRun
-    insertRequest env (jsonOf ConfigKey) (jsonOf config)
-    insertRequest env (jsonOf testRun) (jsonOf pending)
-    refIds <- tokenRequestRefIds env
-    foldDirect env refIds
+seedConfigAndPending env testRun =
+    seedFacts
+        env
+        [ (jsonOf ConfigKey, agentConfig env)
+        , (jsonOf testRun, jsonOf (mkPendingState (aeOracle env) testRun))
+        ]
+
+-- | Seed the facts an agent Report (Running→Done) depends on: the token
+-- 'Config', a Running (accepted) test-run fact, and a RegisterUser fact
+-- binding the test-run's requester to the requester wallet's verification
+-- key (so the agent can encrypt the result URL to it). Same direct
+-- oracle-fold seeding as 'seedConfigAndPending'.
+seedConfigRunningUser :: AcceptEnv -> TestRun -> IO ()
+seedConfigRunningUser env testRun =
+    seedFacts
+        env
+        [ (jsonOf ConfigKey, agentConfig env)
+        , (jsonOf testRun, jsonOf (runningStateOf (aeOracle env) testRun))
+        , (jsonOf (requesterRegisterUserKey env testRun), jsonOf ())
+        ]
 
 -- | Drive the real agent Accept (Pending→Running) for the test-run,
 -- signing with the agent wallet — exactly what the agent process'
@@ -187,6 +208,36 @@ acceptViaAgent AcceptEnv{aeClient, aeAuth, aeAgent, aeTokenId} trId = do
         ValidationSuccess (WithTxHash txh _) -> waitConfirmed aeClient txh
         _ -> pure ()
     pure res
+
+-- | Drive the real agent Report (Running→Done) for the test-run, signing
+-- with the agent wallet — exactly what the agent process' @submitDone@
+-- does (encrypt the result URL for the requester, then submit the
+-- Running→Done update).
+reportViaAgent
+    :: AcceptEnv
+    -> TestRunId
+    -> Duration
+    -> Outcome
+    -> URL
+    -> IO
+        ( AValidationResult
+            ReportFailure
+            (WithTxHash (TestRunState 'DoneT))
+        )
+reportViaAgent
+    AcceptEnv{aeClient, aeAuth, aeAgent, aeTokenId}
+    trId
+    duration
+    outcome
+    url = do
+        res <-
+            cmd
+                $ AgentCommand aeAuth aeClient
+                $ Report aeTokenId aeAgent trId () duration outcome url
+        case res of
+            ValidationSuccess (WithTxHash txh _) -> waitConfirmed aeClient txh
+            _ -> pure ()
+        pure res
 
 -- | Fold the given requests into the token via the real oracle
 -- @UpdateToken@ path (which re-validates each request). Used to
@@ -230,6 +281,16 @@ readRunningFacts
 readRunningFacts AcceptEnv{aeClient, aeTokenId} =
     cmd $ GetFacts aeClient aeTokenId (TestRunFacts (TestRunRunning [] All))
 
+-- | Done test-run facts on the token, with result URLs decrypted using
+-- the requester wallet's key (matching the seeded RegisterUser identity).
+readDoneFacts
+    :: AcceptEnv -> IO [Fact TestRun (TestRunState 'DoneT)]
+readDoneFacts AcceptEnv{aeClient, aeRequester, aeTokenId} =
+    cmd
+        $ GetFacts aeClient aeTokenId
+        $ TestRunFacts
+        $ TestRunDone (Just aeRequester) Nothing [] All
+
 factTestRun :: Fact TestRun v -> TestRun
 factTestRun (Fact k _ _) = k
 
@@ -237,6 +298,43 @@ factTestRun (Fact k _ _) = k
 
 jsonOf :: ToJSON Identity a => a -> JSValue
 jsonOf = runIdentity . toJSON
+
+-- | Insert each (key, value) as a fact request, then fold them all into
+-- the token directly (oracle signed), bypassing moog request validation.
+seedFacts :: AcceptEnv -> [(JSValue, JSValue)] -> IO ()
+seedFacts env kvs = do
+    mapM_ (uncurry (insertRequest env)) kvs
+    refIds <- tokenRequestRefIds env
+    foldDirect env refIds
+
+-- | The token 'Config' value whose @configAgent@ is the agent owner.
+agentConfig :: AcceptEnv -> JSValue
+agentConfig env =
+    jsonOf
+        $ mkCurrentConfig
+            (owner (aeAgent env))
+            (TestRunValidationConfig{maxDuration = 7200, minDuration = 0})
+
+-- | A Running (accepted) state wrapping a seeded Pending state.
+runningStateOf :: Wallet -> TestRun -> TestRunState 'RunningT
+runningStateOf wallet = Accepted . mkPendingState wallet
+
+-- | A RegisterUser fact key binding the test-run's requester username to
+-- the requester wallet's Ed25519 verification key, so the agent encrypts
+-- the result URL to a key the requester wallet can decrypt.
+requesterRegisterUserKey :: AcceptEnv -> TestRun -> RegisterUserKey
+requesterRegisterUserKey env testRun =
+    RegisterUserKey
+        { platform = Platform "linux"
+        , username = requester testRun
+        , githubIdentification = IdentifyViaVKey vkey
+        }
+  where
+    vkey =
+        case encodeVKey (Ed25519.toPublic (privateKey (aeRequester env))) of
+            Right v -> v
+            Left err ->
+                error $ "requesterRegisterUserKey: encodeVKey: " <> show err
 
 bootToken :: MPFSClient -> Auth -> Wallet -> IO TokenId
 bootToken client@MPFSClient{runMPFS, submitTx} auth oracle = do

--- a/test-integration/Lib/Agent/MockAntithesis.hs
+++ b/test-integration/Lib/Agent/MockAntithesis.hs
@@ -1,0 +1,135 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | A mock of the Antithesis read API (the @GET \/api\/v0\/runs@ shape
+-- from "Proxy.Antithesis.Api") served as a Warp test server, so the
+-- agent's reconcile→report cycle can be exercised without a live
+-- Antithesis tenant.
+--
+-- The served run list is supplied by an @IO [AntithesisRun]@ action read
+-- on every request, so a test may mutate an 'Data.IORef.IORef' between
+-- reconcile cycles to drive Pending→Running→Done transitions (slices
+-- B\/C). Pagination follows the real upstream contract: @limit@ caps the
+-- page size and @after@ carries the previous page's last run id as an
+-- opaque cursor; @next_cursor@ is absent on the final page. A missing or
+-- non-@Bearer@ @Authorization@ header is rejected with @401@.
+module Lib.Agent.MockAntithesis
+    ( withMockAntithesisServer
+    )
+where
+
+import Control.Monad (join)
+import Data.Aeson qualified as Aeson
+import Data.ByteString qualified as BS
+import Data.Text (Text)
+import Data.Text qualified as T
+import Network.HTTP.Types
+    ( hAuthorization
+    , queryToQueryText
+    , status200
+    , status401
+    )
+import Network.Wai
+    ( Application
+    , Request (queryString, requestHeaders)
+    , responseLBS
+    )
+import Network.Wai.Handler.Warp (testWithApplication)
+import Text.Read (readMaybe)
+import User.Agent.Antithesis.State
+    ( AntithesisRun (..)
+    , AntithesisRunStatus (..)
+    )
+
+-- | Stand up the mock Antithesis read API on a fresh ephemeral port and
+-- run the action with its base URL (e.g. @http:\/\/127.0.0.1:PORT@). The
+-- run list is re-read from the provider on each request so a test can
+-- evolve it across reconcile cycles.
+withMockAntithesisServer
+    :: IO [AntithesisRun]
+    -- ^ run-list provider, consulted per request
+    -> (String -> IO a)
+    -- ^ action given the server base URL
+    -> IO a
+withMockAntithesisServer getRuns action =
+    testWithApplication (pure $ runsApp getRuns) $ \port ->
+        action $ "http://127.0.0.1:" <> show port
+
+-- | The WAI application: authenticate the @Bearer@ token, then serve one
+-- page of the current run list honouring the @limit@\/@after@ query.
+runsApp :: IO [AntithesisRun] -> Application
+runsApp getRuns request respond =
+    case lookup hAuthorization (requestHeaders request) of
+        Just auth
+            | "Bearer " `BS.isPrefixOf` auth -> do
+                runs <- getRuns
+                let queryText = queryToQueryText (queryString request)
+                    after = join (lookup "after" queryText)
+                    limit =
+                        readLimit =<< join (lookup "limit" queryText)
+                respond $
+                    responseLBS
+                        status200
+                        [("Content-Type", "application/json")]
+                        (Aeson.encode (runsPage runs limit after))
+        _ -> respond $ responseLBS status401 [] ""
+
+readLimit :: Text -> Maybe Int
+readLimit = readMaybe . T.unpack
+
+-- | One page of @runs@ after applying the @after@ cursor and @limit@.
+-- The cursor is the previous page's last run id; @next_cursor@ is set
+-- only when runs remain beyond the page just served.
+runsPage :: [AntithesisRun] -> Maybe Int -> Maybe Text -> Aeson.Value
+runsPage runs limit after =
+    let afterRuns = case after of
+            Nothing -> runs
+            Just cursor ->
+                drop 1 $
+                    dropWhile ((/= cursor) . antithesisRunId) runs
+        (page, remaining) =
+            maybe (afterRuns, []) (`splitAt` afterRuns) limit
+        nextCursor = case (remaining, reverse page) of
+            (_ : _, lastRun : _) -> Just (antithesisRunId lastRun)
+            _ -> Nothing
+     in runsPageJson (map runToJson page) nextCursor
+
+runsPageJson :: [Aeson.Value] -> Maybe Text -> Aeson.Value
+runsPageJson runs nextCursor =
+    Aeson.object
+        [ "data" Aeson..= runs
+        , "next_cursor" Aeson..= nextCursor
+        ]
+
+-- | Serialize an 'AntithesisRun' to the upstream wire shape that
+-- 'User.Agent.Antithesis.State.parseRunsPage' consumes. Absent optional
+-- fields are omitted (description) or rendered @null@ (links) so the
+-- value round-trips back to the same 'AntithesisRun'.
+runToJson :: AntithesisRun -> Aeson.Value
+runToJson run =
+    Aeson.object
+        [ "run_id" Aeson..= antithesisRunId run
+        , "status" Aeson..= statusText (antithesisRunStatus run)
+        , "parameters"
+            Aeson..= Aeson.object
+                (descriptionField (antithesisRunDescription run))
+        , "links"
+            Aeson..= maybe
+                Aeson.Null
+                reportLinks
+                (antithesisRunTriageReport run)
+        ]
+  where
+    descriptionField Nothing = []
+    descriptionField (Just description) =
+        ["antithesis.description" Aeson..= description]
+    reportLinks url = Aeson.object ["triage_report" Aeson..= url]
+
+statusText :: AntithesisRunStatus -> Text
+statusText = \case
+    RunStarting -> "starting"
+    RunInProgress -> "in_progress"
+    RunCompleted -> "completed"
+    RunCancelled -> "cancelled"
+    RunIncomplete -> "incomplete"
+    RunUnknown -> "unknown"

--- a/test-integration/Main.hs
+++ b/test-integration/Main.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NumericUnderscores #-}
 
+import Agent.ValidationSpec (agentValidationSpec)
 import Control.Concurrent (threadDelay)
 import Control.Exception (SomeException, catch)
 import Control.Monad (unless)
@@ -64,6 +65,7 @@ main = do
                     mpfsAPISpec
                     vkeySpec
                 userSpec
+                agentValidationSpec
 
 -- | The role wallets the suite loads. CI commonly points all three at
 -- the same @wallet.json@; the addresses are de-duplicated before

--- a/test/MPFS/ReadSpec.hs
+++ b/test/MPFS/ReadSpec.hs
@@ -1,5 +1,16 @@
 module MPFS.ReadSpec (spec) where
 
+import Cardano.Ledger.Address (Addr, decodeAddr)
+import Cardano.Ledger.Api (ConwayEra, eraProtVerLow)
+import Cardano.Ledger.Api.Scripts.Data
+    ( Data (..)
+    , Datum (..)
+    , dataToBinaryData
+    )
+import Cardano.Ledger.Api.Tx.Out (TxOut, datumTxOutL, mkBasicTxOut)
+import Cardano.Ledger.BaseTypes (Inject (inject))
+import Cardano.Ledger.Binary.Encoding qualified as Ledger
+import Cardano.Ledger.Coin (Coin (..))
 import Cardano.MPFS.API.Encoding (Hex (..))
 import Cardano.MPFS.API.Types
     ( FactEntry (..)
@@ -21,13 +32,21 @@ import Cardano.MPFS.API.Types.Common
     )
 import Core.Types.Change qualified as Change
 import Core.Types.Operation qualified as Operation
+import Cardano.MPFS.Cage.Types
+    ( CageDatum (RequestDatum)
+    , OnChainOperation (OpInsert)
+    , OnChainRequest (..)
+    , OnChainTokenId (..)
+    )
 import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Control.Lens ((&), (.~))
 import Core.Types.Basic (Owner (..), RequestRefId (..))
 import Core.Types.Fact (Fact (..), Slot (..), parseFacts)
 import Core.Types.Tx (Root (..))
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
 import Data.Functor.Identity (Identity (..))
+import Data.Maybe (fromMaybe)
 import Data.Text qualified as T
 import MPFS.Read
     ( factEntriesToJSValue
@@ -47,6 +66,8 @@ import Test.Hspec
     , shouldBe
     , shouldSatisfy
     )
+import PlutusTx.Builtins (toBuiltin)
+import PlutusTx.IsData.Class (toData)
 import Text.JSON.Canonical
     ( FromJSON (..)
     , JSValue (..)
@@ -178,7 +199,10 @@ sampleWitnessedRequest =
         { wrUtxo =
             WitnessedUtxo
                 { wuTxIn = sampleRequestTxIn
-                , wuTxOut = Hex ""
+                , -- The verified read now decodes the request from this
+                  -- inline-datum TxOut, not from the (unverified, lossy)
+                  -- 'RequestJSON' projection below.
+                  wuTxOut = Hex sampleRequestTxOut
                 , wuProof = Hex ""
                 }
         , wrRequest =
@@ -192,6 +216,46 @@ sampleWitnessedRequest =
                 , rjSubmittedAt = 42
                 }
         }
+
+-- | The request owner is a 28-byte payment key hash; the decoded moog
+-- owner is its lowercase hex.
+sampleRequestOwner :: BS.ByteString
+sampleRequestOwner = BS.replicate 28 0x07
+
+-- | The on-chain request datum that 'sampleRequestTxOut' carries. An
+-- insert of @sampleKey@ ↦ @sampleValue@.
+sampleOnChainRequest :: OnChainRequest
+sampleOnChainRequest =
+    OnChainRequest
+        { requestToken = OnChainTokenId (toBuiltin (BS.replicate 28 0x01))
+        , requestOwner = toBuiltin sampleRequestOwner
+        , requestKey = canonicalBytes sampleKey
+        , requestValue = OpInsert (canonicalBytes sampleValue)
+        , requestFee = 1000000
+        , requestSubmittedAt = 42
+        }
+
+-- | A real serialized Conway 'TxOut' whose inline datum is the request
+-- datum — the reverse of @MPFS.Read.decodeRequestDatum@, so the verified
+-- read recovers the typed request (with its real key\/value).
+sampleRequestTxOut :: BS.ByteString
+sampleRequestTxOut =
+    BL.toStrict
+        $ Ledger.serialize (eraProtVerLow @ConwayEra)
+        $ (mkBasicTxOut sampleAddr (inject (Coin 0)) :: TxOut ConwayEra)
+            & datumTxOutL
+                .~ Datum
+                    ( dataToBinaryData
+                        (Data (toData (RequestDatum sampleOnChainRequest)))
+                    )
+
+-- | A minimal valid testnet enterprise (payment-key) address, parsed from
+-- its raw header + 28-byte key hash, so we needn't hand-build ledger
+-- credential\/hash types.
+sampleAddr :: Addr
+sampleAddr =
+    fromMaybe (error "sampleAddr: decodeAddr failed")
+        $ decodeAddr (BS.cons 0x60 (BS.replicate 28 0x07))
 
 sampleToken :: Token Identity
 sampleToken =
@@ -207,7 +271,7 @@ sampleToken =
                 $ UnknownInsertRequest
                 $ Request
                     { outputRefId = txInRef sampleRequestTxIn
-                    , owner = Owner "request-owner"
+                    , owner = Owner (hexString sampleRequestOwner)
                     , change =
                         Change.Change
                             (Change.Key sampleKey)


### PR DESCRIPTION
Closes #179. Part of epic #181.

Validation coverage for the agent reconcile→report cycle against the new facts-only MPFS with a mock Antithesis (the agent is already on the v2 facts API; this proves it end-to-end via the self-hosting harness from #177).

## Slices
- A — mock-Antithesis Warp helper + agent integration spec module
- B — Pending→Running (Accept) integration test
- C — Running→Done (Report) integration test

WIP — driver in progress.