### PR TITLE
docs: align documentation with the v0.5.1.5 code state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Repository Agent Guide
+
+## What this repo is
+
+Moog is a Haskell tool to administer [Antithesis](https://antithesis.com)
+test execution through Cardano. It builds one CLI (`moog`) and three
+services: `moog-oracle` (validates user requests against GitHub and commits
+them to an on-chain token through the MPFS service), `moog-agent` (launches
+accepted test runs on Antithesis and reconciles their results back
+on-chain via the Antithesis REST API), and `moog-antithesis-proxy`
+(GitHub-team-authenticated read access to the Antithesis API). A fourth
+executable, `moog-mpfs-v2-canary`, is an end-to-end probe for the MPFS v2
+migration that is being developed on the `moog-v2` branch.
+
+## How to work here
+
+- Build: `just build` (= `cabal build all --enable-tests`), inside `nix develop`
+- Unit tests: `just unit` (or `nix run .#unit-tests` when the dev shell is unavailable)
+- Format: `just format` (fourmolu + cabal-fmt + nixfmt); lint: `just hlint`
+- Integration/E2E tests need Docker, a funded test wallet and
+  `MOOG_GITHUB_PAT` / `MOOG_SSH_PASSWORD` — see the recipe headers in
+  `justfile`
+- Docs site: MkDocs Material, sources in `docs/`, config in `mkdocs.yml`
+- Docker images: `just build-docker-images`; deployment compose files in `CD/`
+
+## Skills
+
+Activatable procedures live under `skills/`. Load the one whose description
+matches your task:
+
+- `skills/moog-guide/` — repository guide: code map, build/test/run
+  commands, CLI usage, where answers live
+- `skills/antithesis-moog/` — production operations runbook: identities,
+  secrets layout and rotation, stuck-request recovery, result
+  reconciliation debugging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog for moog-cli
 
+### v0.5.1.5 - 2026-06-11
+
+#### Fixed
+
+- **The agent launch is idempotent and duplicate Antithesis runs drain
+  instead of stalling.** A launched-but-not-yet-observed test-run is
+  tracked with an in-process marker so a slow-to-appear run is not
+  launched twice, and when multiple API runs match the same on-chain
+  test-run the agent prefers the completed run as the canonical one and
+  drains the duplicates. (#175)
+- **The finished outcome is derived from run properties, not only run
+  status.** A `completed` Antithesis run with failing test properties
+  now finishes as a failure; Antithesis-platform/coverage properties are
+  excluded from that check so platform noise cannot fail a run. (#190)
+- **The dev shell solves again on GHC 9.12.3** by allowing a newer
+  `base` for `cabal-fmt`. (#191)
+
 ### v0.5.1.4 - 2026-06-09
 
 #### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,6 @@ download the source code for cardano-node (which you don't need to do).
 Then, go from the top-level directory of your cloned Moog and enter:
 
 ```
-cd cli
 cabal update
 cabal build
 cabal run moog -- --help
@@ -71,7 +70,7 @@ If you are a Nix user and want to run the CLI directly from the official
 repository, without cloning the repository:
 
 ```bash
-nix shell github:cardano-foundation/moog?dir=cli#moog
+nix shell github:cardano-foundation/moog#moog
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-![](/assets/tartarus.jpeg)
+# Moog
+
+> A tool to administer Antithesis test execution through Cardano.
 
 <!-- Badges -->
 [![Unit Tests](https://github.com/cardano-foundation/moog/actions/workflows/unit-tests.yaml/badge.svg)](https://github.com/cardano-foundation/moog/actions/workflows/unit-tests.yaml)
@@ -8,23 +10,22 @@
 [![Linux Release](https://github.com/cardano-foundation/moog/actions/workflows/release.yml/badge.svg)](https://github.com/cardano-foundation/moog/actions/workflows/release.yml)
 [![Darwin Release](https://github.com/cardano-foundation/moog/actions/workflows/darwin-release.yml/badge.svg)](https://github.com/cardano-foundation/moog/actions/workflows/darwin-release.yml)
 [![Build docker images](https://github.com/cardano-foundation/moog/actions/workflows/docker-images.yaml/badge.svg)](https://github.com/cardano-foundation/moog/actions/workflows/docker-images.yaml)
-# Moog
+
+![](assets/tartarus.jpeg)
 
 > **⚠️ Project state — MPFS v2 migration in progress.**
 > moog is migrating from the legacy MPFS HTTP API to the new facts-only MPFS
 > service ([cardano-mpfs-offchain](https://github.com/lambdasistemi/cardano-mpfs-offchain)),
 > where the server returns indexed *facts* and the client builds, signs, and
-> submits transactions. The current release (**v0.5.1.4**) runs against the
-> **legacy** MPFS server in production; the oracle `token boot` / `token end`
-> commands were removed because they already targeted the new API, which
-> production does not yet serve. The full client-side facts cutover is happening
-> on a long-lived **`moog-v2`** branch and will land as a single coordinated
-> release. **`main` is frozen during the migration** — see
-> [#144](https://github.com/cardano-foundation/moog/issues/144).
+> submits transactions. Current releases (**v0.5.1.5** at the time of writing)
+> run against the **legacy** MPFS server in production; the oracle
+> `token boot` / `token end` commands were removed in v0.5.1.3 because they
+> already targeted the new API, which production does not yet serve
+> ([#144](https://github.com/cardano-foundation/moog/issues/144)). The full
+> client-side facts cutover is developed on the long-lived
+> [`moog-v2`](https://github.com/cardano-foundation/moog/tree/moog-v2) branch.
 
-Moog is for Cardano network components testing with Antithesis.
-
-## Overview
+## What is this
 
 The [Cardano blockchain's][Cardano] core node software implements complex
 algorithms and protocols who run in a networked, concurrent context. Many
@@ -39,47 +40,136 @@ appearing or disappearing) in a simulated environment, such that if any
 specific random sequence of combination of events leads to a software error, it
 can be reproduced.
 
-Moog aims to facilitate the use of Antithesis for testing various
-components of the Cardano ecosystem, while tracking these test efforts on the
-blockchain.
+Moog facilitates the use of Antithesis for testing components of the Cardano
+ecosystem, while tracking these test efforts on the blockchain. It defines
+three roles: **requesters** submit test-run requests, an **agent** runs them on
+Antithesis and reports results, and an **oracle** validates every request
+against GitHub and commits it to an on-chain token via the
+[MPFS](https://github.com/cardano-foundation/mpfs) service.
 
-## Pre-requisites
+## Architecture
 
-Moog is intended for Cardano developers and builders. Familiarity with the
-Cardano network, its tools and ecosystem is required.
+```mermaid
+flowchart LR
+    subgraph cli [moog CLI]
+        requester[requester commands]
+        facts[facts and token queries]
+        anti[antithesis commands]
+    end
+    subgraph services [Automated services]
+        oracle[moog-oracle]
+        agent[moog-agent]
+        proxy[moog-antithesis-proxy]
+    end
+    mpfs[MPFS service]
+    chain[(Cardano blockchain)]
+    github[GitHub]
+    antithesis[Antithesis platform]
 
-Moog runs on MacOS and Linux.
+    requester -->|submit requests| mpfs
+    facts --> mpfs
+    oracle -->|validate and update token| mpfs
+    oracle -->|check users, roles, repos| github
+    agent -->|poll facts, accept, report| mpfs
+    agent -->|download test assets| github
+    agent -->|launch runs, read results| antithesis
+    anti --> proxy
+    proxy -->|authenticated read API| antithesis
+    proxy -->|team membership check| github
+    mpfs --> chain
+```
 
-Before using Moog there are several preliminary steps, including creating
-a wallet and registering yourself as a user. These are described in the
-user manual.
+The repository builds one CLI (`moog`) and three services: `moog-oracle`
+(validates and batches on-chain requests), `moog-agent` (launches accepted
+test runs on Antithesis and reconciles their results back on-chain), and
+`moog-antithesis-proxy` (GitHub-team-authenticated read access to the
+Antithesis API). See the
+[architecture documentation](https://cardano-foundation.github.io/moog/ops/architecture/)
+for details.
 
-## Getting started
+## Install
 
-Instructions for end-users are available on the [Moog website][Moog].
+Download pre-built binaries for `moog`, `moog-agent` and `moog-oracle` from
+the [releases page](https://github.com/cardano-foundation/moog/releases).
+Each release ships Linux tarballs (`*-x86_64-linux-musl.tar.gz` and
+`aarch64` variants, statically linked), AppImage/deb/rpm packages, and an
+`aarch64-darwin` tarball for macOS.
 
-Instructions for contributors and developers are in
-[Contributing](./CONTRIBUTING.md)
+Alternatively, Nix users can run the CLI directly from the repository:
+
+```bash
+nix shell github:cardano-foundation/moog#moog
+```
+
+## Quickstart
+
+```bash
+# check the CLI is installed
+moog --help
+
+# create a wallet (writes the mnemonics to wallet.json)
+moog wallet create --wallet wallet.json
+
+# inspect it (address and public key hash, never the mnemonics)
+moog wallet info --wallet wallet.json
+
+# point the CLI at the production MPFS service and moog token
+export MOOG_MPFS_HOST=https://mpfs.plutimus.com
+export MOOG_TOKEN_ID=21c523c3b4565f1fc1ad7e54e82ca976f60997d8e7e9946826813fabf341069b
+
+# browse the public system state
+moog facts users
+```
+
+Before requesting test runs you must register as a user and be granted a
+role; the [User Manual][Moog] walks through the full setup.
 
 ## Usage
 
-Moog is used via a command-line-interface (CLI). If you have followed the
-"Getting started" instructions you can check you have a working system by
-invoking:
+Moog is used via a command-line interface. The main command groups:
 
+| Command group | Purpose |
+|---|---|
+| `moog wallet` | Create, inspect, encrypt and decrypt wallets |
+| `moog requester` | Register users/roles and request test runs |
+| `moog agent` | Accept, reject, push and report test runs |
+| `moog oracle` | Update the token and publish the oracle configuration |
+| `moog facts` | Query the on-chain system state (users, roles, test-runs, config) |
+| `moog token` | Inspect the token state and pending requests |
+| `moog retract` | Retract a pending request you own |
+| `moog antithesis` | Read Antithesis run data through the proxy |
+
+Run `moog --help` (or `moog <group> --help`) for the full reference, and see
+the user manual on the [Moog website][Moog].
+
+## Documentation
+
+The full documentation — user manual, operations manual and developer docs —
+is published at [cardano-foundation.github.io/moog][Moog].
+
+For AI agents, start at [AGENTS.md](AGENTS.md).
+
+## Development
+
+```bash
+nix develop        # dev shell with GHC, cabal, HLS, fourmolu, hlint, mkdocs
+just build         # cabal build all --enable-tests
+just unit          # run the unit test suite
+just format        # fourmolu + cabal-fmt + nixfmt
 ```
-moog --help
-```
 
-This should print out Moog's inline help.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for building from source (with or
+without Nix) and for the integration/E2E test setup.
 
-Further instructions for setting up and using Moog are in the user manuals
-available on the [Moog webiste][Moog].
+## License
 
-## See Also
+[Apache 2.0](./LICENSE)
 
-- Other projects by [HAL][HAL]
-- Other projects by the [Cardano Foundation][CF]
+## See also
+
+- Test assets for running a Cardano network in Antithesis:
+  [cardano-node-antithesis](https://github.com/cardano-foundation/cardano-node-antithesis)
+- Other projects by [HAL][HAL] and the [Cardano Foundation][CF]
 - About [Cardano][Cardano]
 
 <!-- MARKDOWN LINKS & IMAGES -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,12 +5,14 @@
     moog is migrating from the legacy MPFS HTTP API to the new facts-only MPFS
     service ([cardano-mpfs-offchain](https://github.com/lambdasistemi/cardano-mpfs-offchain)),
     where the server returns indexed *facts* and the client builds, signs, and
-    submits transactions. The current release (**v0.5.1.4**) runs against the
-    **legacy** MPFS server in production; the oracle `token boot` / `token end`
-    commands were removed because they already targeted the new API, which
-    production does not yet serve. The full client-side facts cutover happens on
-    a long-lived **`moog-v2`** branch and will land as a single coordinated
-    release. **`main` is frozen during the migration.**
+    submits transactions. Current releases (**v0.5.1.5** at the time of
+    writing) run against the **legacy** MPFS server in production; the oracle
+    `token boot` / `token end` commands were removed in v0.5.1.3 because they
+    already targeted the new API, which production does not yet serve
+    ([#144](https://github.com/cardano-foundation/moog/issues/144)). The full
+    client-side facts cutover is developed on the long-lived
+    [`moog-v2`](https://github.com/cardano-foundation/moog/tree/moog-v2)
+    branch.
 
 # Moog
 

--- a/docs/ops/agent-oracle-config-secrets.md
+++ b/docs/ops/agent-oracle-config-secrets.md
@@ -226,8 +226,9 @@ The generated `config.json` is what the compose file should mount at
 
 ### `oracle.json`
 
-`oracle.json` is the oracle wallet file. The token owner is bound when
-`moog oracle token boot` mints the token, so a live oracle wallet cannot be
+`oracle.json` is the oracle wallet file. The token owner is bound when the
+token is minted (the `moog oracle token boot` command that did this was
+removed from the CLI in v0.5.1.3), so a live oracle wallet cannot be
 rotated for an existing token unless the on-chain token state is recreated.
 
 Check wallet metadata without printing the wallet:

--- a/docs/ops/agent-role.md
+++ b/docs/ops/agent-role.md
@@ -4,26 +4,40 @@
 
 ```mermaid
 flowchart TB
-    subgraph Agent Automation Loop
-        poll[Poll for pending test runs]
-        check[Check pending requests]
+    subgraph loop [Agent Automation Loop]
+        poll[Poll MPFS facts and Antithesis API runs]
+        plan[Plan actions for pending and running test-runs]
         download[Download test assets from GitHub]
         validate[Local docker compose validation]
-        push[Push to Antithesis platform]
-        accept[Report acceptance on-chain]
-        email[Check email for results]
+        push[Push config image and launch on Antithesis]
+        accept[Report acceptance on-chain once the run is observed]
+        reconcile[Match runs to on-chain test-runs by description]
+        outcome[Derive outcome from terminal run status and failing properties]
         report[Report completion on-chain]
     end
 
-    poll --> check --> download --> validate --> push --> accept
-    poll --> email --> report
+    poll --> plan
+    plan -->|pending from trusted requester| download --> validate --> push --> accept
+    plan -->|running| reconcile --> outcome --> report
 
     MPFS[(MPFS)] <--> poll
+    AT[Antithesis API] --> poll
     GH[GitHub] --> download
-    AT[Antithesis] <--> push
+    AT2[Antithesis platform] <--> push
     MPFS <--> accept
     MPFS <--> report
 ```
+
+On every poll cycle the agent reads both the on-chain test-run facts (from
+MPFS) and the runs visible in the Antithesis REST API. Pending test-runs
+from trusted requesters are launched (assets downloaded, validated with
+docker compose, pushed as a config image); the on-chain `accepted` fact is
+only submitted once the launched run becomes observable in the API. Running
+test-runs are matched to API runs by their rendered description; when a
+matched run reaches a terminal status, the agent derives the outcome
+(`completed` with a triage report and no failing test properties maps to
+success; `incomplete` and `cancelled` map to failure) and reports it
+on-chain.
 
 ## Running as Docker Service
 
@@ -36,9 +50,10 @@ For production host paths, GAR `config.json` generation, secret rotation, and po
 
 | Flag | Description | Default |
 |---|---|---|
-| `--poll-interval` | Seconds between polling cycles | 60 |
-| `--minutes` | Time window (in minutes) to search for email results | — |
+| `--poll-interval` | Seconds between polling cycles | 30 |
+| `--minutes` | Time window (in minutes) for the legacy email-collection commands | 1440 |
 | `--trust-all-requesters` | Accept test runs from any requester (skip trusted list check) | disabled |
+| `--trusted-test-requester` | GitHub username of a trusted requester (repeatable) | — |
 
 !!! note "Deprecated flag"
     The `--days` flag was replaced by `--minutes` in v0.4.1.1. Use `--minutes 1440` instead of `--days 1`.
@@ -87,7 +102,7 @@ Two commands are available
 
 This will only work if the repository is not already white-listed and the repository is in GitHub.
 ```bash
-moog agent white-list <platform> <repository>
+moog agent white-list --platform <platform> --repository <repository>
 ```
 
 ATM only GitHub is supported as a platform.
@@ -104,7 +119,7 @@ The format of the repository is `<owner>/<repository>`, e.g. `cardano-foundation
 
 This will only work if the repository is white-listed.
 ```bash
-moog agent black-list <platform> <repository>
+moog agent black-list --platform <platform> --repository <repository>
 ```
 
 ## Query pending test-runs
@@ -167,17 +182,26 @@ This will move it from `pending` to `running` state in the facts.
 
 ## Check for the completion of a test-run
 
-ATM we can only collect results via email.
-The email is passed in the post request when the test-run on the recipients list.
+The agent service derives test results from the **Antithesis REST API**: it
+matches each on-chain `accepted` test-run to an Antithesis run by its
+description and finishes it when the run reaches a terminal status. You can
+inspect the same API data manually with the `moog antithesis` subcommands
+(see the [Antithesis proxy](../antithesis-proxy.md) page):
 
+```bash
+moog antithesis runs --limit 100 --no-pretty
+moog antithesis run --run-id <run-id>
+moog antithesis properties --run-id <run-id>
+```
+
+### Legacy: collecting results via email
+
+Earlier versions collected results from the Antithesis notification emails.
+The email-based commands still exist but are no longer on the result path of
+the agent service:
 
 ```bash
 export MOOG_AGENT_EMAIL="<your-email>"
-```
-
-Then you can check for the completion of a test-run via
-
-```bash
 moog agent collect-results-for --test-run-id <test-run-id> --minutes <n> --ask-agent-email-password
 ```
 

--- a/docs/ops/architecture.md
+++ b/docs/ops/architecture.md
@@ -80,16 +80,16 @@ To grant the Antithesis tester role, a GitHub repository must explicitly list Gi
 
 Any GitHub repository that has been registered with the system (i.e., contains a valid user public key and is whitelisted for test execution) can host a directory containing test definitions that meet the required format and standards. Currently only a runnable docker-compose.yaml is required.
 
-- Example: [test definition](https://github.com/cardano-foundation/moog/tree/main/compose/testnets/cardano_node_master)
+- Example: [test definition](https://github.com/cardano-foundation/cardano-node-antithesis/tree/main/testnets/cardano_node_master)
 
 ### Antithesis Platform
 
 ```mermaid
 graph TD
-        A[Antithesis Platform] -->|runs tests via| B[Antithesis API]
-        A -->|provides test results via| C[email with test results]
+        A[Antithesis Platform] -->|runs tests via| B[Antithesis launch API]
+        A -->|provides test results via| C[Antithesis REST read API]
 ```
-Antithesis is the test execution platform that provides the infrastructure to run tests and collect results. Currently we use a POST API to create test runs and fetch results via email parsing. In the future the platform will provide a better API to manage test runs and fetch results.
+Antithesis is the test execution platform that provides the infrastructure to run tests and collect results. We use a POST API to create test runs, and the Antithesis REST read API (run status, properties, triage report links) to collect results — the agent reconciles on-chain test-runs against the API runs on every poll cycle. Earlier versions parsed result notification emails; that path is no longer used by the agent service.
 
 - Antithesis docs: [API](https://antithesis.com/docs/webhook/test_webhook/)
 
@@ -183,10 +183,10 @@ The `requester` role is fully manual, requiring users to perform all actions thr
 ```mermaid
 graph LR
         A[Agent role] -->|accept test execution requests via| TR[*]
-        TR -->|submission of| B[a create-test request to MPFS service]
-        TR -->|POST to| C[Antithesis API]
+        TR -->|submission of| B[an accept-test request to MPFS service]
+        TR -->|POST to| C[Antithesis launch API]
         A -->|collect test results via| RR[*]
-        RR -->|email parsing from| D[email with test results]
+        RR -->|polling of| D[the Antithesis REST read API]
         RR -->|submission of| E[a report-test request to MPFS service]
 
 ```

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -40,7 +40,7 @@ graph TB
 - **GitHub PAT** with `repo` scope for the agent (used to download test assets)
 - **Antithesis credentials** for the agent (registry password, platform user)
 - **MPFS service** accessible from both machines (default: `https://mpfs.plutimus.com`)
-- **Moog token** already created by the oracle (`moog oracle token boot`)
+- **Moog token** already created by the oracle (the `moog oracle token boot` command was removed in v0.5.1.3; the production token was minted with an earlier release)
 
 ## Oracle Deployment
 

--- a/docs/ops/oracle-role.md
+++ b/docs/ops/oracle-role.md
@@ -6,7 +6,7 @@ This is the role of the user that wants to run a service to control access to th
 
 ```mermaid
 flowchart TB
-    sleep[Sleep MOOG_WAIT seconds] --> poll[Query MPFS for pending requests]
+    sleep[Sleep POLL_INTERVAL_SECONDS, default 30] --> poll[Query MPFS for pending requests]
     poll --> validate[Validate each request against GitHub]
     validate --> submit[Submit batch state update transaction]
     submit --> sleep
@@ -52,7 +52,7 @@ For production host paths, oracle wallet ownership checks, secret rotation, and 
 
 Alternatively, oracle commands can be run manually, using the `moog` CLI. See the [Installation instructions](../user/installation.md) for how to install it.
 
-## Creating the moog token (only once)
+## The oracle wallet and the moog token
 
 Oracle operations need a wallet. Since the oracle role is critical, in addition to setting the `MOOG_WALLET_FILE` environment variable to point to the wallet file, you should also set the `MOOG_WALLET_PASSPHRASE` environment variable to encrypt the wallet.
 
@@ -78,13 +78,17 @@ Example output:
 }
 ```
 
-To create the Antithesis token, you can use the `moog oracle token create` command.
-
-```bash
-moog oracle token boot
-```
-
-It will create the Antithesis token. This token is a unique identifier for the Antithesis platform and will be used by all users to interact with the platform. You have to distribute it so that users can set the `MOOG_TOKEN_ID` environment variable to point to it.
+!!! warning "Token creation and deletion commands were removed"
+    The `moog oracle token boot` and `moog oracle token end` commands were
+    removed in v0.5.1.3 because they targeted the new facts-only MPFS API,
+    which the production MPFS server does not yet serve
+    ([#144](https://github.com/cardano-foundation/moog/issues/144)). The
+    production moog token was created once with an earlier release and is
+    distributed to users, who point at it with the `MOOG_TOKEN_ID`
+    environment variable (see [Configuration](../user/configuration.md)).
+    The token owner is permanently bound to the oracle wallet that minted
+    it. The token lifecycle commands will return with the MPFS v2 cutover
+    on the `moog-v2` branch.
 
 You can review the token info anytime with
 
@@ -112,14 +116,6 @@ Updating the token with new requests is done with the `moog oracle token update`
 
 ```bash
 moog oracle token update -o b6fc7cca5bcae74e6a5983f7922d0e0985285f1f19e62ccc9cb9fd4d3766a81b-0
-```
-
-## Deleting the moog token (DANGEROUS)
-
-To delete the Antithesis token, you can use the `moog oracle token delete` command.
-
-```bash
-moog oracle token delete
 ```
 
 ## Publishing the oracle configuration

--- a/docs/ops/real-world.md
+++ b/docs/ops/real-world.md
@@ -16,14 +16,14 @@ For details of how to achieve this, see [configuration](../user/configuration.md
 
 ### Setting up an interface
 
-To bootstrap the system, the oracle must create an moog token:
+To bootstrap the system, the oracle must create a moog token. The
+`moog oracle token boot` command that did this was removed in v0.5.1.3
+together with `token end`, because both targeted the new facts-only MPFS
+API that production does not yet serve
+([#144](https://github.com/cardano-foundation/moog/issues/144)); token
+creation will return with the MPFS v2 cutover on the `moog-v2` branch.
 
-```
-moog oracle token boot
-
-```
-
-This token is unique for a system. It enables all the actors to collaborate. It needs to be shared by some means with users. For example, the one that has been created (currently on preprod) for this project (an interface the the moogthesis instance managed by Cardano Foundation) is provided in the [configuration](../user/configuration.md). In order to "connect" to this interface all roles need to set the MOOG_TOKEN_ID environment variable to the value that was returned by the above command.
+The token is unique for a system. It enables all the actors to collaborate. It needs to be shared by some means with users. For example, the one that has been created (currently on preprod) for this project (an interface to the Antithesis instance managed by Cardano Foundation) is provided in the [configuration](../user/configuration.md). In order to "connect" to this interface all roles need to set the MOOG_TOKEN_ID environment variable to its value.
 
 Then, the agent must configure this interface on-chain, in particular test durations and the public key hash of the agent:
 

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -7,12 +7,19 @@ The Moog command-line-interface (CLI) can run on Linux and MacOS.
 ## Installing Moog's CLI
 
 The recommended way for end-users to install the Moog CLI is to download the
-pre-built binaries for your platform from the [releases page](https://github.com/cardano-foundation/moog/releases)
+pre-built binaries for your platform from the [releases page](https://github.com/cardano-foundation/moog/releases).
+Each release ships, for the `moog` CLI (and separately for `moog-agent` and
+`moog-oracle`):
+
+- statically linked Linux tarballs: `moog-<version>-x86_64-linux-musl.tar.gz`
+  and `moog-<version>-aarch64-linux-musl.tar.gz`
+- Linux packages: `.AppImage`, `.deb` and `.rpm` for both architectures
+- a macOS tarball: `moog-<version>-aarch64-darwin.tar.gz`
 
 Alternatively, if you are a Nix user you may run the CLI directly from the official repository:
 
 ```bash
-nix shell github:cardano-foundation/moog?dir=cli#moog
+nix shell github:cardano-foundation/moog#moog
 ```
 
 For additional ways, see the CONTRIBUTING files in the [source repository](https://github.com/cardano-foundation/moog).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,10 +80,11 @@ nav:
     - Usage: user/usage.md
     - CI: user/ci.md
     - Secrets Management: user/secrets-management.md
+  - Architecture:
+    - Overview: ops/architecture.md
+    - Protocol: ops/protocol.md
   - Operations Manual:
     - Introduction: ops/intro.md
-    - Architecture: ops/architecture.md
-    - Protocol: ops/protocol.md
     - Deployment: ops/deployment.md
     - Agent/Oracle Config & Secrets: ops/agent-oracle-config-secrets.md
     - Oracle Role: ops/oracle-role.md

--- a/skills/antithesis-moog/SKILL.md
+++ b/skills/antithesis-moog/SKILL.md
@@ -12,10 +12,10 @@ description: MOOG CLI for Antithesis test management on Cardano. Setup using the
 ```bash
 cd /code/moog
 # Download the release binary (same as the GitHub Actions workflow uses).
-# Latest release is v0.5.1.4; asset naming changed at v0.5.x — the portable,
+# Latest release is v0.5.1.5; asset naming changed at v0.5.x — the portable,
 # statically-linked CLI is now `moog-<ver>-x86_64-linux-musl.tar.gz` (it
 # extracts a single `moog` binary; moog-agent / moog-oracle are separate assets).
-curl -sL "https://github.com/cardano-foundation/moog/releases/download/v0.5.1.4/moog-0.5.1.4-x86_64-linux-musl.tar.gz" | tar xz -C ./tmp/
+curl -sL "https://github.com/cardano-foundation/moog/releases/download/v0.5.1.5/moog-0.5.1.5-x86_64-linux-musl.tar.gz" | tar xz -C ./tmp/
 export PATH=/code/moog/tmp:$PATH
 source tmp/prod-setup.sh
 ```

--- a/skills/moog-guide/SKILL.md
+++ b/skills/moog-guide/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: moog-guide
+description: Repository guide for cardano-foundation/moog — administering Antithesis test execution through Cardano. Load when working in this repo or answering questions about it - the moog CLI and its subcommands (wallet, requester, agent, oracle, facts, token, retract, antithesis), the moog-oracle / moog-agent / moog-antithesis-proxy services, MOOG_* environment variables (MOOG_MPFS_HOST, MOOG_TOKEN_ID, MOOG_WALLET_FILE, MOOG_GITHUB_PAT, MOOG_ANTITHESIS_LAUNCH_URL), the MPFS service and on-chain facts, test-run phases (pending/accepted/finished/rejected), Antithesis run reconciliation, building with cabal/nix/just, release artifacts (musl tarballs, AppImage, deb, rpm), or the docs site under docs/.
+---
+
+# Moog repository guide
+
+## Repository map
+
+| Path | Purpose |
+|---|---|
+| `app/` | Executable entry points: `Main.hs` (CLI), `moog-oracle.hs`, `moog-agent.hs`, `moog-antithesis-proxy.hs`, `moog-mpfs-v2-canary.hs`, GitHub auth smoke tools |
+| `src/Cli.hs`, `src/Options.hs` | CLI command GADTs and the opt-env-conf root parser |
+| `src/Core/` | Shared types (wallet, facts, tx, mnemonics) and common options |
+| `src/Wallet/`, `src/User/Requester/`, `src/User/Agent/`, `src/Oracle/` | Per-role commands: wallet management, requester requests, agent automation, oracle validation and token updates |
+| `src/Oracle/Validate/` | Request validation rules (users, roles, whitelists, test-run transitions) |
+| `src/User/Agent/Antithesis/` | Agent-side Antithesis API client and pure reconciliation rules (`State.hs`, `Plan.hs`) |
+| `src/User/Antithesis/` | `moog antithesis` subcommands (read runs through the proxy) |
+| `src/Proxy/Antithesis/` | The antithesis proxy server: API, auth middleware, cache, audit |
+| `src/MPFS/` | MPFS HTTP API client |
+| `src/Lib/` | GitHub access, SSH keys, JSON canonicalization, crypto helpers |
+| `test/`, `test-integration/`, `test-E2E/`, `test-lib/` | Unit, integration and E2E suites plus shared test helpers |
+| `docs/`, `mkdocs.yml` | MkDocs Material documentation site (user, architecture, ops, dev) |
+| `nix/`, `flake.nix`, `justfile` | Build system: haskell.nix project, docker images, dev shell, recipes |
+| `CD/` | Production docker-compose files for oracle and agent |
+| `CI/`, `.github/workflows/` | CI tooling and workflows (unit, integration, E2E, releases, docs) |
+| `scripts/` | Operator helpers (`recent-runs.sh`, `wait-for-test.sh`) |
+
+## Build, test, run
+
+```bash
+nix develop              # dev shell: GHC 9.12, cabal, HLS, fourmolu, hlint, mkdocs
+just build               # cabal build all --enable-tests
+just unit                # unit tests (or: nix run .#unit-tests)
+just format              # fourmolu + cabal-fmt + nixfmt
+just hlint               # lint
+nix build .#moog         # build the CLI with nix (also: .#moog-oracle, .#moog-agent, .#moog-antithesis-proxy)
+mkdocs serve             # preview the docs site locally (inside nix develop)
+```
+
+Integration and E2E tests (`just integration`, `just E2E`) need Docker, a
+wallet file in `tmp/test.json` and the `MOOG_GITHUB_PAT` /
+`MOOG_SSH_PASSWORD` environment variables; read the recipes in `justfile`
+before running them.
+
+## Navigating the code
+
+- The CLI parser starts at `src/Options.hs` (`optionsParser`); each
+  subcommand group has its own `Options.hs` (parser) and `Cli.hs`
+  (interpreter) under `src/Wallet/`, `src/User/Requester/`,
+  `src/User/Agent/`, `src/Oracle/`. Options use opt-env-conf, so most
+  settings exist as flag + `MOOG_*` env var + YAML config key
+  simultaneously.
+- The oracle service loop is `src/Oracle/Process.hs`; validation logic
+  lives in `src/Oracle/Validate/Requests/`.
+- The agent service loop is `src/User/Agent/Process.hs` (`pollOnce`); the
+  pure decision rules that match Antithesis API runs to on-chain test-runs
+  and derive outcomes are in `src/User/Agent/Antithesis/State.hs` and
+  `Plan.hs`.
+- The proxy routes are declared in `src/Proxy/Antithesis/Api.hs` and served
+  in `Server.hs`; GitHub team auth is `Middleware/Auth.hs`.
+- On-chain fact types (test-run phases pending/accepted/finished/rejected)
+  are in `src/User/Types.hs` and `src/Core/Types/Fact.hs`.
+
+## Using moog
+
+The CLI needs `MOOG_MPFS_HOST` (production: `https://mpfs.plutimus.com`)
+and `MOOG_TOKEN_ID` for anything on-chain; see
+`docs/user/configuration.md` for the production token id.
+
+```bash
+moog wallet create --wallet wallet.json   # create a wallet
+moog wallet info --wallet wallet.json     # address + public key hash
+moog facts users                          # registered users (read-only)
+moog facts test-runs pending              # pending test-runs
+moog token                                # token state + pending requests
+moog requester create-test --platform github --username USER \
+    --repository ORG/REPO --directory DIR --commit SHA --try N --duration HOURS
+moog agent query                          # test-runs by phase, agent view
+moog antithesis runs --limit 10           # Antithesis runs via the proxy
+```
+
+Note: `moog oracle token boot` / `token end` were removed in v0.5.1.3
+(#144); only `moog oracle token update` and `moog oracle config set`
+remain. The MPFS v2 cutover happens on the `moog-v2` branch.
+
+## Answering questions
+
+- "What is moog / how does it work?" — README **What is this** +
+  **Architecture**; deeper: `docs/ops/architecture.md` and
+  `docs/ops/protocol.md`.
+- "How do I install / set up?" — `docs/user/installation.md` and
+  `docs/user/configuration.md` (wallet, env vars, production token).
+- "How do I request a test run?" — `docs/user/usage.md`; CI integration in
+  `docs/user/ci.md`.
+- "How do I run the oracle/agent in production?" — `docs/ops/deployment.md`,
+  `docs/ops/oracle-role.md`, `docs/ops/agent-role.md`,
+  `docs/ops/agent-oracle-config-secrets.md`; live-incident procedures in
+  `skills/antithesis-moog/SKILL.md`.
+- "Why is a test-run stuck / how are results derived?" — the
+  reconciliation rules in `src/User/Agent/Antithesis/State.hs` are the
+  source of truth; operator-facing summary in `docs/ops/agent-role.md` and
+  `docs/ops/troubleshooting.md`.
+- "What changed in release X?" — `CHANGELOG.md`.
+- The docs site is published at
+  <https://cardano-foundation.github.io/moog/>.


### PR DESCRIPTION
Documentation review against the actual state of the code at 83c984e (v0.5.1.5). Docs-only diff: README, docs/, mkdocs.yml, CHANGELOG, CONTRIBUTING, skills/, AGENTS.md.

## What was inaccurate

- README and docs/index banner claimed the current release is v0.5.1.4 and that `main` is frozen during the MPFS v2 migration; the repo is at v0.5.1.5 and #144 is closed, with work landing on `main` since.
- CONTRIBUTING and docs/user/installation still instructed `cd cli` and `nix shell github:cardano-foundation/moog?dir=cli#moog`; the `cli/` directory no longer exists.
- docs/ops/oracle-role, real-world, deployment and agent-oracle-config-secrets presented `moog oracle token boot` / `token end` / `token delete` as available commands; `src/Oracle/Token/Options.hs` exposes only `update` (removed in v0.5.1.3, #144).
- docs/ops/agent-role documented the email inbox as the only result path and drew it in the service-loop diagram; the service loop in `src/User/Agent/Process.hs` reconciles on-chain test-runs against the Antithesis REST API (`listAllRuns` + `planAgentPoll`), with email collection remaining only as manual legacy commands.
- `--poll-interval` default documented as 60; the parser default is 30 (`src/Oracle/Process.hs`). The oracle loop diagram attributed the poll cadence to `MOOG_WAIT`.
- `moog agent white-list`/`black-list` shown with positional arguments; the parser takes `--platform`/`--repository` flags (`src/Core/Options.hs`).
- The test-definition example link pointed at `cardano-foundation/moog/tree/main/compose/...`, which no longer exists; now points at `cardano-foundation/cardano-node-antithesis/tree/main/testnets/cardano_node_master`.
- CHANGELOG had no v0.5.1.5 entry although the release is tagged; added one summarized from the #175/#190/#191 commits.
- The antithesis-moog skill pinned v0.5.1.4 as the latest release.

## What changed

- README restructured into the org-standard section order (What is this / Architecture / Install / Quickstart / Usage / Documentation / Development / License), with a new mermaid architecture diagram, the actual release artifact names, and a quickstart against the production MPFS service.
- Agent-role service-loop diagram redrawn around the API reconciliation path; architecture diagrams updated (results via the Antithesis read API, not email parsing).
- mkdocs nav: Architecture and Protocol promoted to their own group.
- Agent layer added: `AGENTS.md` at the root and `skills/moog-guide/SKILL.md` (repository map, build/test/run, code navigation, verified CLI usage); the existing `skills/antithesis-moog` operations skill is referenced, not duplicated.

## How claims were verified

- CLI commands, flags, env vars and defaults checked against the opt-env-conf parsers (`src/Options.hs`, `src/Core/Options.hs`, `src/*/Options.hs`, `src/Oracle/Process.hs`, `src/User/Agent/Options.hs`).
- Agent result path checked against `src/User/Agent/Process.hs` and `src/User/Agent/Antithesis/State.hs`.
- Release artifact names checked against the v0.5.1.5 release assets (`gh release view`).
- Workflow badges checked against `.github/workflows/`.
- Site built with `mkdocs build --strict` (mkdocs-material + mkdocs-asciinema-player in a venv; the nix dev shell was not used) — passes.
- Every mermaid diagram in touched pages checked node-by-node against the code plus a scripted bracket/quote/subgraph balance check.
