### PR TITLE
Repin moog to offchain 0.2.0 + migrate breaking API (#342/#343) + hermetic integration CI (#195)

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -4,9 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       offchain_ref:
-        description: "cardano-mpfs-offchain ref to pair with MOOG"
+        description: >-
+          Optional cardano-mpfs-offchain ref override. Leave empty to
+          build the devnet-server from the rev pinned in moog's
+          cabal.project (so client and server stay the same version).
         required: false
-        default: "main"
+        default: ""
   pull_request:
     branches:
       - main
@@ -37,11 +40,32 @@ jobs:
           fetch-depth: 0
           path: moog
 
+      - name: Resolve offchain rev pinned in cabal.project
+        id: offchain
+        working-directory: moog
+        run: |
+          # Build the paired devnet-server from the EXACT offchain rev moog
+          # pins in cabal.project, so client (moog) and server stay the same
+          # version. A workflow_dispatch override wins when supplied.
+          override="${{ github.event.inputs.offchain_ref }}"
+          if [ -n "$override" ]; then
+            rev="$override"
+            echo "Using dispatch override offchain_ref=$rev"
+          else
+            rev=$(awk '/cardano-mpfs-offchain\.git/{f=1} f&&/^[[:space:]]*tag:/{print $2; exit}' cabal.project)
+            echo "Using cabal.project-pinned offchain rev=$rev"
+          fi
+          if [ -z "$rev" ]; then
+            echo "ERROR: could not resolve offchain rev from cabal.project" >&2
+            exit 1
+          fi
+          echo "ref=$rev" >> "$GITHUB_OUTPUT"
+
       - name: Checkout paired MPFS offchain
         uses: actions/checkout@v6
         with:
           repository: lambdasistemi/cardano-mpfs-offchain
-          ref: ${{ github.event.inputs.offchain_ref || 'main' }}
+          ref: ${{ steps.offchain.outputs.ref }}
           token: ${{ secrets.MOOG_GITHUB_PAT || github.token }}
           path: cardano-mpfs-offchain
 

--- a/cabal.project
+++ b/cabal.project
@@ -11,8 +11,8 @@ packages:
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-mpfs-offchain.git
-  tag: 99cf2a29b4e6ed8a0965bfba2f1b16f6fcb87506
-  --sha256: 0bjzpymvj7n0nbkhh0r4xnda9c5vhjlpgn0xr1pvprdqc44ja8a2
+  tag: 5f200647c00308bb67641b94a16284c68494bff9
+  --sha256: 1fb5cw3nmba4693yrkhkmkakkfkbnh6r3k2hn69kxig8qswia6s1
   subdir:
     cardano-mpfs-api
     cardano-mpfs-cage-tx

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -9,7 +9,7 @@ Computed from the Nix flake closure + `cabal.project` `source-repository-package
 | [**moog**](https://github.com/cardano-foundation/moog/tree/main) | cardano-foundation | Antithesis CLI |
 | [**cardano-ledger-read**](https://github.com/cardano-foundation/cardano-ledger-read/tree/34d0767bd5c3) | cardano-foundation | Read Cardano block data, parametrized by era |
 | [**cardano-mpfs-onchain**](https://github.com/cardano-foundation/cardano-mpfs-onchain/tree/457c1cbcbbf6) | cardano-foundation | Aiken on-chain validators for Merkle Patricia Forestry on Cardano |
-| [**cardano-mpfs-offchain**](https://github.com/lambdasistemi/cardano-mpfs-offchain/tree/99cf2a29b4e6) | lambdasistemi | Fact CRUD, transaction building, devnet server for Merkle Patricia Forestry on Cardano |
+| [**cardano-mpfs-offchain**](https://github.com/lambdasistemi/cardano-mpfs-offchain/tree/5f200647c003) | lambdasistemi | Fact CRUD, transaction building, devnet server for Merkle Patricia Forestry on Cardano |
 | [**cardano-node-clients**](https://github.com/lambdasistemi/cardano-node-clients/tree/e4b01cb9efdf) | lambdasistemi | Haskell clients for Cardano node mini-protocols (N2C + N2N) |
 | [**cardano-tx-tools**](https://github.com/lambdasistemi/cardano-tx-tools/tree/631f1341fde6) | lambdasistemi | Cardano transaction tooling: builder, structural diff, blueprint decoding. Uses cardano-node-clients but is not a node client. |
 | [**cardano-utxo-csmt**](https://github.com/lambdasistemi/cardano-utxo-csmt/tree/f4772f73dde0) | lambdasistemi | HTTP service maintaining a Compact Sparse Merkle Tree over Cardano's UTxO set for efficient inclusion proofs |
@@ -28,6 +28,7 @@ Computed from the Nix flake closure + `cabal.project` `source-repository-package
 
 | Input | Target | Type | Source |
 |-------|--------|------|--------|
+| `cardano-mpfs-offchain` | lambdasistemi/cardano-mpfs-offchain `5f200647c003` | flake | [flake.nix](https://github.com/cardano-foundation/moog/blob/main/flake.nix) |
 | `dev-assets` | paolino/dev-assets `b901b08ce8d2` | flake | [flake.nix](https://github.com/cardano-foundation/moog/blob/main/flake.nix) |
 | `mkdocs` | paolino/dev-assets `45d545c4b8b5` | flake | [flake.nix](https://github.com/cardano-foundation/moog/blob/main/flake.nix) |
 | `asciinema` | paolino/dev-assets `45d545c4b8b5` | flake | [flake.nix](https://github.com/cardano-foundation/moog/blob/main/flake.nix) |
@@ -40,7 +41,7 @@ Computed from the Nix flake closure + `cabal.project` `source-repository-package
 |------------|-----------|--------|
 | cardano-foundation/cardano-ledger-read | `34d0767bd5c3` | [cabal.project:72](https://github.com/cardano-foundation/moog/blob/main/cabal.project#L72) |
 | cardano-foundation/cardano-mpfs-onchain | `457c1cbcbbf6` | [cabal.project:127](https://github.com/cardano-foundation/moog/blob/main/cabal.project#L127) |
-| lambdasistemi/cardano-mpfs-offchain | `99cf2a29b4e6` | [cabal.project:13](https://github.com/cardano-foundation/moog/blob/main/cabal.project#L13) |
+| lambdasistemi/cardano-mpfs-offchain | `5f200647c003` | [cabal.project:13](https://github.com/cardano-foundation/moog/blob/main/cabal.project#L13) |
 | lambdasistemi/cardano-node-clients | `e4b01cb9efdf` | [cabal.project:115](https://github.com/cardano-foundation/moog/blob/main/cabal.project#L115) |
 | lambdasistemi/cardano-tx-tools | `631f1341fde6` | [cabal.project:85](https://github.com/cardano-foundation/moog/blob/main/cabal.project#L85) |
 | lambdasistemi/cardano-utxo-csmt | `f4772f73dde0` | [cabal.project:91](https://github.com/cardano-foundation/moog/blob/main/cabal.project#L91) |
@@ -52,22 +53,22 @@ Computed from the Nix flake closure + `cabal.project` `source-repository-package
 | lambdasistemi/rocksdb-kv-transactions | `e2e77579888e` | [cabal.project:41](https://github.com/cardano-foundation/moog/blob/main/cabal.project#L41) |
 | paolino/aiken-codegen | `74f364c10e93` | [cabal.project:66](https://github.com/cardano-foundation/moog/blob/main/cabal.project#L66) |
 
-### lambdasistemi/cardano-mpfs-offchain @ `99cf2a29b4e6`
+### lambdasistemi/cardano-mpfs-offchain @ `5f200647c003`
 
 | Dependency | Locked tag | Source |
 |------------|-----------|--------|
-| cardano-foundation/cardano-ledger-read | `34d0767bd5c3` | [cabal.project:65](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/99cf2a29b4e6/cabal.project#L65) |
-| cardano-foundation/cardano-mpfs-onchain | `457c1cbcbbf6` | [cabal.project:95](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/99cf2a29b4e6/cabal.project#L95) |
-| lambdasistemi/cardano-node-clients | `e4b01cb9efdf` | [cabal.project:77](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/99cf2a29b4e6/cabal.project#L77) |
-| lambdasistemi/cardano-tx-tools | `631f1341fde6` | [cabal.project:83](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/99cf2a29b4e6/cabal.project#L83) |
-| lambdasistemi/cardano-utxo-csmt | `f4772f73dde0` | [cabal.project:41](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/99cf2a29b4e6/cabal.project#L41) |
-| lambdasistemi/chain-follower | `d592a5015f8d` | [cabal.project:47](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/99cf2a29b4e6/cabal.project#L47) |
-| lambdasistemi/contra-tracer-contrib | `f0518e871391` | [cabal.project:71](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/99cf2a29b4e6/cabal.project#L71) |
-| lambdasistemi/github-release-check | `d90131112a4d` | [cabal.project:89](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/99cf2a29b4e6/cabal.project#L89) |
-| lambdasistemi/haskell-mts | `ab15f7b2dea7` | [cabal.project:53](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/99cf2a29b4e6/cabal.project#L53) |
-| lambdasistemi/rocksdb-haskell | `a3e86b39f951` | [cabal.project:29](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/99cf2a29b4e6/cabal.project#L29) |
-| lambdasistemi/rocksdb-kv-transactions | `e2e77579888e` | [cabal.project:35](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/99cf2a29b4e6/cabal.project#L35) |
-| paolino/aiken-codegen | `74f364c10e93` | [cabal.project:59](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/99cf2a29b4e6/cabal.project#L59) |
+| cardano-foundation/cardano-ledger-read | `34d0767bd5c3` | [cabal.project:65](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/5f200647c003/cabal.project#L65) |
+| cardano-foundation/cardano-mpfs-onchain | `457c1cbcbbf6` | [cabal.project:95](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/5f200647c003/cabal.project#L95) |
+| lambdasistemi/cardano-node-clients | `e4b01cb9efdf` | [cabal.project:77](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/5f200647c003/cabal.project#L77) |
+| lambdasistemi/cardano-tx-tools | `631f1341fde6` | [cabal.project:83](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/5f200647c003/cabal.project#L83) |
+| lambdasistemi/cardano-utxo-csmt | `f4772f73dde0` | [cabal.project:41](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/5f200647c003/cabal.project#L41) |
+| lambdasistemi/chain-follower | `d592a5015f8d` | [cabal.project:47](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/5f200647c003/cabal.project#L47) |
+| lambdasistemi/contra-tracer-contrib | `f0518e871391` | [cabal.project:71](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/5f200647c003/cabal.project#L71) |
+| lambdasistemi/github-release-check | `d90131112a4d` | [cabal.project:89](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/5f200647c003/cabal.project#L89) |
+| lambdasistemi/haskell-mts | `ab15f7b2dea7` | [cabal.project:53](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/5f200647c003/cabal.project#L53) |
+| lambdasistemi/rocksdb-haskell | `a3e86b39f951` | [cabal.project:29](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/5f200647c003/cabal.project#L29) |
+| lambdasistemi/rocksdb-kv-transactions | `e2e77579888e` | [cabal.project:35](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/5f200647c003/cabal.project#L35) |
+| paolino/aiken-codegen | `74f364c10e93` | [cabal.project:59](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/5f200647c003/cabal.project#L59) |
 
 ### lambdasistemi/cardano-node-clients @ `0f44f49c6d7e`
 
@@ -184,7 +185,7 @@ Effective (root pin): [`e4b01cb9efdf`](https://github.com/lambdasistemi/cardano-
 | Declared by | at its own rev | Pins this dep to |
 |-------------|----------------|------------------|
 | cardano-foundation/moog | `main` | [`e4b01cb9efdf`](https://github.com/lambdasistemi/cardano-node-clients/commit/e4b01cb9efdf88e99934cf7a09fed0e25bad1019) |
-| lambdasistemi/cardano-mpfs-offchain | `99cf2a29b4e6` | [`e4b01cb9efdf`](https://github.com/lambdasistemi/cardano-node-clients/commit/e4b01cb9efdf88e99934cf7a09fed0e25bad1019) |
+| lambdasistemi/cardano-mpfs-offchain | `5f200647c003` | [`e4b01cb9efdf`](https://github.com/lambdasistemi/cardano-node-clients/commit/e4b01cb9efdf88e99934cf7a09fed0e25bad1019) |
 | lambdasistemi/cardano-tx-tools | `56918f33ba74` | [`ca86f11d27b3`](https://github.com/lambdasistemi/cardano-node-clients/commit/ca86f11d27b34e37d3814e4d3c3d66e256400403) |
 | lambdasistemi/cardano-tx-tools | `631f1341fde6` | [`ca86f11d27b3`](https://github.com/lambdasistemi/cardano-node-clients/commit/ca86f11d27b34e37d3814e4d3c3d66e256400403) |
 | lambdasistemi/cardano-utxo-csmt | `f4772f73dde0` | [`0f44f49c6d7e`](https://github.com/lambdasistemi/cardano-node-clients/commit/0f44f49c6d7ecf84e8e93750a3bcd9987310690e) |
@@ -196,7 +197,7 @@ Effective (root pin): [`631f1341fde6`](https://github.com/lambdasistemi/cardano-
 | Declared by | at its own rev | Pins this dep to |
 |-------------|----------------|------------------|
 | cardano-foundation/moog | `main` | [`631f1341fde6`](https://github.com/lambdasistemi/cardano-tx-tools/commit/631f1341fde6e4a11e94b058cf5f2925ffeb9eac) |
-| lambdasistemi/cardano-mpfs-offchain | `99cf2a29b4e6` | [`631f1341fde6`](https://github.com/lambdasistemi/cardano-tx-tools/commit/631f1341fde6e4a11e94b058cf5f2925ffeb9eac) |
+| lambdasistemi/cardano-mpfs-offchain | `5f200647c003` | [`631f1341fde6`](https://github.com/lambdasistemi/cardano-tx-tools/commit/631f1341fde6e4a11e94b058cf5f2925ffeb9eac) |
 | lambdasistemi/cardano-utxo-csmt | `f4772f73dde0` | [`56918f33ba74`](https://github.com/lambdasistemi/cardano-tx-tools/commit/56918f33ba74714fb0bd5fb21e03d24013c54774) |
 
 ### lambdasistemi/chain-follower
@@ -206,7 +207,7 @@ Effective (root pin): [`d592a5015f8d`](https://github.com/lambdasistemi/chain-fo
 | Declared by | at its own rev | Pins this dep to |
 |-------------|----------------|------------------|
 | cardano-foundation/moog | `main` | [`d592a5015f8d`](https://github.com/lambdasistemi/chain-follower/commit/d592a5015f8d7edb2d6022936a67a054dfe5329f) |
-| lambdasistemi/cardano-mpfs-offchain | `99cf2a29b4e6` | [`d592a5015f8d`](https://github.com/lambdasistemi/chain-follower/commit/d592a5015f8d7edb2d6022936a67a054dfe5329f) |
+| lambdasistemi/cardano-mpfs-offchain | `5f200647c003` | [`d592a5015f8d`](https://github.com/lambdasistemi/chain-follower/commit/d592a5015f8d7edb2d6022936a67a054dfe5329f) |
 | lambdasistemi/cardano-node-clients | `0f44f49c6d7e` | [`d592a5015f8d`](https://github.com/lambdasistemi/chain-follower/commit/d592a5015f8d7edb2d6022936a67a054dfe5329f) |
 | lambdasistemi/cardano-node-clients | `ca86f11d27b3` | [`371b5930976a`](https://github.com/lambdasistemi/chain-follower/commit/371b5930976ac3bb4e8a4ef576d5098d706984ee) |
 | lambdasistemi/cardano-node-clients | `e4b01cb9efdf` | [`d592a5015f8d`](https://github.com/lambdasistemi/chain-follower/commit/d592a5015f8d7edb2d6022936a67a054dfe5329f) |
@@ -221,7 +222,7 @@ Effective (root pin): [`ab15f7b2dea7`](https://github.com/lambdasistemi/haskell-
 | Declared by | at its own rev | Pins this dep to |
 |-------------|----------------|------------------|
 | cardano-foundation/moog | `main` | [`ab15f7b2dea7`](https://github.com/lambdasistemi/haskell-mts/commit/ab15f7b2dea73165b785c90333bbd09a36528a07) |
-| lambdasistemi/cardano-mpfs-offchain | `99cf2a29b4e6` | [`ab15f7b2dea7`](https://github.com/lambdasistemi/haskell-mts/commit/ab15f7b2dea73165b785c90333bbd09a36528a07) |
+| lambdasistemi/cardano-mpfs-offchain | `5f200647c003` | [`ab15f7b2dea7`](https://github.com/lambdasistemi/haskell-mts/commit/ab15f7b2dea73165b785c90333bbd09a36528a07) |
 | lambdasistemi/cardano-utxo-csmt | `f4772f73dde0` | [`9a5106790759`](https://github.com/lambdasistemi/haskell-mts/commit/9a510679075930bae812fea5f56b47789ce497ca) |
 
 ### lambdasistemi/rocksdb-haskell
@@ -231,7 +232,7 @@ Effective (root pin): [`a3e86b39f951`](https://github.com/lambdasistemi/rocksdb-
 | Declared by | at its own rev | Pins this dep to |
 |-------------|----------------|------------------|
 | cardano-foundation/moog | `main` | [`a3e86b39f951`](https://github.com/lambdasistemi/rocksdb-haskell/commit/a3e86b39f9510fea54abf734ee84aec33d0d683f) |
-| lambdasistemi/cardano-mpfs-offchain | `99cf2a29b4e6` | [`a3e86b39f951`](https://github.com/lambdasistemi/rocksdb-haskell/commit/a3e86b39f9510fea54abf734ee84aec33d0d683f) |
+| lambdasistemi/cardano-mpfs-offchain | `5f200647c003` | [`a3e86b39f951`](https://github.com/lambdasistemi/rocksdb-haskell/commit/a3e86b39f9510fea54abf734ee84aec33d0d683f) |
 | lambdasistemi/cardano-node-clients | `0f44f49c6d7e` | [`a3e86b39f951`](https://github.com/lambdasistemi/rocksdb-haskell/commit/a3e86b39f9510fea54abf734ee84aec33d0d683f) |
 | lambdasistemi/cardano-node-clients | `ca86f11d27b3` | [`a3e86b39f951`](https://github.com/lambdasistemi/rocksdb-haskell/commit/a3e86b39f9510fea54abf734ee84aec33d0d683f) |
 | lambdasistemi/cardano-node-clients | `e4b01cb9efdf` | [`a3e86b39f951`](https://github.com/lambdasistemi/rocksdb-haskell/commit/a3e86b39f9510fea54abf734ee84aec33d0d683f) |
@@ -254,7 +255,7 @@ graph TD
     moog["<a href='https://github.com/cardano-foundation/moog/tree/main'>moog</a><br/>Antithesis CLI<br/><a href='https://github.com/cardano-foundation/moog/commit/main'><code>main</code></a>"]:::haskell
     cardano_ledger_read["<a href='https://github.com/cardano-foundation/cardano-ledger-read/tree/34d0767bd5c3'>cardano-ledger-read</a><br/>Read Cardano block data, parametrized by<br/>era<br/><a href='https://github.com/cardano-foundation/cardano-ledger-read/commit/34d0767bd5c3'><code>34d0767bd5c3</code></a>"]:::haskell
     cardano_mpfs_onchain["<a href='https://github.com/cardano-foundation/cardano-mpfs-onchain/tree/457c1cbcbbf6'>cardano-mpfs-onchain</a><br/>Aiken on-chain validators for Merkle<br/>Patricia Forestry on Cardano<br/><a href='https://github.com/cardano-foundation/cardano-mpfs-onchain/commit/457c1cbcbbf6'><code>457c1cbcbbf6</code></a>"]:::aiken
-    cardano_mpfs_offchain["<a href='https://github.com/lambdasistemi/cardano-mpfs-offchain/tree/99cf2a29b4e6'>cardano-mpfs-offchain</a><br/>Fact CRUD, transaction building, devnet<br/>server for Merkle Patricia Forestry on<br/>Cardano<br/><a href='https://github.com/lambdasistemi/cardano-mpfs-offchain/commit/99cf2a29b4e6'><code>99cf2a29b4e6</code></a>"]:::haskell
+    cardano_mpfs_offchain["<a href='https://github.com/lambdasistemi/cardano-mpfs-offchain/tree/5f200647c003'>cardano-mpfs-offchain</a><br/>Fact CRUD, transaction building, devnet<br/>server for Merkle Patricia Forestry on<br/>Cardano<br/><a href='https://github.com/lambdasistemi/cardano-mpfs-offchain/commit/5f200647c003'><code>5f200647c003</code></a>"]:::haskell
     cardano_node_clients["<a href='https://github.com/lambdasistemi/cardano-node-clients/tree/e4b01cb9efdf'>cardano-node-clients</a><br/>Haskell clients for Cardano node<br/>mini-protocols (N2C + N2N)<br/><a href='https://github.com/lambdasistemi/cardano-node-clients/commit/e4b01cb9efdf'><code>e4b01cb9efdf</code></a>"]:::haskell
     cardano_tx_tools["<a href='https://github.com/lambdasistemi/cardano-tx-tools/tree/631f1341fde6'>cardano-tx-tools</a><br/>Cardano transaction tooling: builder,<br/>structural diff, blueprint decoding.<br/>Uses cardano-node-clients but is not a<br/>node client.<br/><a href='https://github.com/lambdasistemi/cardano-tx-tools/commit/631f1341fde6'><code>631f1341fde6</code></a>"]:::haskell
     cardano_utxo_csmt["<a href='https://github.com/lambdasistemi/cardano-utxo-csmt/tree/f4772f73dde0'>cardano-utxo-csmt</a><br/>HTTP service maintaining a Compact<br/>Sparse Merkle Tree over Cardano's UTxO<br/>set for efficient inclusion proofs<br/><a href='https://github.com/lambdasistemi/cardano-utxo-csmt/commit/f4772f73dde0'><code>f4772f73dde0</code></a>"]:::haskell
@@ -267,6 +268,7 @@ graph TD
     aiken_codegen["<a href='https://github.com/paolino/aiken-codegen/tree/74f364c10e93'>aiken-codegen</a><br/>Haskell DSL for generating Aiken source<br/>code<br/><a href='https://github.com/paolino/aiken-codegen/commit/74f364c10e93'><code>74f364c10e93</code></a>"]:::haskell
     dev_assets["<a href='https://github.com/paolino/dev-assets/tree/b901b08ce8d2'>dev-assets</a><br/>Actions for haskell, nix and mkdocs<br/>workflows<br/><a href='https://github.com/paolino/dev-assets/commit/b901b08ce8d2'><code>b901b08ce8d2</code></a>"]:::nix
 
+    moog -->|"cardano-mpfs-offchain"| cardano_mpfs_offchain
     moog -->|"dev-assets"| dev_assets
     moog -->|"mkdocs"| dev_assets
     moog -->|"asciinema"| dev_assets
@@ -285,15 +287,15 @@ graph TD
     moog ==> aiken_codegen
     cardano_mpfs_offchain ==> cardano_ledger_read
     cardano_mpfs_offchain ==> cardano_mpfs_onchain
-    cardano_mpfs_offchain ==> cardano_node_clients
+    cardano_mpfs_offchain ==>|"cardano-node-clients, devnet"| cardano_node_clients
     cardano_mpfs_offchain ==> cardano_tx_tools
-    cardano_mpfs_offchain ==> cardano_utxo_csmt
+    cardano_mpfs_offchain ==>|"application, library"| cardano_utxo_csmt
     cardano_mpfs_offchain ==> chain_follower
-    cardano_mpfs_offchain ==> contra_tracer_contrib
+    cardano_mpfs_offchain ==>|"contra-tracer-contrib"| contra_tracer_contrib
     cardano_mpfs_offchain ==> github_release_check
-    cardano_mpfs_offchain ==> haskell_mts
-    cardano_mpfs_offchain ==> rocksdb_haskell
-    cardano_mpfs_offchain ==> rocksdb_kv_transactions
+    cardano_mpfs_offchain ==>|"mpf-write, csmt-core, csmt-test-lib, csmt-write, mpf-test-lib, mpf-write, csmt, csmt-core, csmt-test-lib, csmt-verify, mpf, mpf-test-lib, mts, rollbacks, csmt-core, csmt-verify, mpf-write"| haskell_mts
+    cardano_mpfs_offchain ==>|"rocksdb-haskell-jprupp"| rocksdb_haskell
+    cardano_mpfs_offchain ==>|"kv-transactions, rocksdb-kv-transactions"| rocksdb_kv_transactions
     cardano_mpfs_offchain ==> aiken_codegen
     cardano_node_clients ==> cardano_ledger_read
     cardano_node_clients ==> chain_follower
@@ -328,9 +330,9 @@ graph TD
     cardano_utxo_csmt -.->|"skew 9a5106790759"| haskell_mts
     cardano_utxo_csmt -.->|"skew 85977e8673f1"| rocksdb_haskell
 
-    linkStyle 0,1,2 stroke:#2196F3,stroke-width:2px
-    linkStyle 3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52 stroke:#e53935,stroke-width:2px
-    linkStyle 53,54,55,56,57,58,59 stroke:#ffb300,stroke-width:1px,stroke-dasharray:4 3
+    linkStyle 0,1,2,3 stroke:#2196F3,stroke-width:2px
+    linkStyle 4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53 stroke:#e53935,stroke-width:2px
+    linkStyle 54,55,56,57,58,59,60 stroke:#ffb300,stroke-width:1px,stroke-dasharray:4 3
 ```
 
 **Legend**

--- a/flake.lock
+++ b/flake.lock
@@ -280,6 +280,23 @@
         "type": "github"
       }
     },
+    "cardano-mpfs-offchain": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781185796,
+        "narHash": "sha256-QRsVucboxT6TsVDMkQ20a7o51awTzuxHMkStagdnZbk=",
+        "owner": "lambdasistemi",
+        "repo": "cardano-mpfs-offchain",
+        "rev": "5f200647c00308bb67641b94a16284c68494bff9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lambdasistemi",
+        "repo": "cardano-mpfs-offchain",
+        "rev": "5f200647c00308bb67641b94a16284c68494bff9",
+        "type": "github"
+      }
+    },
     "cardano-node-runtime": {
       "inputs": {
         "CHaP": "CHaP_2",
@@ -1999,6 +2016,7 @@
         "CHaP": "CHaP",
         "asciinema": "asciinema",
         "bundlers": "bundlers",
+        "cardano-mpfs-offchain": "cardano-mpfs-offchain",
         "cardano-node-runtime": "cardano-node-runtime",
         "dev-assets": "dev-assets",
         "flake-parts": "flake-parts_2",

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,11 @@
       url = "github:intersectmbo/cardano-haskell-packages/repo";
       flake = false;
     };
+    cardano-mpfs-offchain = {
+      url =
+        "github:lambdasistemi/cardano-mpfs-offchain/5f200647c00308bb67641b94a16284c68494bff9";
+      flake = false;
+    };
     cardano-node-runtime = {
       url = "github:IntersectMBO/cardano-node?ref=10.7.0";
     };
@@ -80,6 +85,7 @@
           project = import ./nix/moog-project.nix {
             indexState = "2026-02-17T10:15:41Z";
             inherit CHaP;
+            cardano-mpfs-offchain = inputs.cardano-mpfs-offchain;
             inherit pkgs;
             inherit cardano-cli;
             mkdocs = mkdocs.packages.${system};

--- a/nix/moog-project.nix
+++ b/nix/moog-project.nix
@@ -1,4 +1,5 @@
-{ CHaP, indexState, pkgs, cardano-cli ? null, mkdocs, asciinema, ... }:
+{ CHaP, cardano-mpfs-offchain, indexState, pkgs, cardano-cli ? null, mkdocs
+, asciinema, ... }:
 
 let
   libOverlay = { lib, pkgs, ... }: {
@@ -70,7 +71,11 @@ let
     compiler-nix-name = "ghc9123";
     shell = shell { inherit pkgs; };
     modules = [ libOverlay ];
-    inputMap = { "https://chap.intersectmbo.org/" = CHaP; };
+    inputMap = {
+      "https://chap.intersectmbo.org/" = CHaP;
+      "https://github.com/lambdasistemi/cardano-mpfs-offchain.git" =
+        cardano-mpfs-offchain;
+    };
   };
   project = pkgs.haskell-nix.cabalProject' mkProject;
 

--- a/src/MPFS/Read.hs
+++ b/src/MPFS/Read.hs
@@ -24,7 +24,6 @@ import Cardano.MPFS.API.Types
     , RequestsResponse (..)
     , StatusResponse (..)
     , TokenResponse (..)
-    , TokenStateJSON (..)
     , TxInJSON (..)
     , WitnessedRequest (..)
     , WitnessedTokenState (..)
@@ -35,6 +34,8 @@ import Cardano.MPFS.Cage.Types
     ( CageDatum (..)
     , OnChainOperation (..)
     , OnChainRequest (..)
+    , OnChainRoot (..)
+    , OnChainTokenState (..)
     )
 import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
 import Cardano.MPFS.Client.Verify.Replay (VerifyError)
@@ -153,12 +154,13 @@ tokenResponsesToJSValue
     TokenResponse{trState = state}
     RequestsResponse{rrRequests = requests} = do
         requestZoos <- traverse requestJSONToRequestZoo requests
+        tokenState <- witnessedTokenStateToTokenState state
         pure
             $ runIdentity
             $ toJSON
             $ Token
                 { tokenRefId = txInRefId $ wuTxIn $ wtsUtxo state
-                , tokenState = witnessedTokenStateToTokenState state
+                , tokenState = tokenState
                 , tokenRequests = Identity <$> requestZoos
                 }
 
@@ -193,10 +195,11 @@ requestJSONToRequestZoo :: WitnessedRequest -> Either String RequestZoo
 requestJSONToRequestZoo WitnessedRequest{wrUtxo} = do
     let refId = txInRefId $ wuTxIn wrUtxo
     -- Decode the typed request from the VERIFIED inline-datum TxOut
-    -- (proof-bound to the trusted root by 'verifyTokenRequests'), NOT from
-    -- the unverified, lossy 'RequestJSON' projection — which drops an
-    -- update's old value and so cannot type accept\/reject\/finished\/config
-    -- updates (they collapse to UnknownUpdate).
+    -- (proof-bound to the trusted root by 'verifyTokenRequests'). 0.2.0
+    -- (#342) removed the unverified, lossy server-side request projection,
+    -- which dropped an update's old value and so could not type
+    -- accept\/reject\/finished\/config updates (they collapsed to
+    -- UnknownUpdate); the inline datum carries BOTH values.
     request <- decodeRequestDatum $ wuTxOut wrUtxo
     requestDatumToJSValue refId request >>= parseRequestZoo
 
@@ -281,13 +284,35 @@ parseRequestZoo value =
         "verified request JSON did not match moog RequestZoo"
         (fromJSON value)
 
-witnessedTokenStateToTokenState :: WitnessedTokenState -> TokenState
+{- | Recover the token's owner and trie root from the VERIFIED state
+UTxO. 0.2.0 (#342) dropped the server-side @TokenStateJSON@ projection, so
+the owner\/root now come from the inline 'StateDatum' inside the proof-bound
+@wuTxOut@ — the same source of truth the request path already decodes.
+-}
 witnessedTokenStateToTokenState
-    WitnessedTokenState{wtsState = TokenStateJSON{owner, root = Hex root}} =
+    :: WitnessedTokenState -> Either String TokenState
+witnessedTokenStateToTokenState WitnessedTokenState{wtsUtxo} = do
+    OnChainTokenState{stateOwner, stateRoot} <-
+        decodeStateDatum $ wuTxOut wtsUtxo
+    pure
         TokenState
-            { tokenRoot = Root $ hexString root
-            , tokenOwner = Owner $ T.unpack owner
+            { tokenRoot = Root $ hexString $ unOnChainRoot stateRoot
+            , tokenOwner = Owner $ hexString $ fromBuiltin stateOwner
             }
+
+-- | Decode the on-chain 'OnChainTokenState' from a state UTxO's inline
+-- datum. @wuTxOut@ is the CBOR of the Conway 'TxOut'; its inline datum is
+-- the cage 'StateDatum'.
+decodeStateDatum :: Hex -> Either String OnChainTokenState
+decodeStateDatum (Hex txOutBytes) = do
+    txOut <-
+        first (("state TxOut decode failed: " <>) . show)
+            $ decodeFull (eraProtVerLow @ConwayEra) (BL.fromStrict txOutBytes)
+    case cageDatumOf txOut of
+        Just (StateDatum state) -> Right state
+        Just (RequestDatum _) ->
+            Left "state UTxO carries a request datum, not a state datum"
+        Nothing -> Left "state UTxO has no inline cage datum"
 
 txInRefId :: TxInJSON -> RequestRefId
 txInRefId TxInJSON{tjTxId = Hex txId, tjTxIx} =

--- a/test-integration/Agent/ValidationSpec.hs
+++ b/test-integration/Agent/ValidationSpec.hs
@@ -117,6 +117,7 @@ agentValidationSpec = describe "Agent.Validation" $ do
                 let plan =
                         planAgentPoll
                             (const True)
+                            mempty
                             apiRuns
                             pendingFacts
                             runningBefore
@@ -156,7 +157,7 @@ agentValidationSpec = describe "Agent.Validation" $ do
                             "second Accept unexpectedly succeeded"
                 pendingFinal <- readPendingFacts env
                 pendingActions
-                    (planAgentPoll (const True) apiRuns pendingFinal [])
+                    (planAgentPoll (const True) mempty apiRuns pendingFinal [])
                     `shouldBe` []
                 runningFinal <- readRunningFacts env
                 length (filter (== testRun) (map factTestRun runningFinal))
@@ -193,7 +194,7 @@ agentValidationSpec = describe "Agent.Validation" $ do
                         =<< listAllRuns apiConfig
                 runningFacts <- readRunningFacts env
                 -- The real planner maps the completed run to a finish action.
-                let plan = planAgentPoll (const True) apiRuns [] runningFacts
+                let plan = planAgentPoll (const True) mempty apiRuns [] runningFacts
                 case runningActions plan of
                     [RunningFinishObserved (Fact tr running _) run outcome url] ->
                         do
@@ -256,6 +257,7 @@ agentValidationSpec = describe "Agent.Validation" $ do
                             runningActions
                                 ( planAgentPoll
                                     (const True)
+                                    mempty
                                     apiRuns
                                     []
                                     runningFinal

--- a/test/MPFS/ReadSpec.hs
+++ b/test/MPFS/ReadSpec.hs
@@ -15,10 +15,8 @@ import Cardano.MPFS.API.Encoding (Hex (..))
 import Cardano.MPFS.API.Types
     ( FactEntry (..)
     , FactsResponse (..)
-    , RequestJSON (..)
     , RequestsResponse (..)
     , TokenResponse (..)
-    , TokenStateJSON (..)
     , TxInJSON (..)
     , WitnessedRequest (..)
     , WitnessedTokenState (..)
@@ -33,10 +31,12 @@ import Cardano.MPFS.API.Types.Common
 import Core.Types.Change qualified as Change
 import Core.Types.Operation qualified as Operation
 import Cardano.MPFS.Cage.Types
-    ( CageDatum (RequestDatum)
+    ( CageDatum (RequestDatum, StateDatum)
     , OnChainOperation (OpInsert)
     , OnChainRequest (..)
+    , OnChainRoot (..)
     , OnChainTokenId (..)
+    , OnChainTokenState (..)
     )
 import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
 import Control.Lens ((&), (.~))
@@ -168,19 +168,14 @@ sampleTokenResponse =
         { trSnapshot = unusedSnapshot
         , trState =
             WitnessedTokenState
-                { wtsUtxo =
+                { -- 0.2.0 (#342) dropped the server-side state projection;
+                  -- the verified read now decodes owner\/root from this
+                  -- inline-datum TxOut, not from a 'TokenStateJSON' field.
+                  wtsUtxo =
                     WitnessedUtxo
                         { wuTxIn = sampleStateTxIn
-                        , wuTxOut = Hex ""
+                        , wuTxOut = Hex sampleStateTxOut
                         , wuProof = Hex ""
-                        }
-                , wtsState =
-                    TokenStateJSON
-                        { owner = "owner"
-                        , root = Hex sampleRoot
-                        , tip = 1000000
-                        , processTime = 60000
-                        , retractTime = 30000
                         }
                 }
         }
@@ -196,24 +191,13 @@ sampleRequestsResponse =
 sampleWitnessedRequest :: WitnessedRequest
 sampleWitnessedRequest =
     WitnessedRequest
-        { wrUtxo =
+        { -- The verified read decodes the request from this inline-datum
+          -- TxOut; 0.2.0 (#342) removed the old 'RequestJSON' projection.
+          wrUtxo =
             WitnessedUtxo
                 { wuTxIn = sampleRequestTxIn
-                , -- The verified read now decodes the request from this
-                  -- inline-datum TxOut, not from the (unverified, lossy)
-                  -- 'RequestJSON' projection below.
-                  wuTxOut = Hex sampleRequestTxOut
+                , wuTxOut = Hex sampleRequestTxOut
                 , wuProof = Hex ""
-                }
-        , wrRequest =
-            RequestJSON
-                { rjToken = sampleTokenId
-                , rjOwner = "request-owner"
-                , rjKey = Hex $ canonicalBytes sampleKey
-                , rjOperation = "insert"
-                , rjValue = Just $ Hex $ canonicalBytes sampleValue
-                , rjFee = 1000000
-                , rjSubmittedAt = 42
                 }
         }
 
@@ -249,6 +233,37 @@ sampleRequestTxOut =
                         (Data (toData (RequestDatum sampleOnChainRequest)))
                     )
 
+-- | The token-state owner is a 28-byte payment key hash; the decoded moog
+-- owner is its lowercase hex.
+sampleStateOwner :: BS.ByteString
+sampleStateOwner = BS.replicate 28 0x09
+
+-- | The on-chain state datum that 'sampleStateTxOut' carries. Its trie root
+-- is @sampleRoot@ and its owner is @sampleStateOwner@.
+sampleOnChainTokenState :: OnChainTokenState
+sampleOnChainTokenState =
+    OnChainTokenState
+        { stateOwner = toBuiltin sampleStateOwner
+        , stateRoot = OnChainRoot sampleRoot
+        , stateMaxFee = 1000000
+        , stateProcessTime = 60000
+        , stateRetractTime = 30000
+        }
+
+-- | A real serialized Conway 'TxOut' whose inline datum is the state datum
+-- — the reverse of @MPFS.Read.decodeStateDatum@, so the verified read
+-- recovers the token owner\/root from the proof-bound TxOut.
+sampleStateTxOut :: BS.ByteString
+sampleStateTxOut =
+    BL.toStrict
+        $ Ledger.serialize (eraProtVerLow @ConwayEra)
+        $ (mkBasicTxOut sampleAddr (inject (Coin 0)) :: TxOut ConwayEra)
+            & datumTxOutL
+                .~ Datum
+                    ( dataToBinaryData
+                        (Data (toData (StateDatum sampleOnChainTokenState)))
+                    )
+
 -- | A minimal valid testnet enterprise (payment-key) address, parsed from
 -- its raw header + 28-byte key hash, so we needn't hand-build ledger
 -- credential\/hash types.
@@ -264,7 +279,7 @@ sampleToken =
         , tokenState =
             TokenState
                 { tokenRoot = Root $ hexString sampleRoot
-                , tokenOwner = Owner "owner"
+                , tokenOwner = Owner (hexString sampleStateOwner)
                 }
         , tokenRequests =
             [ Identity


### PR DESCRIPTION
Closes #195. Was the planAgentPoll #190 compile fix; expanded to the full offchain-0.2.0 migration since that fix alone can't go green against the skewed (main-built) devnet-server.

- Repin cabal.project → offchain 0.2.0 (5f200647)
- Drop the removed RequestJSON projection path; use 0.2.0 response types (reads already decode the verified wuTxOut datum since #179)
- Make integration-tests CI build the devnet-server from the pinned offchain rev, not floating main
- Keep the planAgentPoll launched-arg fix (main #190)