### PR TITLE
fix(dev): allow-newer cabal-fmt:base so the dev shell solves on ghc9123 (#191)

### DIFF
--- a/nix/moog-project.nix
+++ b/nix/moog-project.nix
@@ -24,7 +24,10 @@ let
   shell = { pkgs, ... }: {
     tools = {
       cabal = { index-state = indexState; };
-      cabal-fmt = { index-state = indexState; };
+      cabal-fmt = {
+        index-state = indexState;
+        cabalProjectLocal = "allow-newer: cabal-fmt:base";
+      };
       haskell-language-server = { index-state = indexState; };
       hoogle = { index-state = indexState; };
       fourmolu = { index-state = indexState; };


### PR DESCRIPTION
Closes #191. `nix develop` was unsolvable (cabal-fmt base<4.20 vs ghc9123). Tool-scoped `allow-newer: cabal-fmt:base` fixes it. Verified locally: shell enters, cabal-fmt 0.1.12 + fourmolu 0.19 run. No agent/runtime impact.