### PR TITLE
fix(nix): alias lzma to xz so the dev shell evaluates

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,14 @@
         };
       };
 
+      # The Haskell `lzma` package declares `extra-libraries: lzma`, which
+      # haskell.nix resolves to the top-level `pkgs.lzma` attribute. Recent
+      # nixpkgs removed that attribute (it became `pkgs.xz`, which still
+      # provides liblzma), so the lookup threw "Nixpkgs package set does not
+      # contain the package: lzma" and broke `nix develop`. Restore the
+      # historical alias so the system-library mapping resolves again.
+      fix-lzma = final: prev: { lzma = prev.xz; };
+
       perSystem =
         system:
         let
@@ -79,6 +87,7 @@
               iohkNix.overlays.cardano-lib
               haskellNix.overlay # some functions
               fix-blst
+              fix-lzma
             ];
             inherit system;
           };


### PR DESCRIPTION
Extracted from #197 so the dev-shell fix can land independently of the blocked e2e work.

Recent nixpkgs removed the top-level `pkgs.lzma` attribute (liblzma now lives under `pkgs.xz`). The Haskell `lzma` package declares `extra-libraries: lzma`, which haskell.nix resolves to `pkgs.lzma`, so the lookup throws *"Nixpkgs package set does not contain the package: lzma"* and **`nix develop` on `moog-v2` fails for everyone**. This restores the historical alias via a one-line overlay (`fix-lzma = final: prev: { lzma = prev.xz; }`).

This is commit `4e75fb12` from #197, in isolation. It currently sits behind that PR's red self-hosted `e2e`/`integration` checks (runner contention), which has nothing to do with this fix — so the broken dev shell (and #200/#201 local + CI builds) stays hostage to an unrelated problem. Landing it on its own unblocks `nix develop` immediately; #197 keeps only the actual e2e harness work.

Verified: built `nix build .#moog` locally with this overlay applied.