### PR TITLE
Oracle reject: expose Phase-3 request reject

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+nix develop --accept-flake-config -c bash -c '
+  set -euo pipefail
+  cabal update
+  cabal build -O0 all
+  cabal test unit-tests --test-show-details=direct
+'

--- a/moog.cabal
+++ b/moog.cabal
@@ -136,6 +136,7 @@ library
     MPFS.Devnet
     MPFS.End
     MPFS.Read
+    MPFS.Reject
     MPFS.Request
     MPFS.Retract
     MPFS.Update

--- a/moog.cabal
+++ b/moog.cabal
@@ -498,6 +498,7 @@ test-suite unit-tests
     MPFS.ReadSpec
     MPFS.WriteFactsSpec
     Oracle.Config.CliSpec
+    Oracle.Token.CliSpec
     Oracle.Config.TypesSpec
     Oracle.TypesSpec
     Oracle.Validate.Requests.ConfigSpec

--- a/specs/201-oracle-reject/plan.md
+++ b/specs/201-oracle-reject/plan.md
@@ -1,0 +1,72 @@
+# Plan — #201 oracle reject
+
+## Tech Stack
+
+Haskell + Servant client (`MPFS.API`), `cardano-mpfs-offchain` reject facts and
+cage builders, OptEnvConf CLI parsers, Hspec unit/integration tests, Nix dev
+shell gate. The branch targets `moog-v2`.
+
+## Modules In Scope
+
+- `src/MPFS/Reject.hs` — new reject helper mirroring `MPFS.Update`.
+- `src/MPFS/API.hs` — `/facts/reject` endpoint, MPFS record field, client wiring.
+- `src/Oracle/Token/{Cli,Options}.hs` — `RejectToken` command and parser.
+- `moog.cabal` — expose new module and any new spec module.
+- `test/MPFS/WriteFactsSpec.hs`, `test/MockMPFS.hs` — request-body and record tests.
+- `test/Oracle/Token/CliSpec.hs` — token reject command behavior tests.
+- `test-integration/MPFS/APISpec.hs` or a focused integration spec — live MPFS
+  reject proof if the existing harness can support the timing wait without
+  secrets.
+
+## Slice S1 — MPFS Reject Foundation
+
+RED: unit tests for `rejectTokenFactsRequest` and `mpfsRejectTokenFromFacts` on
+the MPFS record. GREEN: add `MPFS.Reject`, wire `RejectFactsEndpoint` in
+`MPFS.API`, expose the new record field, and update `moog.cabal`.
+
+The helper should mirror `MPFS.Update`: build the request body from token id,
+address, and request refs; read `currentUtxoRoot`; `POST /facts/reject`; verify
+with `verifyRejectFacts`; call `rejectCageTxWithEval`; return `WithUnsignedTx`.
+
+## Slice S2 — Oracle Token Reject CLI
+
+RED: unit tests for `tokenCmdCore (RejectToken ...)` and `oracle token reject`
+parsing. GREEN: add `RejectToken`, reuse update-style token parsing,
+oracle-owner check, pending-ref lookup, and non-empty-subset validation, then
+submit through `mpfsRejectTokenFromFacts`.
+
+Local token decoding does not currently retain request `submittedAt`, request
+fee, or config process/retract times. The CLI must therefore require explicit
+request refs and fail closed through `/facts/reject` plus `verifyRejectFacts`
+for Phase-3 eligibility, rather than trying to infer rejectability from partial
+local data.
+
+## Slice S3 — Reject Boundary Proof
+
+RED: add the narrowest integration or smoke test the existing MPFS harness can
+run: boot a token with short process/retract windows, create a pending request,
+wait until it is rejectable, call the reject command or MPFS reject operation,
+and assert the token root is unchanged while the request disappears. Also prove
+a processable request subset is refused if the harness can make that stable.
+
+GREEN: implement only the test-support code needed for this proof. If the live
+boundary requires preprod credentials or an operator wallet not available in CI,
+write an explicit smoke recipe and capture local evidence in `WIP.md` instead
+of weakening the automated gate.
+
+## Gate
+
+Per-slice focused tests:
+
+- S1: `nix develop --accept-flake-config -c cabal test unit-tests --test-show-details=direct --test-option=--match --test-option="facts-based MPFS write requests"`
+- S2: `nix develop --accept-flake-config -c cabal test unit-tests --test-show-details=direct --test-option=--match --test-option="Oracle.Token.Cli"`
+- S3: focused integration command selected by the slice based on the harness.
+
+Final gate: `./gate.sh`.
+
+## Order Rationale
+
+S1 creates the MPFS operation the CLI consumes. S2 adds the user-facing command
+with local validation and submission. S3 exercises the live MPFS boundary after
+the command path exists.
+

--- a/specs/201-oracle-reject/spec.md
+++ b/specs/201-oracle-reject/spec.md
@@ -1,0 +1,59 @@
+# Spec — #201 oracle reject for expired/dishonest requests
+
+Parent epic: #181. Branch base: `moog-v2`. PR target: `moog-v2`.
+
+## P1 User Story
+
+As an oracle operator, I run a moog reject command and observe expired or
+dishonest pending requests cleared from the token, with request owners refunded
+by the on-chain Phase-3 path.
+
+## Context
+
+The oracle update path already validates chosen pending requests and submits a
+facts-built cage transaction through `MPFS.Update` and `MPFS.API`. The MPFS
+offchain server already exposes `POST /facts/reject`, but moog does not surface
+that endpoint in its MPFS record or in `oracle token`.
+
+`Oracle.Types` already includes `RejectRequest` for a test-run rejection fact.
+That is separate from the MPFS Phase-3 reject operation in this ticket: the new
+command rejects pending request UTxOs at the cage layer instead of creating an
+agent-level rejected test-run fact.
+
+## Functional Requirements
+
+- FR1 — `MPFS.API` exposes `POST /facts/reject`, verifies returned reject facts
+  against the current trusted root, and builds the unsigned cage reject
+  transaction with the offchain reject builder.
+- FR2 — the `MPFS m` record has an `mpfsRejectTokenFromFacts` operation that
+  mirrors `mpfsUpdateTokenFromFacts` and accepts a token plus an explicit
+  non-empty request-ref subset.
+- FR3 — moog exposes `oracle token reject -t/--token-id ... -w/--wallet ... -o
+  <request-ref>...` and submits through `mpfsRejectTokenFromFacts`.
+- FR4 — the reject command is oracle-only: the signing wallet owner must match
+  the token owner, the token must parse, the token must have pending requests,
+  every requested ref must exist on the token, and an empty subset fails before
+  submission.
+- FR5 — wrong subsets fail closed. A processable request or otherwise
+  non-rejectable request must not be silently included; MPFS `/facts/reject` and
+  `verifyRejectFacts` are the source of truth for Phase-3 eligibility.
+- FR6 — the MPF root is unchanged by a successful reject; rejected request UTxOs
+  are consumed and owner refunds are produced according to the on-chain
+  conservation rule.
+
+## Success Criteria
+
+- Unit tests prove reject request-body construction, MPFS record wiring, and
+  `oracle token reject` routing/validation behavior.
+- The focused gate passes for each slice and the final `./gate.sh` passes at
+  HEAD.
+- Integration or live-boundary evidence demonstrates an expired request can be
+  rejected against MPFS and that a non-expired/processable subset is refused.
+
+## Non-Goals
+
+- Requester-side retract; `moog retract` already covers Phase 2.
+- Changing validator economics, refund math, tip policy, or token boot
+  parameters.
+- Changing the agent `reject-test` command or test-run rejection fact semantics.
+

--- a/specs/201-oracle-reject/tasks.md
+++ b/specs/201-oracle-reject/tasks.md
@@ -6,9 +6,9 @@
 - [X] T201-S1 Proof: focused MPFS write-facts unit tests and `./gate.sh` pass.
 
 ## Slice S2 — oracle token reject CLI
-- [ ] T201-S2 RED unit tests for `RejectToken` validation/submission and parser shape.
-- [ ] T201-S2 GREEN `oracle token reject` command requiring explicit `-o <request-ref>` refs and routing through `mpfsRejectTokenFromFacts`.
-- [ ] T201-S2 Proof: focused Oracle.Token.Cli unit tests and `./gate.sh` pass.
+- [X] T201-S2 RED unit tests for `RejectToken` validation/submission and parser shape.
+- [X] T201-S2 GREEN `oracle token reject` command requiring explicit `-o <request-ref>` refs and routing through `mpfsRejectTokenFromFacts`.
+- [X] T201-S2 Proof: focused Oracle.Token.Cli unit tests and `./gate.sh` pass.
 
 ## Slice S3 — reject boundary proof
 - [ ] T201-S3 RED integration/smoke proof for expired-request reject and fail-closed processable subset.

--- a/specs/201-oracle-reject/tasks.md
+++ b/specs/201-oracle-reject/tasks.md
@@ -1,9 +1,9 @@
 # Tasks — #201 oracle reject
 
 ## Slice S1 — MPFS reject foundation
-- [ ] T201-S1 RED unit tests for `rejectTokenFactsRequest` and MPFS record wiring.
-- [ ] T201-S1 GREEN `MPFS.Reject`, `/facts/reject` endpoint, `mpfsRejectTokenFromFacts`, and cabal module exposure.
-- [ ] T201-S1 Proof: focused MPFS write-facts unit tests and `./gate.sh` pass.
+- [X] T201-S1 RED unit tests for `rejectTokenFactsRequest` and MPFS record wiring.
+- [X] T201-S1 GREEN `MPFS.Reject`, `/facts/reject` endpoint, `mpfsRejectTokenFromFacts`, and cabal module exposure.
+- [X] T201-S1 Proof: focused MPFS write-facts unit tests and `./gate.sh` pass.
 
 ## Slice S2 — oracle token reject CLI
 - [ ] T201-S2 RED unit tests for `RejectToken` validation/submission and parser shape.
@@ -14,4 +14,3 @@
 - [ ] T201-S3 RED integration/smoke proof for expired-request reject and fail-closed processable subset.
 - [ ] T201-S3 GREEN harness support or documented operator smoke recipe for any non-CI live-boundary portion.
 - [ ] T201-S3 Proof: focused integration/smoke command and `./gate.sh` pass.
-

--- a/specs/201-oracle-reject/tasks.md
+++ b/specs/201-oracle-reject/tasks.md
@@ -1,0 +1,17 @@
+# Tasks — #201 oracle reject
+
+## Slice S1 — MPFS reject foundation
+- [ ] T201-S1 RED unit tests for `rejectTokenFactsRequest` and MPFS record wiring.
+- [ ] T201-S1 GREEN `MPFS.Reject`, `/facts/reject` endpoint, `mpfsRejectTokenFromFacts`, and cabal module exposure.
+- [ ] T201-S1 Proof: focused MPFS write-facts unit tests and `./gate.sh` pass.
+
+## Slice S2 — oracle token reject CLI
+- [ ] T201-S2 RED unit tests for `RejectToken` validation/submission and parser shape.
+- [ ] T201-S2 GREEN `oracle token reject` command requiring explicit `-o <request-ref>` refs and routing through `mpfsRejectTokenFromFacts`.
+- [ ] T201-S2 Proof: focused Oracle.Token.Cli unit tests and `./gate.sh` pass.
+
+## Slice S3 — reject boundary proof
+- [ ] T201-S3 RED integration/smoke proof for expired-request reject and fail-closed processable subset.
+- [ ] T201-S3 GREEN harness support or documented operator smoke recipe for any non-CI live-boundary portion.
+- [ ] T201-S3 Proof: focused integration/smoke command and `./gate.sh` pass.
+

--- a/specs/201-oracle-reject/tasks.md
+++ b/specs/201-oracle-reject/tasks.md
@@ -11,6 +11,6 @@
 - [X] T201-S2 Proof: focused Oracle.Token.Cli unit tests and `./gate.sh` pass.
 
 ## Slice S3 — reject boundary proof
-- [ ] T201-S3 RED integration/smoke proof for expired-request reject and fail-closed processable subset.
-- [ ] T201-S3 GREEN harness support or documented operator smoke recipe for any non-CI live-boundary portion.
-- [ ] T201-S3 Proof: focused integration/smoke command and `./gate.sh` pass.
+- [X] T201-S3 RED integration/smoke proof for expired-request reject and fail-closed processable subset.
+- [X] T201-S3 GREEN harness support or documented operator smoke recipe for any non-CI live-boundary portion.
+- [X] T201-S3 Proof: focused integration/smoke command and `./gate.sh` pass.

--- a/src/MPFS/API.hs
+++ b/src/MPFS/API.hs
@@ -4,6 +4,7 @@ module MPFS.API
     , requestUpdateFromFacts
     , retractChangeFromFacts
     , updateTokenFromFacts
+    , rejectTokenFromFacts
     , getToken
     , getTokenV2
     , getTokenFacts
@@ -31,6 +32,7 @@ import Cardano.MPFS.API.Types
     , RequestDeleteFacts
     , RequestInsertFacts
     , RequestUpdateFacts
+    , RejectRequest
     , RequestsResponse
     , RetractFacts
     , RetractRequest
@@ -42,7 +44,7 @@ import Cardano.MPFS.API.Types
     , UpdateValueRequest
     )
 import Cardano.MPFS.API.Encoding (Hex (..))
-import Cardano.MPFS.API.Types.Facts (UpdateFacts)
+import Cardano.MPFS.API.Types.Facts (RejectFacts, UpdateFacts)
 import Control.Monad (void)
 import Core.Types.Basic (Address, RequestRefId, TokenId)
 import Core.Types.Tx (SignedTx (..), TxHash (..), WithUnsignedTx)
@@ -63,6 +65,7 @@ import MPFS.Request
     , RequestUpdateBody (..)
     )
 import MPFS.Request qualified as Request
+import MPFS.Reject qualified as Reject
 import MPFS.Retract qualified as Retract
 import MPFS.Update qualified as Update
 import Servant.API
@@ -122,6 +125,12 @@ type UpdateFactsEndpoint =
         :> "update"
         :> ReqBody '[JSON] UpdateRequest
         :> Post '[JSON] UpdateFacts
+
+type RejectFactsEndpoint =
+    "facts"
+        :> "reject"
+        :> ReqBody '[JSON] RejectRequest
+        :> Post '[JSON] RejectFacts
 
 type RetractFactsEndpoint =
     "facts"
@@ -203,6 +212,14 @@ updateTokenFromFacts
 updateTokenFromFacts =
     Update.updateTokenFromFacts status' updateFacts'
 
+rejectTokenFromFacts
+    :: Address
+    -> TokenId
+    -> [RequestRefId]
+    -> ClientM (WithUnsignedTx JSValue)
+rejectTokenFromFacts =
+    Reject.rejectTokenFromFacts status' rejectFacts'
+
 retractChangeFromFacts
     :: Address -> RequestRefId -> ClientM (WithUnsignedTx JSValue)
 retractChangeFromFacts =
@@ -277,6 +294,10 @@ updateFacts' :: UpdateRequest -> ClientM UpdateFacts
 updateFacts' =
     client (Proxy :: Proxy UpdateFactsEndpoint)
 
+rejectFacts' :: RejectRequest -> ClientM RejectFacts
+rejectFacts' =
+    client (Proxy :: Proxy RejectFactsEndpoint)
+
 retractFacts' :: RetractRequest -> ClientM RetractFacts
 retractFacts' =
     client (Proxy :: Proxy RetractFactsEndpoint)
@@ -309,6 +330,7 @@ mpfsClient =
         , mpfsRequestUpdateFromFacts = requestUpdateFromFacts
         , mpfsRetractChangeFromFacts = retractChangeFromFacts
         , mpfsUpdateTokenFromFacts = updateTokenFromFacts
+        , mpfsRejectTokenFromFacts = rejectTokenFromFacts
         , mpfsGetToken = getToken
         , mpfsGetTokenFacts = getTokenFacts
         }
@@ -336,6 +358,11 @@ data MPFS m = MPFS
         -> RequestRefId
         -> m (WithUnsignedTx JSValue)
     , mpfsUpdateTokenFromFacts
+        :: Address
+        -> TokenId
+        -> [RequestRefId]
+        -> m (WithUnsignedTx JSValue)
+    , mpfsRejectTokenFromFacts
         :: Address
         -> TokenId
         -> [RequestRefId]

--- a/src/MPFS/Reject.hs
+++ b/src/MPFS/Reject.hs
@@ -1,0 +1,81 @@
+module MPFS.Reject
+    ( rejectTokenFromFacts
+    , rejectTokenFactsRequest
+    ) where
+
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types
+    ( RejectRequest (..)
+    , StatusResponse (..)
+    )
+import Cardano.MPFS.API.Types.Facts (RejectFacts)
+import Cardano.MPFS.Client.Cage.Reject (rejectCageTxWithEval)
+import Cardano.MPFS.Client.Facts (verifyRejectFacts)
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Control.Monad.IO.Class (liftIO)
+import Core.Types.Basic
+    ( Address
+    , RequestRefId (requestId)
+    , TokenId
+    )
+import Core.Types.Tx
+    ( UnsignedTx (..)
+    , WithUnsignedTx (..)
+    )
+import MPFS.Cage
+    ( addressBytesForCage
+    , liftEitherClientM
+    , loadCageConfig
+    , resolveEvalContext
+    , txHex
+    , walletPolicy
+    )
+import MPFS.End (tokenIdJSONFromTokenId)
+import Servant.Client (ClientM)
+import Text.JSON.Canonical (JSValue)
+
+rejectTokenFromFacts
+    :: ClientM StatusResponse
+    -> (RejectRequest -> ClientM RejectFacts)
+    -> Address
+    -> TokenId
+    -> [RequestRefId]
+    -> ClientM (WithUnsignedTx JSValue)
+rejectTokenFromFacts getStatus postFacts address tokenId requests = do
+    request <- liftEitherClientM $ rejectTokenFactsRequest address tokenId requests
+    StatusResponse{currentUtxoRoot} <- getStatus
+    trustedRoot <-
+        liftEitherClientM $ maybeToEither noUtxoRoot currentUtxoRoot
+    facts <- postFacts request
+    verified <-
+        liftEitherClientM
+            $ firstShow
+            $ verifyRejectFacts (TrustedRoot trustedRoot) facts
+    rawAddress <- liftEitherClientM $ addressBytesForCage address
+    cfg <- liftIO $ loadCageConfig rawAddress
+    evalCtx <- resolveEvalContext
+    tx <-
+        liftEitherClientM
+            $ firstShow
+            $ rejectCageTxWithEval evalCtx cfg walletPolicy verified
+    pure $ WithUnsignedTx (UnsignedTx $ txHex tx) Nothing
+
+rejectTokenFactsRequest
+    :: Address -> TokenId -> [RequestRefId] -> Either String RejectRequest
+rejectTokenFactsRequest address tokenId requests =
+    RejectRequest
+        <$> tokenIdJSONFromTokenId tokenId
+        <*> (Hex <$> addressBytesForCage address)
+        <*> pure (requestId <$> requests)
+
+firstShow :: Show e => Either e a -> Either String a
+firstShow =
+    either (Left . show) Right
+
+maybeToEither :: e -> Maybe a -> Either e a
+maybeToEither e =
+    maybe (Left e) Right
+
+noUtxoRoot :: String
+noUtxoRoot =
+    "GET /status returned no utxo_root; MPFS indexer is not ready"

--- a/src/Oracle/Token/Cli.hs
+++ b/src/Oracle/Token/Cli.hs
@@ -2,6 +2,9 @@ module Oracle.Token.Cli
     ( tokenCmdCore
     , TokenCommand (..)
     , TokenUpdateFailure (..)
+    , TokenRejectFailure (..)
+    , TokenRejectRequestValidation (..)
+    , TokenRejectRequestValidationProblem (..)
     , BootParams (..)
     ) where
 
@@ -89,6 +92,38 @@ data TokenUpdateFailure
 
 instance Exception TokenUpdateFailure
 
+data TokenRejectRequestValidation = TokenRejectRequestValidation
+    { rejectValidationRequestId :: RequestRefId
+    , rejectProblem :: TokenRejectRequestValidationProblem
+    }
+    deriving (Show, Eq)
+
+instance Monad m => ToJSON m TokenRejectRequestValidation where
+    toJSON (TokenRejectRequestValidation reqId problem) =
+        object
+            [ "requestId" .= reqId
+            , "problem" .= problem
+            ]
+
+data TokenRejectRequestValidationProblem
+    = TokenRejectRequestNotFound
+    deriving (Show, Eq)
+
+instance Monad m => ToJSON m TokenRejectRequestValidationProblem where
+    toJSON = \case
+        TokenRejectRequestNotFound ->
+            toJSON ("Request not found" :: String)
+
+data TokenRejectFailure
+    = TokenRejectNotParsable TokenId
+    | TokenRejectOfNoRequests
+    | TokenRejectRequestValidations
+        [TokenRejectRequestValidation]
+    | TokenRejectNotRequestedFromTokenOwner
+    deriving (Show, Eq)
+
+instance Exception TokenRejectFailure
+
 data TokenBootFailure
     = NoTokenIdReturned
     | TokenIdNotValidJSON
@@ -114,6 +149,17 @@ instance Monad m => ToJSON m TokenUpdateFailure where
         TokenUpdateNotRequestedFromTokenOwner ->
             toJSON ("Token update not requested from token owner" :: String)
 
+instance Monad m => ToJSON m TokenRejectFailure where
+    toJSON = \case
+        TokenRejectNotParsable tk ->
+            object ["tokenRejectNotParsable" .= tk]
+        TokenRejectOfNoRequests ->
+            toJSON ("No requests to reject" :: String)
+        TokenRejectRequestValidations validations ->
+            object ["tokenRejectRequestValidations" .= validations]
+        TokenRejectNotRequestedFromTokenOwner ->
+            toJSON ("Token reject not requested from token owner" :: String)
+
 data TokenCommand a where
     BootToken
         :: Wallet
@@ -127,6 +173,15 @@ data TokenCommand a where
         -> TokenCommand
             ( AValidationResult
                 TokenUpdateFailure
+                TxHash
+            )
+    RejectToken
+        :: TokenId
+        -> Wallet
+        -> [RequestRefId]
+        -> TokenCommand
+            ( AValidationResult
+                TokenRejectFailure
                 TxHash
             )
     EndToken :: TokenId -> Wallet -> TokenCommand TxHash
@@ -180,6 +235,29 @@ tokenCmdCore command = do
                 WithTxHash txHash _ <- lift
                     $ submit
                     $ \address -> mpfsUpdateTokenFromFacts mpfs address tk wanted
+                pure txHash
+        RejectToken tk wallet wanted -> do
+            Submission submit <- askSubmit wallet
+            lift $ runValidate $ do
+                when (null wanted) $ notValidated TokenRejectOfNoRequests
+                mpendings <- lift $ fromJSON <$> mpfsGetToken mpfs tk
+                token <- liftMaybe (TokenRejectNotParsable tk) mpendings
+                let requests = tokenRequests token
+                    oracle = tokenOwner $ tokenState token
+                when (owner wallet /= oracle)
+                    $ notValidated TokenRejectNotRequestedFromTokenOwner
+                when (null requests) $ notValidated TokenRejectOfNoRequests
+                void
+                    $ mapFailure TokenRejectRequestValidations
+                    $ sequenceValidate
+                    $ wanted
+                    <&> \req ->
+                        liftMaybe
+                            (TokenRejectRequestValidation req TokenRejectRequestNotFound)
+                            $ find ((== req) . requestZooRefId . runIdentity) requests
+                WithTxHash txHash _ <- lift
+                    $ submit
+                    $ \address -> mpfsRejectTokenFromFacts mpfs address tk wanted
                 pure txHash
         BootToken wallet bootParams -> do
             Submission submit <- askSubmit wallet

--- a/src/Oracle/Token/Options.hs
+++ b/src/Oracle/Token/Options.hs
@@ -12,6 +12,7 @@ import Core.Options
     , tokenIdOption
     , walletOption
     )
+import Core.Types.Basic (TokenId (..))
 import Lib.Box (Box (..))
 import OptEnvConf
     ( Alternative (many)
@@ -26,6 +27,8 @@ import OptEnvConf
     , option
     , reader
     , setting
+    , short
+    , str
     , value
     )
 import Oracle.Token.Cli
@@ -42,6 +45,11 @@ tokenCommandParser =
                 <$> tokenIdOption
                 <*> walletOption
                 <*> many outputReferenceParser
+        , command "reject" "Reject token requests"
+            $ fmap (fmap Box) . RejectToken
+                <$> rejectTokenIdOption
+                <*> walletOption
+                <*> many outputReferenceParser
         , command "boot" "Boot a new token"
             $ fmap Box . BootToken
                 <$> walletOption
@@ -49,6 +57,19 @@ tokenCommandParser =
         , command "end" "End the token"
             $ fmap Box . EndToken <$> tokenIdOption <*> walletOption
         ]
+
+rejectTokenIdOption :: Parser TokenId
+rejectTokenIdOption =
+    TokenId
+        <$> setting
+            [ env "MOOG_TOKEN_ID"
+            , long "token-id"
+            , short 't'
+            , metavar "TOKEN"
+            , help "The token ID of the antithesis token"
+            , reader str
+            , option
+            ]
 
 -- | Operator-supplied boot economics. Defaults are network-safe, not
 -- the devnet 5s windows: a request stays processable long enough for

--- a/test-integration/MPFS/APISpec.hs
+++ b/test-integration/MPFS/APISpec.hs
@@ -18,6 +18,7 @@ import Cardano.Ledger.Binary
     , decodeFullAnnotator
     )
 import Cardano.Tx.Ledger (ConwayTx)
+import Control.Monad (when)
 import Control.Concurrent (threadDelay)
 import Control.Exception (throwIO)
 import Control.Lens ((^.))
@@ -26,6 +27,7 @@ import Control.Monad.IO.Class (MonadIO (..))
 import Core.Context (withContext)
 import Core.Types.Basic
     ( Owner (..)
+    , RequestRefId
     , TokenId (..)
     )
 import Core.Types.CageDatum (CageDatum (..))
@@ -34,7 +36,8 @@ import Core.Types.Fact (Fact (..), parseFacts)
 import Core.Types.Mnemonics (Mnemonics (..))
 import Core.Types.Operation (Op (..), Operation (..))
 import Core.Types.Tx
-    ( TxHash
+    ( Root
+    , TxHash
     , UnsignedTx (..)
     , WithTxHash (..)
     , WithUnsignedTx (..)
@@ -77,11 +80,13 @@ import Oracle.Config.Types
     )
 import Oracle.Token.Cli
     ( TokenCommand (..)
+    , TokenRejectFailure
     , tokenCmdCore
     )
 import Oracle.Types
     ( RequestZoo (..)
     , Token (..)
+    , TokenState (..)
     , requestZooRefId
     )
 import Oracle.Validate.Requests.TestRun.Config
@@ -92,7 +97,7 @@ import PlutusTx (Data (..), FromData, fromData)
 import Servant.Client (ClientM, mkClientEnv, parseBaseUrl, runClientM)
 import Submitting
     ( IfToWait (..)
-    , Submission
+    , Submission (..)
     , Submitting (..)
     , readWallet
     , signAndSubmitMPFS
@@ -221,6 +226,15 @@ data Context = Context
     , auth :: Auth
     }
 
+data RejectBoundaryProof = RejectBoundaryProof
+    { rejectBoundaryRejectedRequest :: RequestRefId
+    , rejectBoundaryRootBefore :: Root
+    , rejectBoundaryRootAfter :: Root
+    , rejectBoundaryPendingBefore :: [RequestRefId]
+    , rejectBoundaryPendingAfter :: [RequestRefId]
+    , rejectBoundaryProcessableRefused :: Bool
+    }
+
 setup :: Auth -> IO Context
 setup auth = do
     requesterWallet <- loadRequesterWallet
@@ -314,6 +328,110 @@ pollToken (Call call) tk ok = go (180 :: Int)
             _ -> do
                 threadDelay 1000000
                 go (n - 1)
+
+pendingRequestRefs :: Token Identity -> [RequestRefId]
+pendingRequestRefs =
+    fmap (requestZooRefId . runIdentity) . tokenRequests
+
+submitBoundaryInsert :: Context -> JSValue -> JSValue -> IO RequestRefId
+submitBoundaryInsert Context{mpfs, wait180S, tokenId, requesterWallet} key value = do
+    WithTxHash txHash _ <-
+        calling mpfs
+            $ submit (wait180S requesterWallet)
+            $ \address ->
+                requestInsertFromFacts address tokenId
+                    $ RequestInsertBody key value
+    waitTx mpfs txHash
+    pending <- pollToken mpfs tokenId $ not . null . tokenRequests
+    case pendingRequestRefs pending of
+        [reqId] -> pure reqId
+        reqIds ->
+            expectationFailure
+                ( "expected one pending boundary request, got "
+                    <> show reqIds
+                )
+                >> error "unreachable"
+
+rejectBoundaryRequest
+    :: Context
+    -> RequestRefId
+    -> IO (AValidationResult TokenRejectFailure TxHash)
+rejectBoundaryRequest Context{mpfs, wait180S, tokenId, oracleWallet, auth} reqId =
+    calling mpfs
+        $ withContext mpfsClient (mkEffects auth) wait180S
+        $ tokenCmdCore
+        $ RejectToken tokenId oracleWallet [reqId]
+
+rejectBoundaryRequestRefused :: Context -> RequestRefId -> IO Bool
+rejectBoundaryRequestRefused ctx reqId =
+    ( do
+        result <- rejectBoundaryRequest ctx reqId
+        case result of
+            ValidationFailure _ -> pure True
+            ValidationSuccess _ -> pure False
+    )
+        `catch` \(_ :: SomeException) -> pure True
+
+rejectBoundaryProof :: Context -> IO RejectBoundaryProof
+rejectBoundaryProof ctx@Context{mpfs, tokenId} = do
+    _ <- pollToken mpfs tokenId $ null . tokenRequests
+    rejectedRequest <-
+        submitBoundaryInsert
+            ctx
+            (JSString "moog/reject-boundary/expired")
+            (JSString "reject-me")
+
+    -- canaryBootParams uses 5s process and 5s retract windows.
+    threadDelay 12000000
+    beforeReject <-
+        pollToken mpfs tokenId
+            $ (== [rejectedRequest]) . pendingRequestRefs
+    let rejectBoundaryRootBefore = tokenRoot $ tokenState beforeReject
+        rejectBoundaryPendingBefore = pendingRequestRefs beforeReject
+
+    rejectResult <- rejectBoundaryRequest ctx rejectedRequest
+    rejectTxHash <- case rejectResult of
+        ValidationSuccess txHash -> pure txHash
+        ValidationFailure err ->
+            expectationFailure
+                ("expired reject was refused: " <> show err)
+                >> error "unreachable"
+    waitTx mpfs rejectTxHash
+    afterReject <-
+        pollToken mpfs tokenId
+            $ notElem rejectedRequest . pendingRequestRefs
+    let rejectBoundaryRootAfter = tokenRoot $ tokenState afterReject
+        rejectBoundaryPendingAfter = pendingRequestRefs afterReject
+
+    freshRequest <-
+        submitBoundaryInsert
+            ctx
+            (JSString "moog/reject-boundary/fresh")
+            (JSString "reject-too-early")
+    rejectBoundaryProcessableRefused <-
+        rejectBoundaryRequestRefused ctx freshRequest
+    when rejectBoundaryProcessableRefused $ do
+        threadDelay 12000000
+        cleanupResult <- rejectBoundaryRequest ctx freshRequest
+        cleanupTxHash <- case cleanupResult of
+            ValidationSuccess txHash -> pure txHash
+            ValidationFailure err ->
+                expectationFailure
+                    ("cleanup reject was refused: " <> show err)
+                    >> error "unreachable"
+        waitTx mpfs cleanupTxHash
+        _ <- pollToken mpfs tokenId $ null . tokenRequests
+        pure ()
+
+    pure
+        RejectBoundaryProof
+            { rejectBoundaryRejectedRequest = rejectedRequest
+            , rejectBoundaryRootBefore
+            , rejectBoundaryRootAfter
+            , rejectBoundaryPendingBefore
+            , rejectBoundaryPendingAfter
+            , rejectBoundaryProcessableRefused
+            }
 
 setupAction :: ActionWith Context -> ActionWith Auth
 setupAction action auth = do
@@ -482,3 +600,11 @@ mpfsAPISpec = aroundAllWith setupAction $ do
                     factValue
                     (parseFacts factsJson :: [Fact ConfigKey Config])
                     `shouldBe` [config]
+        it "rejects an expired request without changing the token root and refuses a fresh reject"
+            $ \ctx@Context{} -> do
+                RejectBoundaryProof{..} <- rejectBoundaryProof ctx
+                rejectBoundaryPendingBefore
+                    `shouldBe` [rejectBoundaryRejectedRequest]
+                rejectBoundaryPendingAfter `shouldBe` []
+                rejectBoundaryRootAfter `shouldBe` rejectBoundaryRootBefore
+                rejectBoundaryProcessableRefused `shouldBe` True

--- a/test/MPFS/WriteFactsSpec.hs
+++ b/test/MPFS/WriteFactsSpec.hs
@@ -4,6 +4,7 @@ import Cardano.MPFS.API.Encoding (Hex (..))
 import Cardano.MPFS.API.Types
     ( DeleteRequest (..)
     , InsertRequest (..)
+    , RejectRequest (..)
     , RetractRequest (..)
     , UpdateRequest (..)
     , UpdateValueRequest (..)
@@ -29,6 +30,7 @@ import MPFS.API
     , RequestInsertBody (..)
     , RequestUpdateBody (..)
     )
+import MPFS.Reject (rejectTokenFactsRequest)
 import MPFS.Request
     ( requestDeleteFactsRequest
     , requestInsertFactsRequest
@@ -98,6 +100,17 @@ spec =
                     urAddr `shouldBe` Hex sampleAddressBytes
                     urRequests `shouldBe` [requestId sampleRequestRef]
 
+        it "builds POST /facts/reject request bodies" $
+            case rejectTokenFactsRequest
+                sampleAddress
+                sampleToken
+                [sampleRequestRef] of
+                Left err -> error err
+                Right RejectRequest{..} -> do
+                    rejToken `shouldBe` sampleTokenJSON
+                    rejAddr `shouldBe` Hex sampleAddressBytes
+                    rejRequests `shouldBe` [requestId sampleRequestRef]
+
         it "builds POST /facts/retract request bodies" $
             case retractFactsRequest sampleAddress sampleRequestRef of
                 Left err -> error err
@@ -126,12 +139,22 @@ spec =
                             \_ _ _ -> Identity tx
                         , mpfsUpdateTokenFromFacts =
                             \_ _ _ -> Identity tx
+                        , mpfsRejectTokenFromFacts =
+                            \_ _ _ -> Identity tx
                         , mpfsRetractChangeFromFacts =
                             \_ _ -> Identity tx
                         }
 
             runIdentity
                 ( mpfsUpdateTokenFromFacts
+                    mpfs
+                    sampleAddress
+                    sampleToken
+                    [sampleRequestRef]
+                )
+                `shouldBe` tx
+            runIdentity
+                ( mpfsRejectTokenFromFacts
                     mpfs
                     sampleAddress
                     sampleToken

--- a/test/MockMPFS.hs
+++ b/test/MockMPFS.hs
@@ -35,6 +35,8 @@ mockMPFS =
             \_ _ -> error "retract change facts not implemented"
         , mpfsUpdateTokenFromFacts =
             \_ _ _ -> error "update token facts not implemented"
+        , mpfsRejectTokenFromFacts =
+            \_ _ _ -> error "reject token facts not implemented"
         , mpfsGetToken = \_ -> toJSON $ mockToken []
         , mpfsGetTokenFacts = \_ -> toJSON ([] :: [JSFact])
         }

--- a/test/Oracle/Token/CliSpec.hs
+++ b/test/Oracle/Token/CliSpec.hs
@@ -1,0 +1,256 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Oracle.Token.CliSpec
+    ( spec
+    ) where
+
+import Control.Exception (bracket_)
+import Cli (Command (OracleCommand))
+import Core.Context (withContext)
+import Core.Types.Basic
+    ( Address (..)
+    , Owner (..)
+    , RequestRefId (..)
+    , TokenId (..)
+    )
+import Core.Types.Change (Change (..), Key (..))
+import Core.Types.Mnemonics (Mnemonics (ClearText), MnemonicsPhase (DecryptedS))
+import Core.Types.Operation (Operation (..))
+import Core.Types.Tx
+    ( Root (..)
+    , TxHash (..)
+    , UnsignedTx (..)
+    , WithTxHash (..)
+    , WithUnsignedTx (..)
+    )
+import Core.Types.Wallet (Wallet (..))
+import Core.Types.Wallet qualified as Wallet
+import Data.Functor.Identity (Identity (..))
+import Data.Text (Text)
+import Data.Version (makeVersion)
+import Lib.Box (Box (..))
+import MPFS.API (MPFS (..))
+import MockMPFS (mockMPFS)
+import Options (Options (..), parseArgs)
+import Oracle.Cli (OracleCommand (..))
+import Oracle.Token.Cli
+    ( TokenCommand (..)
+    , TokenRejectFailure (..)
+    , TokenRejectRequestValidation (..)
+    , TokenRejectRequestValidationProblem (..)
+    , tokenCmdCore
+    )
+import Oracle.Types (Request (..), RequestZoo (..), Token (..), TokenState (..))
+import Oracle.Validate.Requests.TestRun.Lib (mkEffects, noValidation)
+import Oracle.Validate.Types (AValidationResult (..))
+import Submitting (Submission (..), readWallet)
+import System.Environment
+    ( lookupEnv
+    , setEnv
+    , unsetEnv
+    , withArgs
+    )
+import System.IO (hClose, hPutStr)
+import System.IO.Temp (withSystemTempFile)
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    )
+import Text.JSON.Canonical (JSValue (JSString), ToJSON (toJSON))
+
+spec :: Spec
+spec =
+    describe "Oracle.Token.Cli" $ do
+        describe "tokenCmdCore" $ do
+            it "routes RejectToken through mpfsRejectTokenFromFacts" $ do
+                runReject markedMPFS [wantedRef]
+                    `shouldBe` ValidationSuccess (TxHash "facts-reject")
+
+            it "rejects an empty wanted request-ref subset before submission" $ do
+                runReject markedMPFS []
+                    `shouldBe` ValidationFailure TokenRejectOfNoRequests
+
+            it "rejects a missing wanted request ref before submission" $ do
+                runReject markedMPFS [RequestRefId "missing-0"]
+                    `shouldBe` ValidationFailure
+                        ( TokenRejectRequestValidations
+                            [ TokenRejectRequestValidation
+                                (RequestRefId "missing-0")
+                                TokenRejectRequestNotFound
+                            ]
+                        )
+
+            it "rejects a non-oracle signing wallet before submission" $ do
+                runRejectAs
+                    nonOracleWallet
+                    markedMPFS{mpfsRejectTokenFromFacts = unexpectedSubmit}
+                    [wantedRef]
+                    `shouldBe` ValidationFailure TokenRejectNotRequestedFromTokenOwner
+
+            it "rejects an unparsable token before submission" $ do
+                let unparsable =
+                        markedMPFS
+                            { mpfsGetToken = const $ pure (JSString "not-a-token")
+                            , mpfsRejectTokenFromFacts = unexpectedSubmit
+                            }
+                runReject unparsable [wantedRef]
+                    `shouldBe` ValidationFailure (TokenRejectNotParsable sampleToken)
+
+        it "parses oracle token reject with one or more -o refs" $ do
+            withSystemTempFile "wallet.json" $ \walletPath handle -> do
+                hPutStr handle walletJsonContent
+                hClose handle
+                parsed <-
+                    withParserEnv
+                        $ withArgs
+                        [ "oracle"
+                        , "token"
+                        , "reject"
+                        , "-t"
+                        , "token"
+                        , "-w"
+                        , walletPath
+                        , "-o"
+                        , "aaa-0"
+                        , "-o"
+                        , "bbb-1"
+                        ]
+                        $ parseArgs (makeVersion [0])
+                case parsed of
+                    Box
+                        ( Options
+                                False
+                                ( OracleCommand
+                                        _
+                                        _
+                                        ( OracleTokenCommand
+                                                ( RejectToken
+                                                        token
+                                                        _
+                                                        refs
+                                                    )
+                                            )
+                                    )
+                            ) -> do
+                            token `shouldBe` sampleToken
+                            refs
+                                `shouldBe` [ RequestRefId "aaa-0"
+                                           , RequestRefId "bbb-1"
+                                           ]
+                    _ -> expectationFailure "expected oracle token reject command"
+
+sampleToken :: TokenId
+sampleToken = TokenId "token"
+
+wantedRef :: RequestRefId
+wantedRef = RequestRefId "aaa-0"
+
+sampleRequest :: RequestZoo
+sampleRequest =
+    UnknownInsertRequest
+        Request
+            { outputRefId = wantedRef
+            , owner = Owner "requester"
+            , change = Change (Key (JSString "key")) (Insert (JSString "value"))
+            }
+
+runReject
+    :: MPFS Identity
+    -> [RequestRefId]
+    -> AValidationResult TokenRejectFailure TxHash
+runReject = runRejectAs sampleWallet
+
+runRejectAs
+    :: Wallet
+    -> MPFS Identity
+    -> [RequestRefId]
+    -> AValidationResult TokenRejectFailure TxHash
+runRejectAs wallet mpfs wanted =
+    runIdentity
+        $ withContext
+            mpfs
+            (\m _ -> mkEffects m noValidation)
+            (const recordingSubmission)
+            (tokenCmdCore (RejectToken sampleToken wallet wanted))
+
+withRequestsOwnedBy :: Monad m => Owner -> [RequestZoo] -> MPFS m -> MPFS m
+withRequestsOwnedBy tokenOwner reqs mpfs =
+    mpfs
+        { mpfsGetToken =
+            \_ ->
+                toJSON
+                    Token
+                        { tokenRequests = Identity <$> reqs
+                        , tokenState =
+                            TokenState
+                                { tokenRoot = Root "mock-root"
+                                , tokenOwner = tokenOwner
+                                }
+                        , tokenRefId = RequestRefId "mock-token-ref-id"
+                        }
+        }
+
+markedMPFS :: MPFS Identity
+markedMPFS =
+    withRequestsOwnedBy (Wallet.owner sampleWallet) [sampleRequest]
+        mockMPFS
+            { mpfsRejectTokenFromFacts =
+                \_ _ _ -> pure $ marker "facts-reject"
+            }
+
+unexpectedSubmit
+    :: Address
+    -> TokenId
+    -> [RequestRefId]
+    -> Identity (WithUnsignedTx JSValue)
+unexpectedSubmit _ _ _ = error "reject submission should not run"
+
+marker :: Text -> WithUnsignedTx JSValue
+marker name = WithUnsignedTx (UnsignedTx name) Nothing
+
+recordingSubmission :: Submission Identity
+recordingSubmission = Submission $ \action -> do
+    WithUnsignedTx (UnsignedTx tx) value <- action (Address "addr")
+    pure (WithTxHash (TxHash tx) value)
+
+sampleWallet :: Wallet
+sampleWallet = case readWallet (True, sampleMnemonics) of
+    Left err -> error (show err)
+    Right wallet -> wallet
+
+nonOracleWallet :: Wallet
+nonOracleWallet =
+    sampleWallet{Wallet.owner = Owner "not-oracle"}
+
+sampleMnemonics :: Mnemonics 'DecryptedS
+sampleMnemonics =
+    ClearText
+        "coin april solid purity wish slight acquire kitchen dragon faculty clutch picnic"
+
+walletJsonContent :: String
+walletJsonContent =
+    "{\"mnemonics\":\"coin april solid purity wish slight \
+    \acquire kitchen dragon faculty clutch picnic\"}"
+
+withParserEnv :: IO a -> IO a
+withParserEnv =
+    withEnv "MOOG_GITHUB_PAT" "token"
+        . withEnv "MOOG_MPFS_HOST" "http://127.0.0.1:1"
+        . withoutEnv "MOOG_WALLET_PASSPHRASE"
+
+withEnv :: String -> String -> IO a -> IO a
+withEnv name v action = do
+    mPrev <- lookupEnv name
+    bracket_ (setEnv name v) (restore name mPrev) action
+
+withoutEnv :: String -> IO a -> IO a
+withoutEnv name action = do
+    mPrev <- lookupEnv name
+    bracket_ (unsetEnv name) (restore name mPrev) action
+
+restore :: String -> Maybe String -> IO ()
+restore name Nothing = unsetEnv name
+restore name (Just old) = setEnv name old


### PR DESCRIPTION
## Summary

- Wires MPFS `/facts/reject` into the moog MPFS client and record.
- Adds `oracle token reject` with explicit request refs, oracle-owner checks, and submission through `mpfsRejectTokenFromFacts`.
- Adds an MPFS integration boundary proof for expired reject, token-root stability, pending-request disappearance, and fail-closed fresh reject behavior.

## Verification

- `./gate.sh` passed at final HEAD `daad7d91` (269 examples, 0 failures).
- S3 focused integration target compiled; local execution was blocked by missing `MOOG_TEST_*` wallet/devnet env, so the self-hosted integration proof is left for CI.

Closes #201