### PR TITLE
chore(release): v0.5.1.5

### DIFF
--- a/moog.cabal
+++ b/moog.cabal
@@ -21,7 +21,7 @@ name:            moog
 -- PVP summary:     +-+------- breaking API changes
 --                  | | +----- non-breaking API additions
 --                  | | | +--- code changes with no API change
-version:         0.5.1.4
+version:         0.5.1.5
 
 -- A short (one-line) description of the package.
 synopsis:


### PR DESCRIPTION
Hand-cut patch release bundling the merged agent fixes:
- #175 idempotent launch + drain duplicate runs
- #190 property-derived finished outcome
- #191 dev-shell solvable on ghc9123

Bumps `moog.cabal` 0.5.1.4 → 0.5.1.5 so the `v0.5.1.5` tag passes the version==tag check; tagging the merged commit publishes the official images/artifacts.