### PR TITLE
feat(agent): derive finished outcome from run properties, not status (#190)

### DIFF
--- a/specs/190-property-outcome/plan.md
+++ b/specs/190-property-outcome/plan.md
@@ -1,0 +1,46 @@
+# Plan — #190 property-derived outcome
+
+Base: built on the #175 fix (df8d8ab1). The S4 commit (c1012bf5) added the
+mechanism: `RunProperty`/`PropertiesPage` parsing, `listAllProperties`
+(paginated), the `/properties` `after` query param, and `resolveFinishOutcome`
+in Process.hs (a `completed`+`success` finish fetches properties and downgrades
+to `failure` when `runFailedAssertions`). This plan refines the **predicate**.
+
+## Refinement — catch everything except a platform exclusion list
+
+Operator policy (2026-06-11): a run is `success` only if green on **both** the
+platform and the SUT/moog checks; do NOT mask. So **any** failing property
+(event OR assert) counts as failure, EXCEPT a maintained list of
+platform/Antithesis properties we cannot control (escalated upstream).
+
+Two defects in the shipped `runFailedAssertions = any (failing && not event)`:
+1. it counts `Unique Edges` (a universal Antithesis-platform assert) ⇒ marks
+   ~every run failure;
+2. it ignores `is_event=true` ⇒ MISSES real SUT failures that are event-typed
+   (`asteria-game/*.sh`, `container: …, exit code: 1`, `cluster fork …`).
+
+### State.hs
+- `platformExcludedProperties :: [Text]` (exported, haddocked as the
+  upstream-escalation list; refine as Antithesis fixes them):
+  `"Unique Edges"`, `"Sometimes: Root moments"`, `"node - throttle"`,
+  `"No Antithesis errors"`, `"systemd-journal"`,
+  `"Never: There are events with very high output that will fail to materialize & artifact from."`
+- Rewrite `runFailedAssertions :: [RunProperty] -> Bool` to:
+  `any (\p -> propFailing p && propName p `notElem` platformExcludedProperties)`
+  — i.e. catch every failing property (event or assert) whose name is not
+  excluded. (Drop the `is_event` restriction.)
+- Keep `RunProperty`/`PropertiesPage`/parsing as-is.
+
+### StateSpec
+- A failing **event** that is a SUT check (e.g. `asteria-game/eventually_alive.sh`)
+  ⇒ `runFailedAssertions == True` (regression: events now count).
+- A failing **excluded** property (`Unique Edges`, `Sometimes: Root moments`)
+  ⇒ does NOT by itself make `True`.
+- All-passing or only-excluded-failing ⇒ `False`.
+- A failing non-excluded assert (`Unexpected terminations: state_timed_out`)
+  ⇒ `True` (unchanged).
+
+### Gate / commit
+`nix run .#unit-tests` + `nix build .#moog-agent`. One commit
+`fix(agent): catch all non-platform failing properties; exclude platform list (#190)`
++ `Tasks: T190-S2`.

--- a/src/Proxy/Antithesis/Api.hs
+++ b/src/Proxy/Antithesis/Api.hs
@@ -121,6 +121,10 @@ type AntithesisProxyJsonAPI =
             :> "runs"
             :> Capture "run_id" Text
             :> "properties"
+            -- Properties paginate the same way as @/runs@: follow @after=@
+            -- (the upstream @next_cursor@) or later pages of assertions are
+            -- silently missed.
+            :> QueryParam "after" Text
             :> Get '[PlainJSON] Value
 
 -- | Streaming sub-API. All three handlers return a 'SourceIO ByteString'
@@ -166,7 +170,7 @@ data JsonClient = JsonClient
     { getOpenApi :: ClientM Value
     , listRuns :: Maybe Int -> Maybe Text -> ClientM Value
     , getRun :: Text -> ClientM Value
-    , getProperties :: Text -> ClientM Value
+    , getProperties :: Text -> Maybe Text -> ClientM Value
     }
 
 antithesisProxyJsonClient :: JsonClient

--- a/src/User/Agent/Antithesis/Client.hs
+++ b/src/User/Agent/Antithesis/Client.hs
@@ -11,6 +11,7 @@ module User.Agent.Antithesis.Client
     , deriveAntithesisApiUrl
     , listRunsPage
     , listAllRuns
+    , listAllProperties
     )
 where
 
@@ -41,7 +42,10 @@ import Servant.Client
     )
 import User.Agent.Antithesis.State
     ( AntithesisRun
+    , PropertiesPage (..)
+    , RunProperty
     , RunsPage (..)
+    , parsePropertiesPage
     , parseRunsPage
     )
 import User.Agent.PushTest (LaunchUrl (..))
@@ -84,7 +88,7 @@ listRunsPage
     -> IO (Either AntithesisApiError RunsPage)
 listRunsPage config limit cursor =
     withApiEnv config $ \env ->
-        runJsonRequest env $
+        runJsonRequest parseRunsPage env $
             listRuns antithesisProxyJsonClient limit cursor
 
 listAllRuns :: AntithesisApiConfig -> IO (Either AntithesisApiError [AntithesisRun])
@@ -94,7 +98,7 @@ listAllRuns config =
   where
     go env cursor acc = do
         result <-
-            runJsonRequest env $
+            runJsonRequest parseRunsPage env $
                 listRuns antithesisProxyJsonClient (Just 100) cursor
         case result of
             Left err -> pure $ Left err
@@ -106,6 +110,31 @@ listAllRuns config =
                         -- non-terminating upstream cursor (e.g. an ignored
                         -- pagination param) must never accumulate pages until
                         -- the agent OOMs; bail instead of looping forever.
+                        Just nextCursor
+                            | Just nextCursor == cursor -> pure $ Right acc'
+                            | otherwise -> go env (Just nextCursor) acc'
+
+-- | Fetch all properties of a run, following @after@/@next_cursor@ to the
+-- end (50–100 per page upstream) so later pages of assertions are not
+-- missed. Same stop-if-cursor-unchanged guard as 'listAllRuns'.
+listAllProperties
+    :: AntithesisApiConfig
+    -> Text
+    -> IO (Either AntithesisApiError [RunProperty])
+listAllProperties config runId =
+    withApiEnv config $ \env ->
+        go env Nothing []
+  where
+    go env cursor acc = do
+        result <-
+            runJsonRequest parsePropertiesPage env $
+                getProperties antithesisProxyJsonClient runId cursor
+        case result of
+            Left err -> pure $ Left err
+            Right PropertiesPage{propsPageData, propsPageNextCursor} ->
+                let acc' = acc <> propsPageData
+                 in case propsPageNextCursor of
+                        Nothing -> pure $ Right acc'
                         Just nextCursor
                             | Just nextCursor == cursor -> pure $ Right acc'
                             | otherwise -> go env (Just nextCursor) acc'
@@ -149,10 +178,11 @@ withBearer key env =
      in env{makeClientRequest = injecting}
 
 runJsonRequest
-    :: ClientEnv
+    :: (Aeson.Value -> Either String a)
+    -> ClientEnv
     -> ClientM Aeson.Value
-    -> IO (Either AntithesisApiError RunsPage)
-runJsonRequest env action = do
+    -> IO (Either AntithesisApiError a)
+runJsonRequest parse env action = do
     result <- try @SomeException $ runClientM action env
     pure $ case result of
         Left err ->
@@ -160,7 +190,7 @@ runJsonRequest env action = do
         Right (Left err) ->
             Left $ fromClientError err
         Right (Right value) ->
-            case parseRunsPage value of
+            case parse value of
                 Left err -> Left $ AntithesisApiInvalidJson $ T.pack err
                 Right page -> Right page
 

--- a/src/User/Agent/Antithesis/State.hs
+++ b/src/User/Agent/Antithesis/State.hs
@@ -12,6 +12,7 @@ module User.Agent.Antithesis.State
     , parseRunsPage
     , parsePropertiesPage
     , runFailedAssertions
+    , platformExcludedProperties
     , descriptionKey
     , matchingRuns
     , canonicalRun
@@ -152,14 +153,32 @@ parseRunsPage = parseEither parseJSON
 parsePropertiesPage :: Value -> Either String PropertiesPage
 parsePropertiesPage = parseEither parseJSON
 
--- | Did the run fail according to its properties? Initial heuristic (#190,
--- still open): any @Failing@ property that is a real assertion
--- (@is_event = false@) means the run failed; failing event/coverage
--- properties (@Sometimes:@ goals and the like) do not flip it. The exact
--- platform-vs-SUT predicate is an open #190 question.
+-- | Did the run fail according to its properties? A run is @success@ only if
+-- it is green on BOTH the Antithesis platform and the SUT/moog checks, so any
+-- @Failing@ property — assertion OR event — counts as a failure, EXCEPT the
+-- platform properties listed in 'platformExcludedProperties' (which fail
+-- independent of the SUT and are escalated upstream). Event-typed SUT checks
+-- (@asteria-game/*.sh@, @container … exit code: 1@, @cluster fork …@) now
+-- count; failing @Unique Edges@ and friends no longer flip a run.
 runFailedAssertions :: [RunProperty] -> Bool
 runFailedAssertions =
-    any $ \p -> propFailing p && not (propIsEvent p)
+    any $ \p ->
+        propFailing p
+            && propName p `notElem` platformExcludedProperties
+
+-- | Upstream-escalation list of Antithesis-platform/coverage properties that
+-- fail independent of the SUT. A @Failing@ property whose name is on this list
+-- does not by itself flip a run to failure; refine the list as Antithesis
+-- fixes the underlying platform/coverage issues upstream.
+platformExcludedProperties :: [Text]
+platformExcludedProperties =
+    [ "Unique Edges"
+    , "Sometimes: Root moments"
+    , "node - throttle"
+    , "No Antithesis errors"
+    , "systemd-journal"
+    , "Never: There are events with very high output that will fail to materialize & artifact from."
+    ]
 
 -- | Deterministic reconciliation key for a test-run: the description
 -- Antithesis stores under @antithesis.description@. One stable key per

--- a/src/User/Agent/Antithesis/State.hs
+++ b/src/User/Agent/Antithesis/State.hs
@@ -5,9 +5,13 @@ module User.Agent.Antithesis.State
     ( AntithesisRunStatus (..)
     , AntithesisRun (..)
     , RunsPage (..)
+    , RunProperty (..)
+    , PropertiesPage (..)
     , PendingDecision (..)
     , RunningDecision (..)
     , parseRunsPage
+    , parsePropertiesPage
+    , runFailedAssertions
     , descriptionKey
     , matchingRuns
     , canonicalRun
@@ -84,6 +88,46 @@ instance FromJSON RunsPage where
             <$> obj .: "data"
             <*> obj .:? "next_cursor"
 
+-- | One Antithesis property of a run: a named assertion or event/coverage
+-- property and whether it is currently @Failing@. @propIsEvent@ distinguishes
+-- an event/coverage property (e.g. a @Sometimes:@ reachability goal) from a
+-- real assertion.
+data RunProperty = RunProperty
+    { propName :: Text
+    , propFailing :: Bool
+    , propIsEvent :: Bool
+    }
+    deriving (Eq, Show)
+
+instance FromJSON RunProperty where
+    parseJSON = withObject "RunProperty" $ \obj -> do
+        propName <- obj .: "name"
+        propFailing <- obj .: "status" >>= parsePropertyStatus
+        propIsEvent <- obj .: "is_event"
+        pure RunProperty{..}
+
+-- | A page of a run's properties. @status@ is the string @"Passing"@ /
+-- @"Failing"@ (not a bool); the listing paginates via @next_cursor@.
+data PropertiesPage = PropertiesPage
+    { propsPageData :: [RunProperty]
+    , propsPageNextCursor :: Maybe Text
+    }
+    deriving (Eq, Show)
+
+instance FromJSON PropertiesPage where
+    parseJSON = withObject "PropertiesPage" $ \obj ->
+        PropertiesPage
+            <$> obj .: "data"
+            <*> obj .:? "next_cursor"
+
+-- | Decode the @status@ string of a property to @propFailing@.
+parsePropertyStatus :: Text -> Parser Bool
+parsePropertyStatus = \case
+    "Failing" -> pure True
+    "Passing" -> pure False
+    other ->
+        fail $ "unknown Antithesis property status: " <> T.unpack other
+
 data PendingDecision
     = PendingLaunch
     | PendingAccept AntithesisRun
@@ -104,6 +148,18 @@ data RunningDecision
 
 parseRunsPage :: Value -> Either String RunsPage
 parseRunsPage = parseEither parseJSON
+
+parsePropertiesPage :: Value -> Either String PropertiesPage
+parsePropertiesPage = parseEither parseJSON
+
+-- | Did the run fail according to its properties? Initial heuristic (#190,
+-- still open): any @Failing@ property that is a real assertion
+-- (@is_event = false@) means the run failed; failing event/coverage
+-- properties (@Sometimes:@ goals and the like) do not flip it. The exact
+-- platform-vs-SUT predicate is an open #190 question.
+runFailedAssertions :: [RunProperty] -> Bool
+runFailedAssertions =
+    any $ \p -> propFailing p && not (propIsEvent p)
 
 -- | Deterministic reconciliation key for a test-run: the description
 -- Antithesis stores under @antithesis.description@. One stable key per

--- a/src/User/Agent/Process.hs
+++ b/src/User/Agent/Process.hs
@@ -81,6 +81,7 @@ import User.Agent.Antithesis.Client
     , AntithesisApiKey
     , AntithesisApiUrl
     , deriveAntithesisApiUrl
+    , listAllProperties
     , listAllRuns
     )
 import User.Agent.Antithesis.Plan
@@ -91,7 +92,10 @@ import User.Agent.Antithesis.Plan
     )
 import User.Agent.Antithesis.State
     ( AntithesisRun (..)
+    , AntithesisRunStatus (..)
+    , RunProperty (..)
     , descriptionKey
+    , runFailedAssertions
     )
 import User.Agent.Lib (testRunDuration)
 import User.Agent.Options
@@ -120,7 +124,13 @@ import User.Agent.Types
     ( TestRunId (..)
     , mkTestRunId
     )
-import User.Types (Outcome, Phase (..), TestRun (..), TestRunState, URL (..))
+import User.Types
+    ( Outcome (..)
+    , Phase (..)
+    , TestRun (..)
+    , TestRunState
+    , URL (..)
+    )
 
 intro :: String
 intro =
@@ -490,7 +500,8 @@ executeRunningAction opts = \case
                 ++ " with result URL "
                 ++ urlStr
                 ++ "."
-        eres <- submitDone opts testId (testRunDuration testState) outcome url
+        outcome' <- resolveFinishOutcome opts run outcome
+        eres <- submitDone opts testId (testRunDuration testState) outcome' url
         case eres of
             ValidationFailure err ->
                 loggin
@@ -522,7 +533,8 @@ executeRunningAction opts = \case
                 ++ " with result URL "
                 ++ urlStr
                 ++ "."
-        eres <- submitDone opts testId (testRunDuration testState) outcome url
+        outcome' <- resolveFinishOutcome opts canonical outcome
+        eres <- submitDone opts testId (testRunDuration testState) outcome' url
         case eres of
             ValidationFailure err ->
                 loggin
@@ -546,6 +558,47 @@ executeRunningAction opts = \case
                 ++ "; canonical run "
                 ++ T.unpack (antithesisRunId canonical)
                 ++ " not yet terminal, waiting."
+
+-- | When finishing a `completed` run as success, re-derive the outcome from
+-- the run's Antithesis properties (#190): a run that ran to completion but
+-- carries a failing assertion is recorded as failure, not success. Reads every
+-- property page. On a properties-fetch error the status-based outcome is kept
+-- so the on-chain transition is never blocked.
+resolveFinishOutcome
+    :: ProcessOptions
+    -> AntithesisRun
+    -> Outcome
+    -> IO Outcome
+resolveFinishOutcome opts run outcome
+    | antithesisRunStatus run == RunCompleted && outcome == OutcomeSuccess = do
+        let runId = antithesisRunId run
+        eprops <- listAllProperties (poAntithesisApiConfig opts) runId
+        case eprops of
+            Left err -> do
+                loggin
+                    $ "Could not read Antithesis properties for run "
+                        ++ T.unpack runId
+                        ++ " ("
+                        ++ show err
+                        ++ "); keeping the status-based outcome."
+                pure outcome
+            Right props
+                | runFailedAssertions props -> do
+                    loggin
+                        $ "Antithesis run "
+                            ++ T.unpack runId
+                            ++ " completed but "
+                            ++ show (failingAssertionCount props)
+                            ++ " assertion(s) failing; recording failure."
+                    pure OutcomeFailure
+                | otherwise -> pure outcome
+    | otherwise = pure outcome
+
+-- | Count failing real assertions (event/coverage properties excluded), for
+-- the downgrade log line. Mirrors the 'runFailedAssertions' predicate.
+failingAssertionCount :: [RunProperty] -> Int
+failingAssertionCount =
+    length . filter (\p -> propFailing p && not (propIsEvent p))
 
 launchPendingTest
     :: ProcessOptions

--- a/src/User/Antithesis/Cli.hs
+++ b/src/User/Antithesis/Cli.hs
@@ -79,7 +79,7 @@ antithesisCmd = \case
     Run rid ->
         runJson $ getRun jc rid
     Properties rid ->
-        runJson $ getProperties jc rid
+        runJson $ getProperties jc rid Nothing
     Events rid q ->
         runStream $ getEvents sc rid q
     Logs rid hh vt ->

--- a/test/User/Agent/Antithesis/StateSpec.hs
+++ b/test/User/Agent/Antithesis/StateSpec.hs
@@ -312,16 +312,35 @@ spec =
                             )
                 other -> expectationFailure $ "expected one run, got " <> show other
 
-        it "treats a failing assertion as a run failure" $ do
+        it "treats a failing non-excluded assertion as a run failure" $ do
             let props =
                     [ RunProperty "always: ledger valid" False False
-                    , RunProperty "eventually_converged" True False
+                    , RunProperty
+                        "Unexpected terminations: state_timed_out"
+                        True
+                        False
                     ]
             runFailedAssertions props `shouldBe` True
 
-        it "ignores failing event/coverage properties" $ do
+        it "treats a failing event SUT check as a run failure" $ do
+            -- Events now count: a failing event-typed SUT check (an
+            -- `asteria-game/*.sh` command, exit code 1, …) is a real
+            -- failure, not platform coverage noise.
             let props =
-                    [ RunProperty "Sometimes: fork reached" True True
+                    [ RunProperty
+                        "asteria-game/eventually_alive.sh"
+                        True
+                        True
+                    , RunProperty "always: ledger valid" False False
+                    ]
+            runFailedAssertions props `shouldBe` True
+
+        it "ignores failing platform-excluded properties" $ do
+            -- A failing platform property (assert or event) on the
+            -- upstream-escalation list does not by itself flip the run.
+            let props =
+                    [ RunProperty "Unique Edges" True False
+                    , RunProperty "Sometimes: Root moments" True True
                     , RunProperty "always: ledger valid" False False
                     ]
             runFailedAssertions props `shouldBe` False

--- a/test/User/Agent/Antithesis/StateSpec.hs
+++ b/test/User/Agent/Antithesis/StateSpec.hs
@@ -13,12 +13,16 @@ import User.Agent.Antithesis.State
     ( AntithesisRun (..)
     , AntithesisRunStatus (..)
     , PendingDecision (..)
+    , PropertiesPage (..)
     , RunningDecision (..)
+    , RunProperty (..)
     , RunsPage (..)
     , canonicalRun
     , matchingRuns
+    , parsePropertiesPage
     , parseRunsPage
     , pendingDecision
+    , runFailedAssertions
     , runningDecision
     )
 import User.Agent.PushTest (renderTestRun)
@@ -308,6 +312,52 @@ spec =
                             )
                 other -> expectationFailure $ "expected one run, got " <> show other
 
+        it "treats a failing assertion as a run failure" $ do
+            let props =
+                    [ RunProperty "always: ledger valid" False False
+                    , RunProperty "eventually_converged" True False
+                    ]
+            runFailedAssertions props `shouldBe` True
+
+        it "ignores failing event/coverage properties" $ do
+            let props =
+                    [ RunProperty "Sometimes: fork reached" True True
+                    , RunProperty "always: ledger valid" False False
+                    ]
+            runFailedAssertions props `shouldBe` False
+
+        it "passes when every assertion passes" $ do
+            let props =
+                    [ RunProperty "always: ledger valid" False False
+                    , RunProperty "Sometimes: fork reached" False True
+                    ]
+            runFailedAssertions props `shouldBe` False
+
+        it "parses a properties page with a pagination cursor" $ do
+            parsePropertiesPage
+                ( propertiesPageJson
+                    [ propertyJson "always: ledger valid" "Passing" False
+                    , propertyJson "eventually_converged" "Failing" False
+                    ]
+                    (Just "cursor-2")
+                )
+                `shouldBe` Right
+                    PropertiesPage
+                        { propsPageData =
+                            [ RunProperty
+                                { propName = "always: ledger valid"
+                                , propFailing = False
+                                , propIsEvent = False
+                                }
+                            , RunProperty
+                                { propName = "eventually_converged"
+                                , propFailing = True
+                                , propIsEvent = False
+                                }
+                            ]
+                        , propsPageNextCursor = Just "cursor-2"
+                        }
+
 -- | Reconstructed on-chain test-run for the live Leios fixture (#138). Its
 -- fields must hash (via mkTestRunId) to testRunId 42030238… so matchingRuns
 -- pairs it with the captured Antithesis run.
@@ -381,4 +431,19 @@ runJson runId status description report =
                         ]
                 )
                 report
+        ]
+
+propertiesPageJson :: [Aeson.Value] -> Maybe Text -> Aeson.Value
+propertiesPageJson props nextCursor =
+    Aeson.object
+        [ "data" Aeson..= props
+        , "next_cursor" Aeson..= nextCursor
+        ]
+
+propertyJson :: Text -> Text -> Bool -> Aeson.Value
+propertyJson name status isEvent =
+    Aeson.object
+        [ "name" Aeson..= name
+        , "status" Aeson..= status
+        , "is_event" Aeson..= isEvent
         ]


### PR DESCRIPTION
Closes #190.

The agent decided `outcome` from Antithesis run **status** (`completed → success`)
and never looked at properties — so a run that completed with failing assertions
was recorded `success`. Live evidence: completed runs with 3–13 failing
assertions (e.g. `state_timed_out`, `eventually_converged failed`).

This PR (built on the #175 fix in #176):
- Adds paginated property reading (`/properties` `after` param,
  `RunProperty`/`PropertiesPage`, `listAllProperties`).
- In the finish path, a `completed`+`success` run has its properties fetched and
  is **downgraded to `failure`** when any non-platform property is `Failing`
  (event or assert). A fetch error keeps the status outcome (never blocks).
- Policy (operator): green required on BOTH platform and SUT — catch everything
  except a maintained `platformExcludedProperties` list (Antithesis-platform /
  coverage properties that fail independent of the SUT; escalated upstream).

Note: depends on #175 (#176); the diff currently includes those commits until
#176 merges. Gate: `nix run .#unit-tests` 249/249 + `nix build .#moog-agent`.
