### PR TITLE
fix(cli): accept v2 txHash#index output references for oracle update/reject

### DIFF
--- a/moog.cabal
+++ b/moog.cabal
@@ -473,6 +473,7 @@ test-suite unit-tests
   -- Modules included in this executable, other than Main.
   other-modules:
     Core.EncryptionSpec
+    Core.OptionsSpec
     Core.Types.FactSpec
     Core.Types.VKeySpec
     Docker.FaultExclusionSpec

--- a/src/Core/Options.hs
+++ b/src/Core/Options.hs
@@ -9,6 +9,7 @@ module Core.Options
     , sshPublicKeyHashParser
     , vkeyOption
     , outputReferenceParser
+    , parseOutputReference
     , durationOption
     , tryOption
     , tokenIdOption
@@ -173,25 +174,26 @@ outputReferenceParser =
     setting
         [ long "outref"
         , short 'o'
-        , metavar "OUTPUT_REF"
-        , help "The transaction hash and index for the output reference"
+        , metavar "txHash#index"
+        , help "The output reference in txHash#index format"
         , reader parseOutputReference
         , option
         ]
 
 parseOutputReference :: Reader RequestRefId
 parseOutputReference = Reader $ \s -> do
-    case break (== '-') s of
-        (_txHash, '-' : indexStr) -> do
+    case break (`elem` ['#', '-']) s of
+        (txHash, separator : indexStr) | separator `elem` ['#', '-'] -> do
             _index :: Int <- case reads indexStr of
                 [(i, "")] -> pure i
                 _ ->
                     Left
-                        "Invalid index format. Use 'txHash-index' where index is an integer."
+                        "Invalid index format. Use 'txHash#index' where index is an integer."
             pure
                 $ RequestRefId
-                $ T.pack s
-        _ -> Left "Invalid output reference format. Use 'txHash-index'"
+                $ T.pack
+                $ txHash <> "#" <> indexStr
+        _ -> Left "Invalid output reference format. Use 'txHash#index'"
 
 durationOption :: Parser Duration
 durationOption =

--- a/test/Core/OptionsSpec.hs
+++ b/test/Core/OptionsSpec.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Core.OptionsSpec
+    ( spec
+    ) where
+
+import Core.Options (parseOutputReference)
+import Core.Types.Basic (RequestRefId (..))
+import Data.Text qualified as T
+import OptEnvConf.Reader (Reader (..))
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+
+spec :: Spec
+spec =
+    describe "Core.Options" $ do
+        describe "parseOutputReference" $ do
+            it "accepts v2 txHash#index output references" $ do
+                runParse outputReference
+                    `shouldBe` Right (RequestRefId $ T.pack outputReference)
+
+            it "normalizes legacy txHash-index output references to txHash#index" $ do
+                runParse legacyOutputReference
+                    `shouldBe` Right (RequestRefId $ T.pack outputReference)
+
+            it "rejects output references with non-integer indexes" $ do
+                runParse (txHash <> "#x")
+                    `shouldBe` Left
+                        "Invalid index format. Use 'txHash#index' where index is an integer."
+
+runParse :: String -> Either String RequestRefId
+runParse input =
+    let Reader parse = parseOutputReference
+    in  parse input
+
+outputReference :: String
+outputReference = txHash <> "#0"
+
+legacyOutputReference :: String
+legacyOutputReference = txHash <> "-0"
+
+txHash :: String
+txHash = "a9ffa9ffa9ffa9ffa9ffa9ffa9ffa9ffa9ffa9ffa9ffa9ffa9ffa9ffa9ff193a"

--- a/test/Oracle/Token/CliSpec.hs
+++ b/test/Oracle/Token/CliSpec.hs
@@ -4,8 +4,8 @@ module Oracle.Token.CliSpec
     ( spec
     ) where
 
-import Control.Exception (bracket_)
 import Cli (Command (OracleCommand))
+import Control.Exception (bracket_)
 import Core.Context (withContext)
 import Core.Types.Basic
     ( Address (..)
@@ -14,7 +14,10 @@ import Core.Types.Basic
     , TokenId (..)
     )
 import Core.Types.Change (Change (..), Key (..))
-import Core.Types.Mnemonics (Mnemonics (ClearText), MnemonicsPhase (DecryptedS))
+import Core.Types.Mnemonics
+    ( Mnemonics (ClearText)
+    , MnemonicsPhase (DecryptedS)
+    )
 import Core.Types.Operation (Operation (..))
 import Core.Types.Tx
     ( Root (..)
@@ -40,7 +43,12 @@ import Oracle.Token.Cli
     , TokenRejectRequestValidationProblem (..)
     , tokenCmdCore
     )
-import Oracle.Types (Request (..), RequestZoo (..), Token (..), TokenState (..))
+import Oracle.Types
+    ( Request (..)
+    , RequestZoo (..)
+    , Token (..)
+    , TokenState (..)
+    )
 import Oracle.Validate.Requests.TestRun.Lib (mkEffects, noValidation)
 import Oracle.Validate.Types (AValidationResult (..))
 import Submitting (Submission (..), readWallet)
@@ -106,18 +114,18 @@ spec =
                 parsed <-
                     withParserEnv
                         $ withArgs
-                        [ "oracle"
-                        , "token"
-                        , "reject"
-                        , "-t"
-                        , "token"
-                        , "-w"
-                        , walletPath
-                        , "-o"
-                        , "aaa-0"
-                        , "-o"
-                        , "bbb-1"
-                        ]
+                            [ "oracle"
+                            , "token"
+                            , "reject"
+                            , "-t"
+                            , "token"
+                            , "-w"
+                            , walletPath
+                            , "-o"
+                            , "aaa-0"
+                            , "-o"
+                            , "bbb-1"
+                            ]
                         $ parseArgs (makeVersion [0])
                 case parsed of
                     Box
@@ -137,8 +145,8 @@ spec =
                             ) -> do
                             token `shouldBe` sampleToken
                             refs
-                                `shouldBe` [ RequestRefId "aaa-0"
-                                           , RequestRefId "bbb-1"
+                                `shouldBe` [ RequestRefId "aaa#0"
+                                           , RequestRefId "bbb#1"
                                            ]
                     _ -> expectationFailure "expected oracle token reject command"
 
@@ -176,7 +184,8 @@ runRejectAs wallet mpfs wanted =
             (const recordingSubmission)
             (tokenCmdCore (RejectToken sampleToken wallet wanted))
 
-withRequestsOwnedBy :: Monad m => Owner -> [RequestZoo] -> MPFS m -> MPFS m
+withRequestsOwnedBy
+    :: Monad m => Owner -> [RequestZoo] -> MPFS m -> MPFS m
 withRequestsOwnedBy tokenOwner reqs mpfs =
     mpfs
         { mpfsGetToken =
@@ -195,7 +204,9 @@ withRequestsOwnedBy tokenOwner reqs mpfs =
 
 markedMPFS :: MPFS Identity
 markedMPFS =
-    withRequestsOwnedBy (Wallet.owner sampleWallet) [sampleRequest]
+    withRequestsOwnedBy
+        (Wallet.owner sampleWallet)
+        [sampleRequest]
         mockMPFS
             { mpfsRejectTokenFromFacts =
                 \_ _ _ -> pure $ marker "facts-reject"


### PR DESCRIPTION
## Summary

- Accept canonical v2 `txHash#index` output references in the shared `--outref` parser.
- Normalize legacy `txHash-index` inputs to stored `txHash#index` request refs.
- Add parser regression coverage and update the oracle token reject CLI expectation.

References #201.

## Verification

- `nix develop --accept-flake-config -c cabal test unit-tests` (272 examples, 0 failures)
