### PR TITLE
Oracle boot: configurable process/retract timing + tip (#200)

### DIFF
--- a/src/MPFS/API.hs
+++ b/src/MPFS/API.hs
@@ -16,6 +16,7 @@ module MPFS.API
     , bootToken
     , endToken
     , MPFS (..)
+    , BootParams (..)
     , mpfsClient
     ) where
 
@@ -50,7 +51,7 @@ import Data.ByteString.Base16 qualified as Base16
 import Data.Data (Proxy (..))
 import Data.Text.Encoding qualified as Text
 import Lib.JSON.Canonical.Extra (fromAesonThrow)
-import MPFS.Boot (bootTokenFromFacts)
+import MPFS.Boot (BootParams (..), bootTokenFromFacts)
 import MPFS.End (endTokenFromFacts)
 import MPFS.Read
     ( getTokenFactsFromVerifiedRead
@@ -162,7 +163,7 @@ type AwaitTransactionV2 =
         :> Get '[JSON] NoContent
 
 bootToken
-    :: Address -> ClientM (WithUnsignedTx JSValue)
+    :: BootParams -> Address -> ClientM (WithUnsignedTx JSValue)
 bootToken =
     bootTokenFromFacts status' bootFacts'
 endToken
@@ -313,7 +314,7 @@ mpfsClient =
         }
 
 data MPFS m = MPFS
-    { mpfsBootToken :: Address -> m (WithUnsignedTx JSValue)
+    { mpfsBootToken :: BootParams -> Address -> m (WithUnsignedTx JSValue)
     , mpfsEndToken :: Address -> TokenId -> m (WithUnsignedTx JSValue)
     , mpfsRequestInsertFromFacts
         :: Address

--- a/src/MPFS/Boot.hs
+++ b/src/MPFS/Boot.hs
@@ -1,8 +1,10 @@
 module MPFS.Boot
     ( addressBytesForBoot
     , bootTokenFromFacts
+    , BootParams (..)
     ) where
 
+import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Mary.Value
     ( AssetName (..)
     , MultiAsset (..)
@@ -52,12 +54,41 @@ addressBytesForBoot :: Address -> Either String ByteString
 addressBytesForBoot =
     addressBytesForCage
 
+-- | Operator-supplied economics for booting a new token. These values
+-- populate the State datum at mint time and are immutable across
+-- @Modify@; every other operation reads them back from on-chain state.
+-- The devnet 5s defaults baked into 'loadCageConfig' make a token
+-- un-foldable on a real network (Phase 1 closes before a request
+-- confirms), so boot must take them from the operator.
+data BootParams = BootParams
+    { bootProcessTimeMs :: !Integer
+    -- ^ Phase-1 window (ms): the oracle must process a request within
+    -- this window of its submission.
+    , bootRetractTimeMs :: !Integer
+    -- ^ Phase-2 window (ms): the requester may retract before the
+    -- oracle may reject.
+    , bootTipLovelace :: !Integer
+    -- ^ Oracle tip (lovelace) per request, taken from the requester's
+    -- locked value when the request is processed or rejected.
+    }
+    deriving (Eq, Show)
+
+-- | Overlay operator-supplied 'BootParams' onto a loaded 'CageConfig'.
+applyBootParams :: BootParams -> CageConfig -> CageConfig
+applyBootParams bootParams cfg =
+    cfg
+        { defaultProcessTime = bootProcessTimeMs bootParams
+        , defaultRetractTime = bootRetractTimeMs bootParams
+        , defaultTip = Coin (bootTipLovelace bootParams)
+        }
+
 bootTokenFromFacts
     :: ClientM StatusResponse
     -> (BootRequest -> ClientM BootFacts)
+    -> BootParams
     -> Address
     -> ClientM (WithUnsignedTx JSValue)
-bootTokenFromFacts getStatus postBootFacts address = do
+bootTokenFromFacts getStatus postBootFacts bootParams address = do
     rawAddress <- liftEitherClientM $ addressBytesForBoot address
     StatusResponse{currentUtxoRoot} <- getStatus
     trustedRoot <-
@@ -67,7 +98,7 @@ bootTokenFromFacts getStatus postBootFacts address = do
         liftEitherClientM
             $ firstShow
             $ verifyBootFacts (TrustedRoot trustedRoot) facts
-    cfg <- liftIO $ loadCageConfig rawAddress
+    cfg <- applyBootParams bootParams <$> liftIO (loadCageConfig rawAddress)
     evalCtx <- resolveEvalContext
     tx <-
         liftEitherClientM

--- a/src/MPFS/Canary.hs
+++ b/src/MPFS/Canary.hs
@@ -3,6 +3,7 @@
 module MPFS.Canary
     ( BootCanaryFailure (..)
     , FullLifecycleCanaryResult (..)
+    , canaryBootParams
     , fullLifecycleCanary
     , pollGoneBoundaryWithDelay
     , tokenIdFromBootValue

--- a/src/MPFS/Canary.hs
+++ b/src/MPFS/Canary.hs
@@ -41,7 +41,8 @@ import Lib.JSON.Canonical.Extra
     , (.=)
     )
 import MPFS.API
-    ( MPFS (..)
+    ( BootParams (..)
+    , MPFS (..)
     , RequestInsertBody (..)
     , awaitTransactionV2
     , getTokenV2
@@ -118,6 +119,16 @@ instance Monad m => ToJSON m FullLifecycleCanaryResult where
             , ("tokenGonePolls", intJSON tokenGonePolls)
             ]
 
+-- | Devnet boot economics for the canary: short 5s windows are fine
+-- on a fast local devnet, where the oracle can fold within seconds.
+canaryBootParams :: BootParams
+canaryBootParams =
+    BootParams
+        { bootProcessTimeMs = 5_000
+        , bootRetractTimeMs = 5_000
+        , bootTipLovelace = 1_000_000
+        }
+
 fullLifecycleCanary
     :: MPFSClient
     -> Wallet
@@ -125,7 +136,7 @@ fullLifecycleCanary
     -> IO FullLifecycleCanaryResult
 fullLifecycleCanary MPFSClient{runMPFS} wallet@Wallet{sign} maxPolls = do
     WithUnsignedTx unsignedTx rawTokenId <-
-        runMPFS $ mpfsBootToken mpfsClient (address wallet)
+        runMPFS $ mpfsBootToken mpfsClient canaryBootParams (address wallet)
     signedTx <-
         case sign unsignedTx of
             Right tx -> pure tx

--- a/src/Oracle/Token/Cli.hs
+++ b/src/Oracle/Token/Cli.hs
@@ -2,6 +2,7 @@ module Oracle.Token.Cli
     ( tokenCmdCore
     , TokenCommand (..)
     , TokenUpdateFailure (..)
+    , BootParams (..)
     ) where
 
 import Control.Exception (Exception)
@@ -22,7 +23,8 @@ import Data.Functor.Identity (Identity (..))
 import Data.List (find)
 import Lib.JSON.Canonical.Extra (object, (.=))
 import MPFS.API
-    ( MPFS (..)
+    ( BootParams (..)
+    , MPFS (..)
     , mpfsGetToken
     )
 import Oracle.Types
@@ -115,6 +117,7 @@ instance Monad m => ToJSON m TokenUpdateFailure where
 data TokenCommand a where
     BootToken
         :: Wallet
+        -> BootParams
         -> TokenCommand
             (AValidationResult TokenBootFailure (WithTxHash TokenId))
     UpdateToken
@@ -178,10 +181,11 @@ tokenCmdCore command = do
                     $ submit
                     $ \address -> mpfsUpdateTokenFromFacts mpfs address tk wanted
                 pure txHash
-        BootToken wallet -> do
+        BootToken wallet bootParams -> do
             Submission submit <- askSubmit wallet
             lift $ do
-                WithTxHash txHash jTokenId <- submit $ mpfsBootToken mpfs
+                WithTxHash txHash jTokenId <-
+                    submit $ mpfsBootToken mpfs bootParams
                 runValidate $ do
                     tkId <- liftMaybe NoTokenIdReturned jTokenId
                     tokenId <- liftMaybe TokenIdNotValidJSON $ fromJSON tkId

--- a/src/Oracle/Token/Options.hs
+++ b/src/Oracle/Token/Options.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NumericUnderscores #-}
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
 module Oracle.Token.Options
@@ -15,11 +16,21 @@ import Lib.Box (Box (..))
 import OptEnvConf
     ( Alternative (many)
     , Parser
+    , auto
     , command
     , commands
+    , env
+    , help
+    , long
+    , metavar
+    , option
+    , reader
+    , setting
+    , value
     )
 import Oracle.Token.Cli
-    ( TokenCommand (..)
+    ( BootParams (..)
+    , TokenCommand (..)
     )
 
 tokenCommandParser
@@ -31,7 +42,62 @@ tokenCommandParser =
                 <$> tokenIdOption
                 <*> walletOption
                 <*> many outputReferenceParser
-        , command "boot" "Boot a new token" $ Box . BootToken <$> walletOption
+        , command "boot" "Boot a new token"
+            $ fmap Box . BootToken
+                <$> walletOption
+                <*> bootParamsParser
         , command "end" "End the token"
             $ fmap Box . EndToken <$> tokenIdOption <*> walletOption
+        ]
+
+-- | Operator-supplied boot economics. Defaults are network-safe, not
+-- the devnet 5s windows: a request stays processable long enough for
+-- the oracle to fold it on a real network (~20s blocks + indexing).
+bootParamsParser :: Parser BootParams
+bootParamsParser =
+    BootParams
+        <$> processTimeOption
+        <*> retractTimeOption
+        <*> tipOption
+
+processTimeOption :: Parser Integer
+processTimeOption =
+    setting
+        [ help
+            "Phase-1 process window in ms: the oracle must process a \
+            \request within this window of its submission"
+        , reader auto
+        , long "process-time-ms"
+        , metavar "MILLIS"
+        , env "MOOG_PROCESS_TIME_MS"
+        , option
+        , value 180_000
+        ]
+
+retractTimeOption :: Parser Integer
+retractTimeOption =
+    setting
+        [ help
+            "Phase-2 retract window in ms: the requester may retract \
+            \before the oracle may reject"
+        , reader auto
+        , long "retract-time-ms"
+        , metavar "MILLIS"
+        , env "MOOG_RETRACT_TIME_MS"
+        , option
+        , value 180_000
+        ]
+
+tipOption :: Parser Integer
+tipOption =
+    setting
+        [ help
+            "Oracle tip in lovelace, taken from each request's locked \
+            \value when it is processed or rejected"
+        , reader auto
+        , long "tip"
+        , metavar "LOVELACE"
+        , env "MOOG_TIP_LOVELACE"
+        , option
+        , value 1_000_000
         ]

--- a/test-integration/Lib/Agent/AcceptHarness.hs
+++ b/test-integration/Lib/Agent/AcceptHarness.hs
@@ -85,6 +85,7 @@ import MPFS.API
     , awaitTransactionV2
     , mpfsClient
     )
+import MPFS.Canary (canaryBootParams)
 import Oracle.Config.Types
     ( ConfigKey (..)
     , mkCurrentConfig
@@ -342,7 +343,7 @@ bootToken client@MPFSClient{runMPFS, submitTx} auth oracle = do
         runMPFS
             $ withContext mpfsClient (mkEffects auth) submitTx
             $ tokenCmdCore
-            $ BootToken oracle
+            $ BootToken oracle canaryBootParams
     case res of
         ValidationSuccess (WithTxHash txh (Just tokenId)) -> do
             waitConfirmed client txh

--- a/test-integration/MPFS/APISpec.hs
+++ b/test-integration/MPFS/APISpec.hs
@@ -62,6 +62,7 @@ import MPFS.API
     , requestInsertFromFacts
     , requestUpdateFromFacts
     )
+import MPFS.Canary (canaryBootParams)
 import Network.HTTP.Client
     ( ManagerSettings (managerResponseTimeout)
     , newManager
@@ -251,7 +252,7 @@ setup auth = do
             (mkEffects auth)
             wait180S
             $ tokenCmdCore
-            $ BootToken oracleWallet
+            $ BootToken oracleWallet canaryBootParams
     liftIO $ waitTx call txHash
     case mTokenId of
         Nothing -> error "BootToken failed, no TokenId returned"

--- a/test/MockMPFS.hs
+++ b/test/MockMPFS.hs
@@ -19,7 +19,7 @@ import Text.JSON.Canonical (ToJSON (..))
 mockMPFS :: Monad m => MPFS m
 mockMPFS =
     MPFS
-        { mpfsBootToken = \_ -> error "boot token not implemented"
+        { mpfsBootToken = \_ _ -> error "boot token not implemented"
         , mpfsEndToken = \_ _ -> error "end token not implemented"
         , mpfsRequestInsertFromFacts = \_ _ RequestInsertBody{value = body} ->
             pure


### PR DESCRIPTION
Implements #200 — boot was baking hardcoded devnet economics (`process_time = retract_time = 5_000 ms`, `tip = 1 ADA`) via `loadCageConfig` with no override, making every moog-booted token un-foldable on a real network (Phase 1 closes before a request confirms). Blocks the #153 cutover.

## Change

- New `BootParams { bootProcessTimeMs, bootRetractTimeMs, bootTipLovelace }` (ledger-free `Integer`s) threaded through `mpfsBootToken` → `bootTokenFromFacts`, overlaid onto the `CageConfig` **at boot only** (`applyBootParams`). Every other op still reads timing from on-chain state, so `loadCageConfig` is untouched for them.
- `oracle token boot` gains env-backed flags: `--process-time-ms` / `MOOG_PROCESS_TIME_MS`, `--retract-time-ms` / `MOOG_RETRACT_TIME_MS`, `--tip` / `MOOG_TIP_LOVELACE`. Defaults are network-safe `180_000` ms / `1_000_000` lovelace (not the devnet 5s).
- The canary keeps the 5s devnet values explicitly (`canaryBootParams`).

## AC status

- [x] `oracle token boot` accepts `--process-time-ms` / `--retract-time-ms` (env-backed), defaults ≠ 5 000 ms
- [x] `oracle token boot` accepts a configurable `--tip`, written into the State datum
- [x] Threaded through `bootTokenFromFacts`; no longer hardcoded in `MPFS/Cage.hs` for boot
- [x] `MPFS/Canary.hs` uses the same surface (no separate hardcoded path)
- [ ] **Live-boundary proof on preprod** — comes with the cost-showcase e2e (boot with realistic timing → submit → process within Phase 1). Pending.

## Verification

- `nix build .#moog` ✅ (moog-exe-moog-0.5.1.5 builds; all modules compile)
- `hlint` ✅ on changed files

> Note: moog-v2's `nix develop` is currently broken by the removed `pkgs.lzma` (the `lzma→xz` flake fix lives on #197/#186, not yet merged). I built locally with that fix applied; nix-based CI here needs #197 merged (or a rebase) to go green. Not introduced by this PR.

Refs #200. Blocks #153.