### PR TITLE
ci: run x86_64 release build on nix-enabled-runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,9 +46,9 @@ concurrency:
 jobs:
   linux-bundles:
     name: Build Linux ${{ matrix.executable.name }} (${{ matrix.arch.id }})
-    # x86_64 non-fork builds run on the self-hosted builder-new fleet (label: moog);
+    # x86_64 non-fork builds run on the ARC nix-enabled-runners;
     # fork PRs and aarch64 fall back to the matrix runner (GitHub-hosted).
-    runs-on: ${{ (matrix.arch.id == 'x86_64' && !github.event.pull_request.head.repo.fork) && fromJSON('["self-hosted","moog"]') || matrix.arch.runner }}
+    runs-on: ${{ (matrix.arch.id == 'x86_64' && !github.event.pull_request.head.repo.fork) && 'nix-enabled-runners' || matrix.arch.runner }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Move the x86_64 release build off the `[self-hosted, moog]` runners (builder-new) onto the ARC `nix-enabled-runners` fleet. Fork/aarch64 fallbacks unchanged. Part of decommissioning builder-new (nix-in-OS + shared store now available on the fleet).