### PR TITLE
fix(nix): make the dev shell build + gate it in CI (lmdb/liburing)

### DIFF
--- a/.github/workflows/dev-shell.yaml
+++ b/.github/workflows/dev-shell.yaml
@@ -1,0 +1,27 @@
+name: Dev shell
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      - moog-v2
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dev-shell:
+    name: nix develop builds and is usable
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: sudo rm -rf /opt&
+      - uses: actions/checkout@v6
+      - uses: paolino/dev-assets/setup-nix@v0.1.0
+        with:
+          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: nix develop -c builds the project
+        run: nix develop --accept-flake-config -c cabal build all -O0

--- a/.github/workflows/dev-shell.yaml
+++ b/.github/workflows/dev-shell.yaml
@@ -24,4 +24,6 @@ jobs:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: nix develop -c builds the project
-        run: nix develop --accept-flake-config -c cabal build all -O0
+        # A fresh runner has no cabal package index, so `cabal build`
+        # cannot resolve deps until the Hackage/CHaP index is fetched.
+        run: nix develop --accept-flake-config -c bash -c 'cabal update && cabal build -O0 all'

--- a/nix/moog-project.nix
+++ b/nix/moog-project.nix
@@ -43,6 +43,7 @@ let
         project.hsPkgs.bech32.components.exes.bech32
         pkgs.nixfmt-classic
         pkgs.lmdb.dev
+        pkgs.liburing.dev
         pkgs.mkdocs
         mkdocs.from-nixpkgs
         mkdocs.asciinema-plugin

--- a/nix/moog-project.nix
+++ b/nix/moog-project.nix
@@ -12,8 +12,6 @@ let
       lib.mkForce [[ pkgs.libsodium-vrf pkgs.secp256k1 ]];
     packages.cardano-crypto-class.components.library.pkgconfig =
       lib.mkForce [[ pkgs.libsodium-vrf pkgs.secp256k1 pkgs.libblst ]];
-    packages.cardano-lmdb.components.library.pkgconfig =
-      lib.mkForce [[ pkgs.lmdb.dev ]];
     packages.cardano-ledger-binary.components.library.doHaddock =
       lib.mkForce false;
     packages.plutus-core.components.library.doHaddock =

--- a/nix/moog-project.nix
+++ b/nix/moog-project.nix
@@ -12,6 +12,8 @@ let
       lib.mkForce [[ pkgs.libsodium-vrf pkgs.secp256k1 ]];
     packages.cardano-crypto-class.components.library.pkgconfig =
       lib.mkForce [[ pkgs.libsodium-vrf pkgs.secp256k1 pkgs.libblst ]];
+    packages.cardano-lmdb.components.library.pkgconfig =
+      lib.mkForce [[ pkgs.lmdb.dev ]];
     packages.cardano-ledger-binary.components.library.doHaddock =
       lib.mkForce false;
     packages.plutus-core.components.library.doHaddock =
@@ -40,6 +42,7 @@ let
         project.hsPkgs.cardano-addresses.components.exes.cardano-address
         project.hsPkgs.bech32.components.exes.bech32
         pkgs.nixfmt-classic
+        pkgs.lmdb.dev
         pkgs.mkdocs
         mkdocs.from-nixpkgs
         mkdocs.asciinema-plugin


### PR DESCRIPTION
Make `nix develop` usable again and guard it in CI so shell-only breakage can't slip through.

- **`nix/moog-project.nix`** — add `lmdb` + `liburing` to the dev shell so `cabal build` resolves `cardano-lmdb`. The packaged derivations (`nix run .#integration-tests`) already had these, but the interactive `shellFor` was missing `lmdb.pc`/`liburing.pc`, so local `cabal build` died at configure.
- **`.github/workflows/dev-shell.yaml`** — new gate running `nix develop --accept-flake-config -c cabal build -O0 all`. Packaged `nix build`/`nix run`/`nix flake check` never enter the dev shell, so shell-only breakage (this, and the earlier `lzma`→`xz`) was invisible to CI until it hit local dev. To be marked a required check on moog-v2.

Verified locally: `nix develop --accept-flake-config -c cabal build -O0 all` exits 0.